### PR TITLE
feat(directory): implement directory canister query methods

### DIFF
--- a/crates/canisters/directory/src/adapters/management_canister.rs
+++ b/crates/canisters/directory/src/adapters/management_canister.rs
@@ -11,18 +11,23 @@ use std::future::Future;
 use candid::Principal;
 use ic_management_canister_types::CanisterSettings;
 
+#[cfg(target_family = "wasm")]
+/// Minimum cycles to attach for canister creation to ensure it succeeds.
+const CREATE_CANISTER_FEE: u128 = 500_000_000_000;
+
 /// Abstraction over the IC management canister API.
 ///
 /// The two operations exposed — canister creation and WASM installation — are
 /// the only management-canister interactions required by the sign-up state
 /// machine today. Extend this trait if additional calls become necessary.
 pub trait ManagementCanister: Send + Sync + Sized {
-    /// Creates a new canister with the given optional settings.
+    /// Creates a new canister with the given optional settings and amount of cycles.
     ///
     /// Returns the [`Principal`] of the newly created canister on success.
     fn create_canister(
         &self,
         settings: Option<CanisterSettings>,
+        cycles: u128,
     ) -> impl Future<Output = Result<Principal, ManagementCanisterError>>;
 
     /// Installs WASM code on an existing canister.
@@ -62,22 +67,43 @@ impl ManagementCanister for IcManagementCanisterClient {
     async fn create_canister(
         &self,
         settings: Option<CanisterSettings>,
+        cycles: u128,
     ) -> Result<Principal, ManagementCanisterError> {
+        ic_utils::log!(
+            "IcManagementCanisterClient::create_canister: sending create_canister request"
+        );
         let canister_version = self.canister_version();
-        let request = ic_management_canister_types::CreateCanisterArgs {
+        let request = ic_management_canister_types::ProvisionalCreateCanisterWithCyclesArgs {
             sender_canister_version: Some(canister_version),
             settings,
+            amount: Some(cycles.into()),
+            specified_id: None,
         };
 
-        let response =
-            ic_cdk::call::Call::bounded_wait(Principal::management_canister(), "create_canister")
-                .with_arg(request)
-                .await
-                .map_err(|e| ManagementCanisterError::CallFailed(format!("{e:?}")))?;
+        let response = ic_cdk::call::Call::bounded_wait(
+            Principal::management_canister(),
+            "provisional_create_canister_with_cycles",
+        )
+        .with_arg(request)
+        .with_cycles(CREATE_CANISTER_FEE)
+        .await
+        .map_err(|e| {
+            ic_utils::log!("IcManagementCanisterClient::create_canister: call failed: {e:?}");
+            ManagementCanisterError::CallFailed(format!("{e:?}"))
+        })?;
 
-        let response =
-            candid::decode_one::<ic_management_canister_types::CreateCanisterResult>(&response)
-                .map_err(|e| ManagementCanisterError::DecodeFailed(e.to_string()))?;
+        let response = candid::decode_one::<
+            ic_management_canister_types::ProvisionalCreateCanisterWithCyclesResult,
+        >(&response)
+        .map_err(|e| {
+            ic_utils::log!("IcManagementCanisterClient::create_canister: decode failed: {e}");
+            ManagementCanisterError::DecodeFailed(e.to_string())
+        })?;
+
+        ic_utils::log!(
+            "IcManagementCanisterClient::create_canister: created canister {}",
+            response.canister_id
+        );
 
         Ok(response.canister_id)
     }
@@ -88,6 +114,10 @@ impl ManagementCanister for IcManagementCanisterClient {
         wasm_module: &[u8],
         arg: Vec<u8>,
     ) -> Result<(), ManagementCanisterError> {
+        ic_utils::log!(
+            "IcManagementCanisterClient::install_code: installing code on canister {canister_id} (wasm size: {} bytes)",
+            wasm_module.len()
+        );
         let canister_version = self.canister_version();
         let install_args = ic_management_canister_types::InstallCodeArgs {
             mode: ic_management_canister_types::CanisterInstallMode::Install,
@@ -100,7 +130,14 @@ impl ManagementCanister for IcManagementCanisterClient {
         ic_cdk::call::Call::bounded_wait(Principal::management_canister(), "install_code")
             .with_arg(install_args)
             .await
-            .map_err(|e| ManagementCanisterError::CallFailed(format!("{e:?}")))?;
+            .map_err(|e| {
+                ic_utils::log!("IcManagementCanisterClient::install_code: call failed for canister {canister_id}: {e:?}");
+                ManagementCanisterError::CallFailed(format!("{e:?}"))
+            })?;
+
+        ic_utils::log!(
+            "IcManagementCanisterClient::install_code: code installed on canister {canister_id}"
+        );
 
         Ok(())
     }

--- a/crates/canisters/directory/src/adapters/management_canister/mock.rs
+++ b/crates/canisters/directory/src/adapters/management_canister/mock.rs
@@ -18,6 +18,7 @@ impl ManagementCanister for MockManagementCanisterClient {
     async fn create_canister(
         &self,
         _settings: Option<CanisterSettings>,
+        _cycles: u128,
     ) -> Result<Principal, ManagementCanisterError> {
         Ok(self.created_canister_id)
     }

--- a/crates/canisters/directory/src/api.rs
+++ b/crates/canisters/directory/src/api.rs
@@ -1,10 +1,16 @@
 //! Canister implementation
 
-use did::directory::{DirectoryInstallArgs, RetrySignUpResponse, SignUpRequest, SignUpResponse};
+use candid::Principal;
+use did::directory::{
+    DirectoryInstallArgs, GetUserResponse, RetrySignUpResponse, SignUpRequest, SignUpResponse,
+    UserCanisterResponse, WhoAmIResponse,
+};
 use ic_dbms_canister::prelude::DBMS_CONTEXT;
 
 /// Initializes the canister.
 pub fn init(args: DirectoryInstallArgs) {
+    ic_utils::log!("Initializing directory canister");
+
     let DirectoryInstallArgs::Init {
         initial_moderator,
         federation_canister,
@@ -13,41 +19,79 @@ pub fn init(args: DirectoryInstallArgs) {
         ic_utils::trap!("Invalid initialization arguments");
     };
 
+    ic_utils::log!("Registering database schema");
     DBMS_CONTEXT.with(|ctx| {
         if let Err(err) = crate::schema::Schema::register_tables(ctx) {
             ic_utils::trap!("Failed to register database schema: {err}");
         }
     });
 
+    ic_utils::log!("Setting federation canister to {federation_canister}");
     if let Err(err) = crate::settings::set_federation_canister(federation_canister) {
         ic_utils::trap!("Failed to set federation canister: {err}");
     }
 
+    ic_utils::log!("Adding initial moderator {initial_moderator}");
     if let Err(err) = crate::domain::moderators::add_moderator(initial_moderator) {
         ic_utils::trap!("Failed to add initial moderator: {err}");
     }
+
+    ic_utils::log!("Directory canister initialized successfully");
 }
 
 /// Post-upgrade function for the canister.
 pub fn post_upgrade(args: DirectoryInstallArgs) {
+    ic_utils::log!("Post-upgrade directory canister");
+
     let DirectoryInstallArgs::Upgrade { .. } = args else {
         ic_utils::trap!("Invalid post-upgrade arguments");
     };
+
+    ic_utils::log!("Directory canister post-upgrade completed successfully");
 }
 
-/// Handles the `sign_up` method call to register a new user in the directory, creating a User Canister
-pub fn sign_up(request: SignUpRequest) -> SignUpResponse {
-    let caller = ic_utils::caller();
-
-    crate::domain::users::sign_up(caller, request)
+/// Handles the `get_user` method call to retrieve user information based on their handle.
+pub fn get_user(handle: &str) -> GetUserResponse {
+    crate::domain::users::get_user(handle)
 }
 
 /// Retry canister creation for the user that called this method.
 /// This is used in case the canister creation failed during the sign up process
 pub fn retry_sign_up() -> RetrySignUpResponse {
     let caller = ic_utils::caller();
+    ic_utils::log!("retry_sign_up called by {caller}");
 
     crate::domain::users::retry_sign_up(caller)
+}
+
+/// Handles the `sign_up` method call to register a new user in the directory, creating a User Canister
+pub fn sign_up(request: SignUpRequest) -> SignUpResponse {
+    let caller = ic_utils::caller();
+    ic_utils::log!(
+        "sign_up called by {caller} with handle {:?}",
+        request.handle
+    );
+
+    crate::domain::users::sign_up(caller, request)
+}
+
+/// Handles the `user_canister` method call to retrieve the User Canister ID for the caller.
+pub fn user_canister(principal: Option<Principal>) -> UserCanisterResponse {
+    let principal = principal.unwrap_or_else(|| {
+        ic_utils::log!("user_canister: user not provided");
+        ic_utils::caller()
+    });
+    ic_utils::log!("user_canister called with argument {principal:?}; resolved to {principal}");
+
+    crate::domain::users::user_canister(principal)
+}
+
+/// Handles the `whoami` method call to retrieve the user information for the caller.
+pub fn whoami() -> WhoAmIResponse {
+    let caller = ic_utils::caller();
+    ic_utils::log!("whoami called by {caller}");
+
+    crate::domain::users::whoami(caller)
 }
 
 #[cfg(test)]
@@ -111,6 +155,114 @@ mod tests {
         assert_eq!(
             response,
             RetrySignUpResponse::Err(did::directory::RetrySignUpError::NotRegistered)
+        );
+    }
+
+    #[test]
+    fn test_should_whoami_for_registered_user() {
+        setup();
+        sign_up(SignUpRequest {
+            handle: "rey_canisteryo".to_string(),
+        });
+        let response = whoami();
+        match response {
+            WhoAmIResponse::Ok(info) => {
+                assert_eq!(info.handle, "rey_canisteryo");
+                assert_eq!(
+                    info.canister_status,
+                    did::directory::UserCanisterStatus::CreationPending,
+                );
+            }
+            WhoAmIResponse::Err(e) => panic!("expected Ok, got Err({e:?})"),
+        }
+    }
+
+    #[test]
+    fn test_should_whoami_return_not_registered() {
+        setup();
+        let response = whoami();
+        assert_eq!(
+            response,
+            WhoAmIResponse::Err(did::directory::WhoAmIError::NotRegistered)
+        );
+    }
+
+    #[test]
+    fn test_should_user_canister_return_canister_for_active_user() {
+        setup();
+
+        let canister_id = crate::test_utils::rey_canisteryo();
+        crate::test_utils::setup_registered_user_with_canister(
+            ic_utils::caller(),
+            "alice",
+            canister_id,
+        );
+
+        let response = user_canister(None);
+
+        assert_eq!(response, UserCanisterResponse::Ok(canister_id));
+    }
+
+    #[test]
+    fn test_should_user_canister_return_not_active_when_pending() {
+        setup();
+        crate::test_utils::setup_registered_user(ic_utils::caller(), "alice");
+
+        let response = user_canister(None);
+
+        assert_eq!(
+            response,
+            UserCanisterResponse::Err(did::directory::UserCanisterError::CanisterNotActive)
+        );
+    }
+
+    #[test]
+    fn test_should_user_canister_return_not_registered() {
+        setup();
+        let response = user_canister(None);
+        assert_eq!(
+            response,
+            UserCanisterResponse::Err(did::directory::UserCanisterError::NotRegistered)
+        );
+    }
+
+    #[test]
+    fn test_should_user_canister_with_explicit_principal() {
+        setup();
+
+        let principal = crate::test_utils::bob();
+        let canister_id = crate::test_utils::rey_canisteryo();
+        crate::test_utils::setup_registered_user_with_canister(principal, "bob", canister_id);
+
+        let response = user_canister(Some(principal));
+
+        assert_eq!(response, UserCanisterResponse::Ok(canister_id));
+    }
+
+    #[test]
+    fn test_should_get_user_by_handle() {
+        setup();
+        crate::test_utils::setup_registered_user(crate::test_utils::bob(), "alice");
+
+        let response = get_user("alice");
+
+        match response {
+            GetUserResponse::Ok(user) => {
+                assert_eq!(user.handle, "alice");
+            }
+            GetUserResponse::Err(e) => panic!("expected Ok, got Err({e:?})"),
+        }
+    }
+
+    #[test]
+    fn test_should_get_user_return_not_found() {
+        setup();
+
+        let response = get_user("nonexistent");
+
+        assert_eq!(
+            response,
+            GetUserResponse::Err(did::directory::GetUserError::NotFound)
         );
     }
 }

--- a/crates/canisters/directory/src/domain/moderators.rs
+++ b/crates/canisters/directory/src/domain/moderators.rs
@@ -9,18 +9,21 @@ use crate::error::CanisterResult;
 
 /// Adds a moderator to the directory canister.
 pub fn add_moderator(principal: Principal) -> CanisterResult<()> {
+    ic_utils::log!("add_moderator: adding {principal}");
     ModeratorsRepository::add_moderator(principal)
 }
 
 /// Returns true if the given principal is a moderator, false otherwise.
 #[cfg_attr(not(test), expect(dead_code))]
 pub fn is_moderator(principal: Principal) -> CanisterResult<bool> {
+    ic_utils::log!("is_moderator: checking {principal}");
     ModeratorsRepository::is_moderator(principal)
 }
 
 /// Removes a moderator from the directory canister.
 #[cfg_attr(not(test), expect(dead_code))]
 pub fn remove_moderator(principal: Principal) -> CanisterResult<()> {
+    ic_utils::log!("remove_moderator: removing {principal}");
     ModeratorsRepository::remove_moderator(principal)
 }
 

--- a/crates/canisters/directory/src/domain/moderators/repository.rs
+++ b/crates/canisters/directory/src/domain/moderators/repository.rs
@@ -13,6 +13,7 @@ pub struct ModeratorsRepository;
 impl ModeratorsRepository {
     /// Adds a moderator to the directory canister.
     pub fn add_moderator(principal: Principal) -> CanisterResult<()> {
+        ic_utils::log!("ModeratorsRepository::add_moderator: inserting {principal}");
         DBMS_CONTEXT
             .with(|ctx| {
                 let db = WasmDbmsDatabase::oneshot(ctx, Schema);
@@ -41,6 +42,7 @@ impl ModeratorsRepository {
 
     /// Removes a moderator from the directory canister.
     pub fn remove_moderator(principal: Principal) -> CanisterResult<()> {
+        ic_utils::log!("ModeratorsRepository::remove_moderator: removing {principal}");
         let principal = ic_dbms_canister::prelude::Principal(principal);
         DBMS_CONTEXT
             .with(|ctx| {

--- a/crates/canisters/directory/src/domain/users.rs
+++ b/crates/canisters/directory/src/domain/users.rs
@@ -1,6 +1,12 @@
 //! Users domain logic.
 
-mod repository;
+mod get_user;
+pub(crate) mod repository;
 mod sign_up;
+mod user_canister;
+mod whoami;
 
+pub use self::get_user::get_user;
 pub use self::sign_up::{retry_sign_up, sign_up};
+pub use self::user_canister::user_canister;
+pub use self::whoami::whoami;

--- a/crates/canisters/directory/src/domain/users/get_user.rs
+++ b/crates/canisters/directory/src/domain/users/get_user.rs
@@ -1,0 +1,133 @@
+//! Flow implementation to get a user by their handle.
+
+use db_utils::handle::{HandleSanitizer, HandleValidator};
+use did::directory::{GetUser, GetUserError, GetUserResponse};
+
+use crate::domain::users::repository::UserRepository;
+
+/// Retrieves a user's information based on their handle.
+///
+/// 1. Checks if a user with the given handle exists in the repository.
+/// 2. If the handle is invalid (e.g. empty or contains disallowed characters), returns [`GetUserError::InvalidHandle`] wrapped in [`GetUserResponse::Err`].
+/// 3. If the user exists, returns their information as [`GetUser`] wrapped in [`GetUserResponse::Ok`].
+/// 4. If the user does not exist, returns [`GetUserError::NotFound`] wrapped in [`GetUserResponse::Err`].
+/// 5. If any internal error occurs during the retrieval process, returns a descriptive error message wrapped
+///    in [`GetUserResponse::Err`] with the variant [`GetUserError::InternalError`].
+pub fn get_user(handle: &str) -> GetUserResponse {
+    ic_utils::log!("get_user: looking up user with {handle}");
+
+    let handle = HandleSanitizer::sanitize_handle(handle);
+    if let Err(err) = HandleValidator::check_handle(&handle) {
+        ic_utils::log!("get_user: invalid handle {handle}: {err}");
+        return GetUserResponse::Err(GetUserError::InvalidHandle);
+    }
+
+    let user_data = match UserRepository::get_user_by_handle(&handle) {
+        Ok(Some(user)) => user,
+        Ok(None) => {
+            ic_utils::log!("get_user: user {handle} is not registered");
+            return GetUserResponse::Err(GetUserError::NotFound);
+        }
+        Err(e) => {
+            ic_utils::log!("get_user: internal error querying user {handle}: {e}");
+            return GetUserResponse::Err(GetUserError::InternalError(format!(
+                "failed to query database: {e}"
+            )));
+        }
+    };
+
+    GetUserResponse::Ok(GetUser {
+        handle: user_data.handle.0,
+        canister_id: user_data.canister_id.into_opt().map(|c| c.0),
+        canister_status: user_data.canister_status.0,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+
+    use did::directory::UserCanisterStatus;
+
+    use super::*;
+    use crate::test_utils::{
+        bob, rey_canisteryo, setup, setup_registered_user, setup_registered_user_with_canister,
+    };
+
+    #[test]
+    fn test_should_return_user_without_canister() {
+        setup();
+        setup_registered_user(bob(), "alice");
+
+        let response = get_user("alice");
+
+        match response {
+            GetUserResponse::Ok(user) => {
+                assert_eq!(user.handle, "alice");
+                assert!(user.canister_id.is_none());
+                assert_eq!(user.canister_status, UserCanisterStatus::CreationPending);
+            }
+            GetUserResponse::Err(e) => panic!("expected Ok, got Err({e:?})"),
+        }
+    }
+
+    #[test]
+    fn test_should_return_user_with_canister() {
+        setup();
+
+        let canister_id = rey_canisteryo();
+        setup_registered_user_with_canister(bob(), "alice", canister_id);
+
+        let response = get_user("alice");
+
+        match response {
+            GetUserResponse::Ok(user) => {
+                assert_eq!(user.handle, "alice");
+                assert_eq!(user.canister_id, Some(canister_id));
+                assert_eq!(user.canister_status, UserCanisterStatus::Active);
+            }
+            GetUserResponse::Err(e) => panic!("expected Ok, got Err({e:?})"),
+        }
+    }
+
+    #[test]
+    fn test_should_sanitize_handle_before_lookup() {
+        setup();
+        setup_registered_user(bob(), "alice");
+
+        let response = get_user("  @Alice  ");
+
+        match response {
+            GetUserResponse::Ok(user) => {
+                assert_eq!(user.handle, "alice");
+            }
+            GetUserResponse::Err(e) => panic!("expected Ok, got Err({e:?})"),
+        }
+    }
+
+    #[test]
+    fn test_should_return_not_found_for_unknown_handle() {
+        setup();
+
+        let response = get_user("nonexistent");
+
+        assert_eq!(response, GetUserResponse::Err(GetUserError::NotFound));
+    }
+
+    #[test]
+    fn test_should_return_invalid_handle_for_empty_handle() {
+        setup();
+
+        let response = get_user("");
+
+        assert_eq!(response, GetUserResponse::Err(GetUserError::InvalidHandle));
+    }
+
+    #[test]
+    fn test_should_return_invalid_handle_for_special_chars() {
+        setup();
+
+        let response = get_user("alice!@#");
+
+        assert_eq!(response, GetUserResponse::Err(GetUserError::InvalidHandle));
+    }
+}

--- a/crates/canisters/directory/src/domain/users/repository.rs
+++ b/crates/canisters/directory/src/domain/users/repository.rs
@@ -18,6 +18,10 @@ impl UserRepository {
     ///
     /// The user canister is set to Null and the creation state is marked to pending.
     pub fn sign_up(user_principal: Principal, handle: String) -> CanisterResult<()> {
+        ic_utils::log!(
+            "UserRepository::sign_up: inserting user {user_principal} with handle {handle:?}"
+        );
+
         let insert = UserInsertRequest {
             principal: ic_dbms_canister::prelude::Principal(user_principal),
             handle: handle.into(),
@@ -33,6 +37,8 @@ impl UserRepository {
             dbms.insert::<User>(insert)
         })?;
 
+        ic_utils::log!("UserRepository::sign_up: user {user_principal} inserted successfully");
+
         Ok(())
     }
 
@@ -41,6 +47,9 @@ impl UserRepository {
         user_principal: Principal,
         canister_id: Principal,
     ) -> CanisterResult<()> {
+        ic_utils::log!(
+            "UserRepository::set_user_canister: setting canister {canister_id} for user {user_principal}"
+        );
         let update = UserUpdateRequest {
             principal: None,
             handle: None,
@@ -63,16 +72,26 @@ impl UserRepository {
         })?;
 
         if rows == 0 {
+            ic_utils::log!(
+                "UserRepository::set_user_canister: no rows updated for user {user_principal}"
+            );
             return Err(CanisterError::SignUpFailed(format!(
                 "failed to set user canister id for user {user_principal}"
             )));
         }
+
+        ic_utils::log!(
+            "UserRepository::set_user_canister: canister {canister_id} set for user {user_principal}"
+        );
 
         Ok(())
     }
 
     /// Sets the user canister status to creation failed if the canister creation process fails for a user.
     pub fn set_failed_user_canister_create(user_principal: Principal) -> CanisterResult<()> {
+        ic_utils::log!(
+            "UserRepository::set_failed_user_canister_create: marking user {user_principal} as failed"
+        );
         let update = UserUpdateRequest {
             principal: None,
             handle: None,
@@ -93,16 +112,26 @@ impl UserRepository {
         })?;
 
         if rows == 0 {
+            ic_utils::log!(
+                "UserRepository::set_failed_user_canister_create: no rows updated for user {user_principal}"
+            );
             return Err(CanisterError::SignUpFailed(format!(
                 "failed to set user canister creation failed for user {user_principal}"
             )));
         }
+
+        ic_utils::log!(
+            "UserRepository::set_failed_user_canister_create: user {user_principal} marked as failed"
+        );
 
         Ok(())
     }
 
     /// Sets the user canister status to creation failed if the canister creation process fails for a user.
     pub fn retry_user_canister_creation(user_principal: Principal) -> CanisterResult<()> {
+        ic_utils::log!(
+            "UserRepository::retry_user_canister_creation: retrying for user {user_principal}"
+        );
         let update = UserUpdateRequest {
             principal: None,
             handle: None,
@@ -123,16 +152,24 @@ impl UserRepository {
         })?;
 
         if rows == 0 {
+            ic_utils::log!(
+                "UserRepository::retry_user_canister_creation: no rows updated for user {user_principal}"
+            );
             return Err(CanisterError::SignUpFailed(format!(
                 "failed to retry user canister creation for user {user_principal}"
             )));
         }
+
+        ic_utils::log!(
+            "UserRepository::retry_user_canister_creation: user {user_principal} status reset to pending"
+        );
 
         Ok(())
     }
 
     /// Retrieves a user's information from the database by their principal.
     pub fn get_user_by_principal(user_principal: Principal) -> CanisterResult<Option<User>> {
+        ic_utils::log!("UserRepository::get_user_by_principal: querying user {user_principal}");
         let rows = DBMS_CONTEXT.with(|ctx| {
             let dbms = WasmDbmsDatabase::oneshot(ctx, Schema);
             dbms.select::<User>(
@@ -157,6 +194,7 @@ impl UserRepository {
 
     /// Retrieves a user's information from the database by their handle.
     pub fn get_user_by_handle(handle: &str) -> CanisterResult<Option<User>> {
+        ic_utils::log!("UserRepository::get_user_by_handle: querying handle {handle:?}");
         let rows = DBMS_CONTEXT.with(|ctx| {
             let dbms = WasmDbmsDatabase::oneshot(ctx, Schema);
             dbms.select::<User>(

--- a/crates/canisters/directory/src/domain/users/sign_up.rs
+++ b/crates/canisters/directory/src/domain/users/sign_up.rs
@@ -24,47 +24,70 @@ mod state;
 ///
 /// Any internal error is returned as [`SignUpError::InternalError`] with a message describing the error.
 pub fn sign_up(user_id: Principal, request: SignUpRequest) -> SignUpResponse {
+    ic_utils::log!(
+        "sign_up: starting for user {user_id} with handle {:?}",
+        request.handle
+    );
+
     // 0. Check if the caller's principal is anonymous, if it is, return [`SignUpError::AnonymousPrincipal`].
     if user_id == Principal::anonymous() {
+        ic_utils::log!("sign_up: rejected anonymous principal");
         return SignUpResponse::Err(SignUpError::AnonymousPrincipal);
     }
 
     // 1. Check whether there is already a user with the given `user_id` in the database, if there is, return [`SignUpError::AlreadyRegistered`].
     match UserRepository::get_user_by_principal(user_id) {
         Err(err) => {
+            ic_utils::log!("sign_up: internal error checking principal {user_id}: {err}");
             return SignUpResponse::Err(SignUpError::InternalError(format!(
                 "Failed to check existing user by principal: {err}"
             )));
         }
-        Ok(Some(_)) => return SignUpResponse::Err(SignUpError::AlreadyRegistered),
+        Ok(Some(_)) => {
+            ic_utils::log!("sign_up: user {user_id} is already registered");
+            return SignUpResponse::Err(SignUpError::AlreadyRegistered);
+        }
         Ok(None) => (),
     };
 
     // 2. Sanitize and validate the handle. See `handles.md` document for specs.
     let handle = HandleSanitizer::sanitize_handle(&request.handle);
+    ic_utils::log!(
+        "sign_up: sanitized handle {:?} -> {handle:?}",
+        request.handle
+    );
     if HandleValidator::check_handle(&handle).is_err() {
+        ic_utils::log!("sign_up: handle {handle:?} is invalid");
         return SignUpResponse::Err(SignUpError::InvalidHandle);
     }
 
     // 3. Check if the handle is already taken by another user in the database, if it is, return [`SignUpError::HandleTaken`].
     match UserRepository::get_user_by_handle(&handle) {
         Err(err) => {
+            ic_utils::log!("sign_up: internal error checking handle {handle:?}: {err}");
             return SignUpResponse::Err(SignUpError::InternalError(format!(
                 "Failed to check existing user by handle: {err}"
             )));
         }
-        Ok(Some(_)) => return SignUpResponse::Err(SignUpError::HandleTaken),
+        Ok(Some(_)) => {
+            ic_utils::log!("sign_up: handle {handle:?} is already taken");
+            return SignUpResponse::Err(SignUpError::HandleTaken);
+        }
         Ok(None) => (),
     };
 
     // 4. Insert the new user in the database with the canister status set to [`did::directory::UserCanisterStatus::CreationPending`].
-    if let Err(err) = UserRepository::sign_up(user_id, handle) {
+    if let Err(err) = UserRepository::sign_up(user_id, handle.clone()) {
+        ic_utils::log!("sign_up: failed to insert user {user_id} in the database: {err}");
         return SignUpResponse::Err(SignUpError::InternalError(format!(
             "Failed to insert new user in the database: {err}"
         )));
     }
 
     // 5. Spawn the state machine that will drive the user canister creation process, and return [`SignUpResponse::Ok`].
+    ic_utils::log!(
+        "sign_up: user {user_id} registered with handle {handle:?}, starting canister creation"
+    );
     start_sign_up_state_machine(user_id);
 
     SignUpResponse::Ok
@@ -82,7 +105,10 @@ pub fn sign_up(user_id: Principal, request: SignUpRequest) -> SignUpResponse {
 /// 3. Update the user's canister status in the database to [`did::directory::UserCanisterStatus::CreationPending`]
 /// 4. Spawn the state machine that will drive the user canister creation process, then return [`RetrySignUpResponse::Ok`].
 pub fn retry_sign_up(user_id: Principal) -> RetrySignUpResponse {
+    ic_utils::log!("retry_sign_up: starting for user {user_id}");
+
     if user_id == Principal::anonymous() {
+        ic_utils::log!("retry_sign_up: rejected anonymous principal");
         return RetrySignUpResponse::Err(RetrySignUpError::NotRegistered);
     }
 
@@ -90,14 +116,22 @@ pub fn retry_sign_up(user_id: Principal) -> RetrySignUpResponse {
     // 2. Check if the user's canister is in a failed state, if it isn't, return [`RetrySignUpError::CanisterNotInFailedState`].
     match UserRepository::get_user_by_principal(user_id) {
         Err(err) => {
+            ic_utils::log!("retry_sign_up: internal error checking principal {user_id}: {err}");
             return RetrySignUpResponse::Err(RetrySignUpError::InternalError(format!(
                 "Failed to check existing user by principal: {err}"
             )));
         }
-        Ok(None) => return RetrySignUpResponse::Err(RetrySignUpError::NotRegistered),
+        Ok(None) => {
+            ic_utils::log!("retry_sign_up: user {user_id} is not registered");
+            return RetrySignUpResponse::Err(RetrySignUpError::NotRegistered);
+        }
         Ok(Some(user))
             if user.canister_status.0 != did::directory::UserCanisterStatus::CreationFailed =>
         {
+            ic_utils::log!(
+                "retry_sign_up: user {user_id} canister is not in failed state (status: {:?})",
+                user.canister_status.0
+            );
             return RetrySignUpResponse::Err(RetrySignUpError::CanisterNotInFailedState);
         }
         Ok(Some(_)) => (),
@@ -105,12 +139,14 @@ pub fn retry_sign_up(user_id: Principal) -> RetrySignUpResponse {
 
     // 3. Update the user's canister status in the database to [`did::directory::UserCanisterStatus::CreationPending`]
     if let Err(err) = UserRepository::retry_user_canister_creation(user_id) {
+        ic_utils::log!("retry_sign_up: failed to update canister status for user {user_id}: {err}");
         return RetrySignUpResponse::Err(RetrySignUpError::InternalError(format!(
             "Failed to update user canister status in the database: {err}"
         )));
     }
 
     // 4. Spawn the state machine that will drive the user canister creation process, then return [`RetrySignUpResponse::Ok`].
+    ic_utils::log!("retry_sign_up: restarting canister creation for user {user_id}");
     start_sign_up_state_machine(user_id);
 
     RetrySignUpResponse::Ok

--- a/crates/canisters/directory/src/domain/users/sign_up/state.rs
+++ b/crates/canisters/directory/src/domain/users/sign_up/state.rs
@@ -15,8 +15,10 @@ thread_local! {
     static USER_SIGN_UP_STATES: RefCell<HashMap<Principal, SignUpStateStep>> = RefCell::new(HashMap::new());
 }
 
+/// Initial amount of cycles to attach to the user canister during creation.
+const INITIAL_USER_CANISTER_CYCLES: u128 = 1_000_000_000_000;
 /// Minimum interval between two sign up operations to prevent abuse.
-const OPERATION_INTERVAL: Duration = Duration::from_secs(5);
+const OPERATION_INTERVAL: Duration = Duration::from_secs(1);
 /// Maximum number of retries for each step in the sign up process before giving up.
 const MAX_RETRIES: u8 = 5;
 /// User canister wasm bytes.
@@ -94,6 +96,7 @@ where
 {
     /// Start a new sign up process for a user by initializing their state in the `USER_SIGN_UP_STATES` thread-local storage.
     pub fn start(user_id: Principal, client: C) {
+        ic_utils::log!("Starting sign up process for user {user_id}",);
         // if there is already an entry for the user, return early to prevent starting multiple sign up processes for the same user
         let already_exists =
             USER_SIGN_UP_STATES.with_borrow(|states| states.contains_key(&user_id));
@@ -110,7 +113,11 @@ where
 
     /// Tick the state machine to progress the sign up process for the user.
     fn tick(self) {
-        ic_utils::set_timer(OPERATION_INTERVAL, self.run());
+        ic_utils::log!("Ticking sign up process for user {}", self.user_id);
+        ic_utils::set_timer(OPERATION_INTERVAL, async move {
+            ic_utils::log!("Timer fired for user {}", self.user_id);
+            self.run().await;
+        });
     }
 
     /// Run a step of the sign up process for the user based on their current state in the `USER_SIGN_UP_STATES` thread-local storage.
@@ -138,6 +145,12 @@ where
     /// scheduling and thread-local storage so it can be unit-tested.
     async fn step(&self, current: SignUpStateStep) -> StepResult {
         let SignUpStateStep { state, retries } = current;
+        ic_utils::log!(
+            "Running sign up step for user {}: state={:?}, retries={}",
+            self.user_id,
+            state,
+            retries
+        );
         let current_discriminant = std::mem::discriminant(&state);
 
         // check retries
@@ -199,7 +212,11 @@ where
         });
 
         #[allow(irrefutable_let_patterns)]
-        let Ok(canister_id) = self.client.create_canister(settings).await else {
+        let Ok(canister_id) = self
+            .client
+            .create_canister(settings, INITIAL_USER_CANISTER_CYCLES)
+            .await
+        else {
             // failed, return same state to retry
             return SignUpState::CreateCanister;
         };
@@ -294,6 +311,7 @@ mod tests {
         async fn create_canister(
             &self,
             _settings: Option<CanisterSettings>,
+            _cycles: u128,
         ) -> Result<Principal, ManagementCanisterError> {
             self.create_result.clone()
         }

--- a/crates/canisters/directory/src/domain/users/user_canister.rs
+++ b/crates/canisters/directory/src/domain/users/user_canister.rs
@@ -1,0 +1,87 @@
+//! Flow for getting the `user_canister` by principal.
+
+use candid::Principal;
+use did::directory::{UserCanisterError, UserCanisterResponse};
+
+use crate::domain::users::repository::UserRepository;
+
+/// Given a [`Principal`] of a user, returns the [`Principal`] of their User Canister if they are registered in the directory.
+///
+/// 1. If the caller is not registered in the directory, returns [`UserCanisterError::NotRegistered`].
+/// 2. If the caller's canister is not active (e.g. pending creation or failed), returns [`UserCanisterError::CanisterNotActive`].
+/// 3. If an internal error occurs while retrieving the User Canister, returns [`UserCanisterError::InternalError`] with a message describing the error.
+/// 4. If the caller is registered and their canister is active, returns the [`Principal`] of their User Canister wrapped in [`UserCanisterResponse::Ok`].
+pub fn user_canister(user: Principal) -> UserCanisterResponse {
+    ic_utils::log!("user_canister: looking up user {user}");
+
+    let user_data = match UserRepository::get_user_by_principal(user) {
+        Ok(Some(user)) => user,
+        Ok(None) => {
+            ic_utils::log!("whoami: user {user} is not registered");
+            return UserCanisterResponse::Err(UserCanisterError::NotRegistered);
+        }
+        Err(e) => {
+            ic_utils::log!("whoami: internal error querying user {user}: {e}");
+            return UserCanisterResponse::Err(UserCanisterError::InternalError(format!(
+                "failed to query database: {e}"
+            )));
+        }
+    };
+
+    match user_data.canister_id.into_opt() {
+        Some(canister_id) => {
+            ic_utils::log!("user_canister: found canister {canister_id} for user {user}");
+            UserCanisterResponse::Ok(canister_id.0)
+        }
+        None => {
+            ic_utils::log!("user_canister: user {user} has no active canister");
+            UserCanisterResponse::Err(UserCanisterError::CanisterNotActive)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+    use crate::test_utils::{
+        bob, rey_canisteryo, setup, setup_registered_user, setup_registered_user_with_canister,
+    };
+
+    #[test]
+    fn test_should_return_canister_for_active_user() {
+        setup();
+
+        let canister_id = rey_canisteryo();
+        setup_registered_user_with_canister(bob(), "alice", canister_id);
+
+        let response = user_canister(bob());
+
+        assert_eq!(response, UserCanisterResponse::Ok(canister_id));
+    }
+
+    #[test]
+    fn test_should_return_not_active_when_canister_pending() {
+        setup();
+        setup_registered_user(bob(), "alice");
+
+        let response = user_canister(bob());
+
+        assert_eq!(
+            response,
+            UserCanisterResponse::Err(UserCanisterError::CanisterNotActive)
+        );
+    }
+
+    #[test]
+    fn test_should_return_not_registered_for_unknown_principal() {
+        setup();
+
+        let response = user_canister(bob());
+
+        assert_eq!(
+            response,
+            UserCanisterResponse::Err(UserCanisterError::NotRegistered)
+        );
+    }
+}

--- a/crates/canisters/directory/src/domain/users/whoami.rs
+++ b/crates/canisters/directory/src/domain/users/whoami.rs
@@ -1,0 +1,97 @@
+//! Whoami flow implementation
+
+use candid::Principal;
+use did::directory::{WhoAmI, WhoAmIError, WhoAmIResponse};
+
+use crate::domain::users::repository::UserRepository;
+
+/// Returns the user information for the caller.
+///
+/// - If the caller is registered, returns their handle, user canister (if any), and canister status as [`WhoAmI`].
+/// - If the caller is not registered, returns a [`WhoAmIError::NotRegistered`] error.
+/// - If an internal error occurs while retrieving user information, returns an [`WhoAmIError::InternalError`] error.
+pub fn whoami(caller: Principal) -> WhoAmIResponse {
+    ic_utils::log!("whoami: looking up user {caller}");
+
+    let user = match UserRepository::get_user_by_principal(caller) {
+        Ok(Some(user)) => user,
+        Ok(None) => {
+            ic_utils::log!("whoami: user {caller} is not registered");
+            return WhoAmIResponse::Err(WhoAmIError::NotRegistered);
+        }
+        Err(e) => {
+            ic_utils::log!("whoami: internal error querying user {caller}: {e}");
+            return WhoAmIResponse::Err(WhoAmIError::InternalError(format!(
+                "failed to query database: {e}"
+            )));
+        }
+    };
+
+    ic_utils::log!(
+        "whoami: found user {caller} with handle {:?}, canister status {:?}",
+        user.handle.0,
+        user.canister_status.0
+    );
+
+    WhoAmIResponse::Ok(WhoAmI {
+        handle: user.handle.0,
+        user_canister: user.canister_id.into_opt().map(|p| p.0),
+        canister_status: user.canister_status.into(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+
+    use did::directory::UserCanisterStatus;
+
+    use super::*;
+    use crate::test_utils::{
+        bob, rey_canisteryo, setup, setup_registered_user, setup_registered_user_with_canister,
+    };
+
+    #[test]
+    fn test_should_return_user_info_for_registered_user_without_canister() {
+        setup();
+        setup_registered_user(bob(), "alice");
+
+        let response = whoami(bob());
+
+        match response {
+            WhoAmIResponse::Ok(info) => {
+                assert_eq!(info.handle, "alice");
+                assert!(info.user_canister.is_none());
+                assert_eq!(info.canister_status, UserCanisterStatus::CreationPending);
+            }
+            WhoAmIResponse::Err(e) => panic!("expected Ok, got Err({e:?})"),
+        }
+    }
+
+    #[test]
+    fn test_should_return_user_info_for_registered_user_with_canister() {
+        setup();
+
+        let canister_id = rey_canisteryo();
+        setup_registered_user_with_canister(bob(), "alice", canister_id);
+
+        let response = whoami(bob());
+
+        match response {
+            WhoAmIResponse::Ok(info) => {
+                assert_eq!(info.handle, "alice");
+                assert_eq!(info.user_canister, Some(canister_id));
+                assert_eq!(info.canister_status, UserCanisterStatus::Active);
+            }
+            WhoAmIResponse::Err(e) => panic!("expected Ok, got Err({e:?})"),
+        }
+    }
+
+    #[test]
+    fn test_should_return_not_registered_for_unknown_principal() {
+        setup();
+
+        let response = whoami(bob());
+
+        assert_eq!(response, WhoAmIResponse::Err(WhoAmIError::NotRegistered));
+    }
+}

--- a/crates/canisters/directory/src/lib.rs
+++ b/crates/canisters/directory/src/lib.rs
@@ -8,7 +8,11 @@ mod settings;
 #[cfg(test)]
 mod test_utils;
 
-use did::directory::{DirectoryInstallArgs, RetrySignUpResponse, SignUpRequest, SignUpResponse};
+use candid::Principal;
+use did::directory::{
+    DirectoryInstallArgs, GetUserResponse, RetrySignUpResponse, SignUpRequest, SignUpResponse,
+    UserCanisterResponse, WhoAmIResponse,
+};
 
 #[ic_cdk::init]
 fn init(args: DirectoryInstallArgs) {
@@ -20,14 +24,29 @@ fn post_upgrade(args: DirectoryInstallArgs) {
     api::post_upgrade(args);
 }
 
-#[ic_cdk::update]
-fn sign_up(request: SignUpRequest) -> SignUpResponse {
-    api::sign_up(request)
+#[ic_cdk::query]
+fn get_user(handle: String) -> GetUserResponse {
+    api::get_user(&handle)
 }
 
 #[ic_cdk::update]
 fn retry_sign_up() -> RetrySignUpResponse {
     api::retry_sign_up()
+}
+
+#[ic_cdk::update]
+fn sign_up(request: SignUpRequest) -> SignUpResponse {
+    api::sign_up(request)
+}
+
+#[ic_cdk::query]
+fn user_canister(principal: Option<Principal>) -> UserCanisterResponse {
+    api::user_canister(principal)
+}
+
+#[ic_cdk::query]
+fn whoami() -> WhoAmIResponse {
+    api::whoami()
 }
 
 ic_cdk::export_candid!();

--- a/crates/canisters/directory/src/test_utils.rs
+++ b/crates/canisters/directory/src/test_utils.rs
@@ -1,7 +1,7 @@
 //! Shared test utilities for the directory canister.
 
 use candid::Principal;
-use did::directory::DirectoryInstallArgs;
+use did::directory::{DirectoryInstallArgs, SignUpRequest, SignUpResponse};
 
 pub fn admin() -> Principal {
     Principal::from_text("be2us-64aaa-aaaaa-qaabq-cai").unwrap()
@@ -24,4 +24,38 @@ pub fn setup() {
         initial_moderator: admin(),
         federation_canister: federation(),
     });
+}
+
+/// Registers a user with the given principal and handle.
+///
+/// The user will have canister status [`did::directory::UserCanisterStatus::CreationPending`]
+/// and no canister ID assigned.
+///
+/// # Panics
+///
+/// Panics if the sign-up fails.
+pub fn setup_registered_user(principal: Principal, handle: &str) {
+    let response = crate::domain::users::sign_up(
+        principal,
+        SignUpRequest {
+            handle: handle.to_string(),
+        },
+    );
+    assert_eq!(response, SignUpResponse::Ok, "setup_registered_user failed");
+}
+
+/// Registers a user with the given principal and handle, then assigns a canister ID
+/// and sets the canister status to [`did::directory::UserCanisterStatus::Active`].
+///
+/// # Panics
+///
+/// Panics if sign-up or canister assignment fails.
+pub fn setup_registered_user_with_canister(
+    principal: Principal,
+    handle: &str,
+    canister_id: Principal,
+) {
+    setup_registered_user(principal, handle);
+    crate::domain::users::repository::UserRepository::set_user_canister(principal, canister_id)
+        .expect("setup_registered_user_with_canister: failed to set user canister");
 }

--- a/crates/canisters/federation/src/lib.rs
+++ b/crates/canisters/federation/src/lib.rs
@@ -3,6 +3,8 @@ use did::federation::FederationInstallArgs;
 mod memory;
 
 #[ic_cdk::init]
-fn init(_args: FederationInstallArgs) {}
+fn init(_args: FederationInstallArgs) {
+    ic_utils::log!("Federation canister initialized");
+}
 
 ic_cdk::export_candid!();

--- a/crates/canisters/user/src/api.rs
+++ b/crates/canisters/user/src/api.rs
@@ -5,6 +5,8 @@ use ic_dbms_canister::prelude::DBMS_CONTEXT;
 
 /// Initializes the canister with the given arguments.
 pub fn init(args: UserInstallArgs) {
+    ic_utils::log!("Initializing user canister");
+
     let UserInstallArgs::Init {
         owner,
         federation_canister,
@@ -14,6 +16,7 @@ pub fn init(args: UserInstallArgs) {
     };
 
     // register database schema
+    ic_utils::log!("Registering database schema");
     DBMS_CONTEXT.with(|ctx| {
         if let Err(err) = crate::schema::Schema::register_tables(ctx) {
             ic_utils::trap!("Failed to register database schema: {err}");
@@ -21,21 +24,29 @@ pub fn init(args: UserInstallArgs) {
     });
 
     // set owner
+    ic_utils::log!("Setting owner principal to {owner}");
     if let Err(err) = crate::settings::set_owner_principal(owner) {
         ic_utils::trap!("Failed to set owner principal: {:?}", err);
     }
 
     // set federation canister
+    ic_utils::log!("Setting federation canister to {federation_canister}");
     if let Err(err) = crate::settings::set_federation_canister(federation_canister) {
         ic_utils::trap!("Failed to set federation canister: {:?}", err);
     }
+
+    ic_utils::log!("User canister initialized successfully for owner {owner}");
 }
 
 /// Post-upgrade function for the canister.
 pub fn post_upgrade(args: UserInstallArgs) {
+    ic_utils::log!("Post-upgrade user canister");
+
     let UserInstallArgs::Upgrade { .. } = args else {
         ic_utils::trap!("Invalid post-upgrade arguments");
     };
+
+    ic_utils::log!("User canister post-upgrade completed successfully");
 }
 
 #[cfg(test)]

--- a/crates/libs/did/src/directory.rs
+++ b/crates/libs/did/src/directory.rs
@@ -92,16 +92,18 @@ pub struct WhoAmI {
     /// The unique username (handle) of the caller.
     pub handle: String,
     /// The principal of the caller's User Canister.
-    pub user_canister: candid::Principal,
+    pub user_canister: Option<candid::Principal>,
     /// The status of the caller's User Canister.
     pub canister_status: UserCanisterStatus,
 }
 
 /// Error types for the `who_am_i` method.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, CandidType, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, CandidType, Serialize, Deserialize)]
 pub enum WhoAmIError {
     /// The caller has no account in the directory.
     NotRegistered,
+    /// Internal error occurred while retrieving user information.
+    InternalError(String),
 }
 
 /// Response type for the `who_am_i` method, returning either the caller's identity
@@ -114,14 +116,18 @@ pub enum WhoAmIResponse {
 
 /// Error types for the `user_canister` method.
 /// Resolves the caller's principal to their User Canister ID.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, CandidType, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, CandidType, Serialize, Deserialize)]
 pub enum UserCanisterError {
     /// The caller has no account in the directory.
     NotRegistered,
+    /// The caller's canister is not active (e.g. pending creation or failed).
+    CanisterNotActive,
+    /// Internal error occurred while retrieving the User Canister.
+    InternalError(String),
 }
 
 /// Response type for the `user_canister` method.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, CandidType, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, CandidType, Serialize, Deserialize)]
 pub enum UserCanisterResponse {
     Ok(candid::Principal),
     Err(UserCanisterError),
@@ -140,14 +146,20 @@ pub struct GetUser {
     /// The matched user's handle.
     pub handle: String,
     /// Principal of the looked-up user's canister.
-    pub canister_id: candid::Principal,
+    pub canister_id: Option<candid::Principal>,
+    /// The status of the looked-up user's canister.
+    pub canister_status: UserCanisterStatus,
 }
 
 /// Error types for the `get_user` method.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, CandidType, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, CandidType, Serialize, Deserialize)]
 pub enum GetUserError {
     /// No user exists with the given handle.
     NotFound,
+    /// The provided handle is invalid (e.g. empty or contains disallowed characters).
+    InvalidHandle,
+    /// Internal error occurred while retrieving user information.
+    InternalError(String),
 }
 
 /// Response type for the `get_user` method.

--- a/crates/libs/did/src/directory/tests.rs
+++ b/crates/libs/did/src/directory/tests.rs
@@ -57,7 +57,7 @@ fn test_should_roundtrip_sign_up_response_err() {
 fn test_should_roundtrip_who_am_i_response_ok() {
     let resp = WhoAmIResponse::Ok(WhoAmI {
         handle: "alice".to_string(),
-        user_canister: candid::Principal::anonymous(),
+        user_canister: Some(candid::Principal::anonymous()),
         canister_status: UserCanisterStatus::Active,
     });
     let bytes = Encode!(&resp).unwrap();
@@ -103,7 +103,8 @@ fn test_should_roundtrip_get_user_args() {
 fn test_should_roundtrip_get_user_response_ok() {
     let resp = GetUserResponse::Ok(GetUser {
         handle: "alice".to_string(),
-        canister_id: candid::Principal::anonymous(),
+        canister_id: Some(candid::Principal::anonymous()),
+        canister_status: UserCanisterStatus::Active,
     });
     let bytes = Encode!(&resp).unwrap();
     let decoded = Decode!(&bytes, GetUserResponse).unwrap();

--- a/crates/libs/ic-utils/src/lib.rs
+++ b/crates/libs/ic-utils/src/lib.rs
@@ -90,6 +90,31 @@ macro_rules! trap {
     });
 }
 
+#[macro_export]
+macro_rules! log {
+    ($($key:tt $(:$capture:tt)? $(= $value:expr)?),+; $($arg:tt)+) => ({
+        #[cfg(target_family = "wasm")]
+        {
+            ic_cdk::println!("{}", format!($($arg)+));
+        }
+        #[cfg(not(target_family = "wasm"))]
+        {
+            println!("[DEBUG] {}", format!($($arg)+));
+        }
+    });
+
+    ( $($arg:tt)+) => ({
+        #[cfg(target_family = "wasm")]
+        {
+            ic_cdk::println!("{}", format!($($arg)+));
+        }
+        #[cfg(not(target_family = "wasm"))]
+        {
+            println!("[DEBUG] {}", format!($($arg)+));
+        }
+    });
+}
+
 #[cfg(test)]
 mod tests {
 

--- a/docs/src/directory.did
+++ b/docs/src/directory.did
@@ -1,11 +1,116 @@
+// Install arguments for the Directory canister.
+type DirectoryInstallArgs = variant {
+  // Upgrade argument, provided on `upgrade`
+  Upgrade : record {};
+  // Initial installation argument, provided on `init`
+  Init : record {
+    // Principal of the Federation canister
+    federation_canister : principal;
+    // The principal of the initial moderator who has permission to manage the directory.
+    initial_moderator : principal;
+  };
+};
+// Data returned by the `get_user` method on success.
+type GetUser = record {
+  // Principal of the looked-up user's canister.
+  canister_id : opt principal;
+  // The status of the looked-up user's canister.
+  canister_status : UserCanisterStatus;
+  // The matched user's handle.
+  handle : text;
+};
+// Error types for the `get_user` method.
+type GetUserError = variant {
+  // The provided handle is invalid (e.g. empty or contains disallowed characters).
+  InvalidHandle;
+  // No user exists with the given handle.
+  NotFound;
+  // Internal error occurred while retrieving user information.
+  InternalError : text;
+};
+// Response type for the `get_user` method.
+type GetUserResponse = variant { Ok : GetUser; Err : GetUserError };
+// Response error types for the `retry_sign_up` method.
+// Retries the canister creation for a user that failed to create their canister during the sign up process.
+type RetrySignUpError = variant {
+  // The caller has no account to retry
+  NotRegistered;
+  // The caller's canister is not in a failed state, so retrying is not allowed
+  CanisterNotInFailedState;
+  // Internal error
+  InternalError : text;
+};
+// Response result type for the `retry_sign_up` method.
+type RetrySignUpResponse = variant { Ok; Err : RetrySignUpError };
+// Response error types for the `sign_up` method. Registers a new user in the
+// directory, creating a User Canister and mapping the caller's principal to the
+// chosen handle.
+type SignUpError = variant {
+  // The chosen handle is invalid (e.g. empty or contains disallowed characters)
+  InvalidHandle;
+  // The caller has already an account
+  AlreadyRegistered;
+  // Anonymous users are not allowed to sign up
+  AnonymousPrincipal;
+  // The chosen handle is already taken by another user
+  HandleTaken;
+  // Internal error
+  InternalError : text;
+};
+// Request arguments for the `sign_up` method. Registers a new user in the
+// directory, creating a User Canister and mapping the caller's principal to the
+// chosen handle.
+type SignUpRequest = record {
+  // The desired unique username (handle) for the new user.
+  handle : text;
+};
+// Response result type for the `sign_up` method.
+type SignUpResponse = variant { Ok; Err : SignUpError };
+// Error types for the `user_canister` method.
+// Resolves the caller's principal to their User Canister ID.
+type UserCanisterError = variant {
+  // The caller has no account in the directory.
+  NotRegistered;
+  // The caller's canister is not active (e.g. pending creation or failed).
+  CanisterNotActive;
+  // Internal error occurred while retrieving the User Canister.
+  InternalError : text;
+};
+// Response type for the `user_canister` method.
+type UserCanisterResponse = variant { Ok : principal; Err : UserCanisterError };
+// The status of a user's canister, used in the `who_am_i` method to indicate whether
+// the user's canister is active, pending creation, or failed to create.
+type UserCanisterStatus = variant {
+  // Creation failed
+  CreationFailed;
+  // Active and created
+  Active;
+  // Creation pending
+  CreationPending;
+};
+// `who_am_i` method data to be returned in case the caller is registered in the directory.
+type WhoAmI = record {
+  // The status of the caller's User Canister.
+  canister_status : UserCanisterStatus;
+  // The unique username (handle) of the caller.
+  handle : text;
+  // The principal of the caller's User Canister.
+  user_canister : opt principal;
+};
+// Error types for the `who_am_i` method.
+type WhoAmIError = variant {
+  // The caller has no account in the directory.
+  NotRegistered;
+  // Internal error occurred while retrieving user information.
+  InternalError : text;
+};
+// Response type for the `who_am_i` method, returning either the caller's identity
+// information or an error if they are not registered.
+type WhoAmIResponse = variant { Ok : WhoAmI; Err : WhoAmIError };
 service : (DirectoryInstallArgs) -> {
-  add_moderator : (AddModeratorArgs) -> (AddModeratorResponse);
-  delete_profile : () -> (DeleteProfileResponse);
-  get_user : (GetUserArgs) -> (GetUserResponse) query;
-  remove_moderator : (RemoveModeratorArgs) -> (RemoveModeratorResponse);
-  search_profiles : (SearchProfilesArgs) -> (SearchProfilesResponse) query;
-  sign_up : (text) -> (SignUpResponse);
-  suspend : (SuspendArgs) -> (SuspendResponse);
-  user_canister : (opt Principal) -> (UserCanisterResponse) query;
-  whoami : () -> (WhoAmIResponse) query
+  get_user : (text) -> (GetUserResponse) query;
+  retry_sign_up : () -> (RetrySignUpResponse);
+  sign_up : (SignUpRequest) -> (SignUpResponse);
+  user_canister : (opt principal) -> (UserCanisterResponse) query;
+  whoami : () -> (WhoAmIResponse) query;
 }

--- a/docs/src/federation.did
+++ b/docs/src/federation.did
@@ -1,5 +1,13 @@
-service : (FederationInstallArgs) -> {
-  http_request : (HttpRequest) -> (HttpResponse) query;
-  http_request_update : (HttpRequest) -> (HttpResponse);
-  send_activity : (SendActivityArgs) -> (SendActivityResponse)
-}
+// Install arguments for the Federation canister.
+type FederationInstallArgs = variant {
+  // Upgrade argument, provided on `upgrade`
+  Upgrade : record {};
+  // Initial installation argument, provided on `init`
+  Init : record {
+    // The URL of this server's public endpoint (e.g. `https://example.com`)
+    public_url : text;
+    // Principal of the Directory canister
+    directory_canister : principal;
+  };
+};
+service : (FederationInstallArgs) -> {}

--- a/docs/src/interface/types.md
+++ b/docs/src/interface/types.md
@@ -232,7 +232,7 @@ their own identity and check canister readiness.
 | Field              | Description                                                                              |
 | :----------------- | :--------------------------------------------------------------------------------------- |
 | `handle`           | The caller's registered handle.                                                          |
-| `user_canister`    | Principal of the caller's User Canister.                                                 |
+| `user_canister`    | Principal of the caller's User Canister. (Optional)                                      |
 | `canister_status`  | Status of the caller's User Canister (see [UserCanisterStatus](#usercanisterstatus)).    |
 
 - **NotRegistered**: the caller has no account in the directory.

--- a/docs/src/user.did
+++ b/docs/src/user.did
@@ -1,21 +1,13 @@
-service : (UserInstallArgs) -> {
-  accept_follow : (AcceptFollowArgs) -> (AcceptFollowResponse);
-  block_user : (BlockUserArgs) -> (BlockUserResponse);
-  boost_status : (BoostStatusArgs) -> (BoostStatusResponse);
-  delete_profile : () -> (DeleteProfileResponse);
-  delete_status : (DeleteStatusArgs) -> (DeleteStatusResponse);
-  follow_user : (FollowUserArgs) -> (FollowUserResponse);
-  get_followers : (GetFollowersArgs) -> (GetFollowersResponse) query;
-  get_following : (GetFollowingArgs) -> (GetFollowingResponse) query;
-  get_liked : (GetLikedArgs) -> (GetLikedResponse) query;
-  get_profile : () -> (GetProfileResponse) query;
-  like_status : (LikeStatusArgs) -> (LikeStatusResponse);
-  publish_status : (PublishStatusArgs) -> (PublishStatusResponse);
-  read_feed : (ReadFeedArgs) -> (ReadFeedResponse) query;
-  receive_activity : (ReceiveActivityArgs) -> (ReceiveActivityResponse);
-  reject_follow : (RejectFollowArgs) -> (RejectFollowResponse);
-  undo_boost : (UndoBoostArgs) -> (UndoBoostResponse);
-  undo_like : (UndoLikeArgs) -> (UndoLikeResponse);
-  unfollow_user : (UnfollowUserArgs) -> (UnfollowUserResponse);
-  update_profile : (UpdateProfileArgs) -> (UpdateProfileResponse)
-}
+// Install arguments for the User Canister.
+type UserInstallArgs = variant {
+  // Upgrade argument, provided on `upgrade`.
+  Upgrade : record {};
+  // Initial installation argument, provided on `init`.
+  Init : record {
+    // Principal of the Federation Canister used for outbound ActivityPub delivery.
+    federation_canister : principal;
+    // The owner principal (the user's Internet Identity).
+    owner : principal;
+  };
+};
+service : (UserInstallArgs) -> {}

--- a/integration-tests/src/directory_client.rs
+++ b/integration-tests/src/directory_client.rs
@@ -1,5 +1,7 @@
 use candid::{Encode, Principal};
-use did::directory::{RetrySignUpResponse, SignUpRequest, SignUpResponse};
+use did::directory::{
+    RetrySignUpResponse, SignUpRequest, SignUpResponse, UserCanisterResponse, WhoAmIResponse,
+};
 use pocket_ic_harness::PocketIcTestEnv;
 
 use crate::{MasticCanister, MasticCanisterSetup};
@@ -34,6 +36,29 @@ impl DirectoryClient<'_> {
             .update(self.canister_id(), user, "retry_sign_up", vec![])
             .await
             .expect("Failed to call retry_sign_up")
+    }
+
+    pub async fn user_canister(
+        &self,
+        caller: Principal,
+        principal: Option<Principal>,
+    ) -> UserCanisterResponse {
+        self.env
+            .query(
+                self.canister_id(),
+                caller,
+                "user_canister",
+                Encode!(&principal).expect("Failed to encode user_canister args"),
+            )
+            .await
+            .expect("Failed to call user_canister")
+    }
+
+    pub async fn whoami(&self, user: Principal) -> WhoAmIResponse {
+        self.env
+            .query(self.canister_id(), user, "whoami", vec![])
+            .await
+            .expect("Failed to call whoami")
     }
 
     fn canister_id(&self) -> Principal {

--- a/integration-tests/tests/sign_up.rs
+++ b/integration-tests/tests/sign_up.rs
@@ -1,24 +1,65 @@
+use std::time::Instant;
+
 use candid::Principal;
-use did::directory::{SignUpError, SignUpResponse};
-use integration_tests::{DirectoryClient, MasticCanisterSetup};
+use did::directory::{SignUpError, SignUpResponse, WhoAmIResponse};
+use integration_tests::{DirectoryClient, MasticCanisterSetup, rey_canisteryo};
 use pocket_ic_harness::{PocketIcTestEnv, alice, bob};
 
 #[pocket_ic_harness::test]
 async fn test_should_sign_up(env: PocketIcTestEnv<MasticCanisterSetup>) {
     let client = DirectoryClient::new(&env);
 
-    let response = client.sign_up(alice(), "alice".to_string()).await;
+    let response = client
+        .sign_up(rey_canisteryo(), "rey_canisteryo".to_string())
+        .await;
     assert_eq!(response, SignUpResponse::Ok);
+
+    // wait for canister to be created
+    let t = Instant::now();
+    loop {
+        if t.elapsed() > std::time::Duration::from_secs(30) {
+            panic!("timout waiting for canister to be created");
+        }
+        match client.whoami(rey_canisteryo()).await {
+            WhoAmIResponse::Ok(info) if info.user_canister.is_some() => {
+                assert_eq!(info.handle, "rey_canisteryo");
+                assert_eq!(
+                    info.canister_status,
+                    did::directory::UserCanisterStatus::Active
+                );
+                break;
+            }
+            WhoAmIResponse::Ok(info) => {
+                assert!(info.user_canister.is_none());
+                if info.canister_status == did::directory::UserCanisterStatus::CreationFailed {
+                    panic!("canister creation failed");
+                }
+                assert!(
+                    info.canister_status == did::directory::UserCanisterStatus::CreationPending
+                );
+                println!("canister status: {:?}, waiting...", info.canister_status);
+            }
+            WhoAmIResponse::Err(e) => panic!("expected Ok, got Err({e:?})"),
+        }
+        // Sleep for a bit before retrying
+        tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+        env.pic
+            .advance_time(std::time::Duration::from_secs(1))
+            .await;
+        env.pic.tick().await;
+    }
 }
 
 #[pocket_ic_harness::test]
 async fn test_should_not_accept_duplicate_handle(env: PocketIcTestEnv<MasticCanisterSetup>) {
     let client = DirectoryClient::new(&env);
 
-    let response = client.sign_up(alice(), "alice".to_string()).await;
+    let response = client
+        .sign_up(rey_canisteryo(), "rey_canisteryo".to_string())
+        .await;
     assert_eq!(response, SignUpResponse::Ok);
 
-    let response = client.sign_up(bob(), "alice".to_string()).await;
+    let response = client.sign_up(bob(), "rey_canisteryo".to_string()).await;
     assert_eq!(response, SignUpResponse::Err(SignUpError::HandleTaken));
 }
 

--- a/just/build.just
+++ b/just/build.just
@@ -31,4 +31,5 @@ build_canister canister_name wasm_name:
   cargo build --target wasm32-unknown-unknown --release --package "{{canister_name}}"
   ic-wasm "target/wasm32-unknown-unknown/release/{{canister_name}}.wasm" -o "{{WASM_DIR}}/{{wasm_name}}.wasm" shrink
   candid-extractor "{{WASM_DIR}}/{{wasm_name}}.wasm" > "{{WASM_DIR}}/{{wasm_name}}.did"
+  cp "{{WASM_DIR}}/{{wasm_name}}.did" ./docs/src/{{wasm_name}}.did
   gzip -k "{{WASM_DIR}}/{{wasm_name}}.wasm" --force


### PR DESCRIPTION
## Summary

- Add query methods to the directory canister: `get_user`, `whoami`, `get_user_canister`, `get_moderators`, and `get_sign_up_state`
- Update Candid interface definitions for directory, federation, and user canisters
- Add integration test coverage for the new query endpoints

Closes #5