### PR TITLE
feat: implement get_statuses with visibility filtering and directory adapter

### DIFF
--- a/crates/canisters/directory/src/api.rs
+++ b/crates/canisters/directory/src/api.rs
@@ -2,8 +2,8 @@
 
 use candid::Principal;
 use did::directory::{
-    DirectoryInstallArgs, GetUserResponse, RetrySignUpResponse, SignUpRequest, SignUpResponse,
-    UserCanisterResponse, WhoAmIResponse,
+    DirectoryInstallArgs, GetUserArgs, GetUserResponse, RetrySignUpResponse, SignUpRequest,
+    SignUpResponse, UserCanisterResponse, WhoAmIResponse,
 };
 use ic_dbms_canister::prelude::DBMS_CONTEXT;
 
@@ -56,9 +56,9 @@ pub fn post_upgrade(args: DirectoryInstallArgs) {
     ic_utils::log!("Directory canister post-upgrade completed successfully");
 }
 
-/// Handles the `get_user` method call to retrieve user information based on their handle.
-pub fn get_user(handle: &str) -> GetUserResponse {
-    crate::domain::users::get_user(handle)
+/// Handles the `get_user` method call to retrieve user information by handle or principal.
+pub fn get_user(args: GetUserArgs) -> GetUserResponse {
+    crate::domain::users::get_user(args)
 }
 
 /// Retry canister creation for the user that called this method.
@@ -251,7 +251,7 @@ mod tests {
         setup();
         crate::test_utils::setup_registered_user(crate::test_utils::bob(), "alice");
 
-        let response = get_user("alice");
+        let response = get_user(GetUserArgs::Handle("alice".to_string()));
 
         match response {
             GetUserResponse::Ok(user) => {
@@ -265,7 +265,7 @@ mod tests {
     fn test_should_get_user_return_not_found() {
         setup();
 
-        let response = get_user("nonexistent");
+        let response = get_user(GetUserArgs::Handle("nonexistent".to_string()));
 
         assert_eq!(
             response,

--- a/crates/canisters/directory/src/domain/users/get_user.rs
+++ b/crates/canisters/directory/src/domain/users/get_user.rs
@@ -1,46 +1,77 @@
-//! Flow implementation to get a user by their handle.
+//! Flow implementation to get a user by handle or principal.
 
+use candid::Principal;
 use db_utils::handle::{HandleSanitizer, HandleValidator};
-use did::directory::{GetUser, GetUserError, GetUserResponse};
+use did::directory::{GetUser, GetUserArgs, GetUserError, GetUserResponse};
 
 use crate::domain::users::repository::UserRepository;
+use crate::error::CanisterResult;
+use crate::schema::User;
 
-/// Retrieves a user's information based on their handle.
+/// Retrieves a user's information by handle or principal.
 ///
-/// 1. Checks if a user with the given handle exists in the repository.
-/// 2. If the handle is invalid (e.g. empty or contains disallowed characters), returns [`GetUserError::InvalidHandle`] wrapped in [`GetUserResponse::Err`].
+/// 1. Resolves the user via the appropriate lookup (handle or principal).
+/// 2. If the handle variant is used and the handle is invalid, returns [`GetUserError::InvalidHandle`].
 /// 3. If the user exists, returns their information as [`GetUser`] wrapped in [`GetUserResponse::Ok`].
-/// 4. If the user does not exist, returns [`GetUserError::NotFound`] wrapped in [`GetUserResponse::Err`].
-/// 5. If any internal error occurs during the retrieval process, returns a descriptive error message wrapped
-///    in [`GetUserResponse::Err`] with the variant [`GetUserError::InternalError`].
-pub fn get_user(handle: &str) -> GetUserResponse {
-    ic_utils::log!("get_user: looking up user with {handle}");
+/// 4. If the user does not exist, returns [`GetUserError::NotFound`].
+/// 5. If any internal error occurs, returns [`GetUserError::InternalError`].
+pub fn get_user(args: GetUserArgs) -> GetUserResponse {
+    let result = match args {
+        GetUserArgs::Handle(ref handle) => lookup_by_handle(handle),
+        GetUserArgs::Principal(principal) => lookup_by_principal(principal),
+    };
+
+    match result {
+        Ok(user_data) => GetUserResponse::Ok(GetUser {
+            handle: user_data.handle.0,
+            canister_id: user_data.canister_id.into_opt().map(|c| c.0),
+            canister_status: user_data.canister_status.0,
+        }),
+        Err(e) => GetUserResponse::Err(e),
+    }
+}
+
+/// Look up a user by handle, sanitizing and validating the input first.
+fn lookup_by_handle(handle: &str) -> Result<User, GetUserError> {
+    ic_utils::log!("get_user: looking up user by handle {handle}");
 
     let handle = HandleSanitizer::sanitize_handle(handle);
     if let Err(err) = HandleValidator::check_handle(&handle) {
         ic_utils::log!("get_user: invalid handle {handle}: {err}");
-        return GetUserResponse::Err(GetUserError::InvalidHandle);
+        return Err(GetUserError::InvalidHandle);
     }
 
-    let user_data = match UserRepository::get_user_by_handle(&handle) {
-        Ok(Some(user)) => user,
+    resolve_user(UserRepository::get_user_by_handle(&handle), &handle)
+}
+
+/// Look up a user by their IC principal.
+fn lookup_by_principal(principal: Principal) -> Result<User, GetUserError> {
+    ic_utils::log!("get_user: looking up user by principal {principal}");
+
+    resolve_user(
+        UserRepository::get_user_by_principal(principal),
+        &principal.to_string(),
+    )
+}
+
+/// Shared resolution logic: maps a repository result to either a [`User`] or a [`GetUserError`].
+fn resolve_user(
+    result: CanisterResult<Option<User>>,
+    identifier: &str,
+) -> Result<User, GetUserError> {
+    match result {
+        Ok(Some(user)) => Ok(user),
         Ok(None) => {
-            ic_utils::log!("get_user: user {handle} is not registered");
-            return GetUserResponse::Err(GetUserError::NotFound);
+            ic_utils::log!("get_user: user {identifier} is not registered");
+            Err(GetUserError::NotFound)
         }
         Err(e) => {
-            ic_utils::log!("get_user: internal error querying user {handle}: {e}");
-            return GetUserResponse::Err(GetUserError::InternalError(format!(
+            ic_utils::log!("get_user: internal error querying user {identifier}: {e}");
+            Err(GetUserError::InternalError(format!(
                 "failed to query database: {e}"
-            )));
+            )))
         }
-    };
-
-    GetUserResponse::Ok(GetUser {
-        handle: user_data.handle.0,
-        canister_id: user_data.canister_id.into_opt().map(|c| c.0),
-        canister_status: user_data.canister_status.0,
-    })
+    }
 }
 
 #[cfg(test)]
@@ -54,11 +85,11 @@ mod tests {
     };
 
     #[test]
-    fn test_should_return_user_without_canister() {
+    fn test_should_return_user_without_canister_by_handle() {
         setup();
         setup_registered_user(bob(), "alice");
 
-        let response = get_user("alice");
+        let response = get_user(GetUserArgs::Handle("alice".to_string()));
 
         match response {
             GetUserResponse::Ok(user) => {
@@ -71,13 +102,13 @@ mod tests {
     }
 
     #[test]
-    fn test_should_return_user_with_canister() {
+    fn test_should_return_user_with_canister_by_handle() {
         setup();
 
         let canister_id = rey_canisteryo();
         setup_registered_user_with_canister(bob(), "alice", canister_id);
 
-        let response = get_user("alice");
+        let response = get_user(GetUserArgs::Handle("alice".to_string()));
 
         match response {
             GetUserResponse::Ok(user) => {
@@ -94,7 +125,7 @@ mod tests {
         setup();
         setup_registered_user(bob(), "alice");
 
-        let response = get_user("  @Alice  ");
+        let response = get_user(GetUserArgs::Handle("  @Alice  ".to_string()));
 
         match response {
             GetUserResponse::Ok(user) => {
@@ -108,7 +139,7 @@ mod tests {
     fn test_should_return_not_found_for_unknown_handle() {
         setup();
 
-        let response = get_user("nonexistent");
+        let response = get_user(GetUserArgs::Handle("nonexistent".to_string()));
 
         assert_eq!(response, GetUserResponse::Err(GetUserError::NotFound));
     }
@@ -117,7 +148,7 @@ mod tests {
     fn test_should_return_invalid_handle_for_empty_handle() {
         setup();
 
-        let response = get_user("");
+        let response = get_user(GetUserArgs::Handle(String::new()));
 
         assert_eq!(response, GetUserResponse::Err(GetUserError::InvalidHandle));
     }
@@ -126,8 +157,32 @@ mod tests {
     fn test_should_return_invalid_handle_for_special_chars() {
         setup();
 
-        let response = get_user("alice!@#");
+        let response = get_user(GetUserArgs::Handle("alice!@#".to_string()));
 
         assert_eq!(response, GetUserResponse::Err(GetUserError::InvalidHandle));
+    }
+
+    #[test]
+    fn test_should_return_user_by_principal() {
+        setup();
+        setup_registered_user(bob(), "alice");
+
+        let response = get_user(GetUserArgs::Principal(bob()));
+
+        match response {
+            GetUserResponse::Ok(user) => {
+                assert_eq!(user.handle, "alice");
+            }
+            GetUserResponse::Err(e) => panic!("expected Ok, got Err({e:?})"),
+        }
+    }
+
+    #[test]
+    fn test_should_return_not_found_for_unknown_principal() {
+        setup();
+
+        let response = get_user(GetUserArgs::Principal(bob()));
+
+        assert_eq!(response, GetUserResponse::Err(GetUserError::NotFound));
     }
 }

--- a/crates/canisters/directory/src/domain/users/sign_up/state.rs
+++ b/crates/canisters/directory/src/domain/users/sign_up/state.rs
@@ -246,6 +246,7 @@ where
         let init_args = UserInstallArgs::Init {
             owner: self.user_id,
             federation_canister,
+            directory_canister: ic_utils::canister_id(),
             handle: self.handle.clone(),
             public_url,
         };

--- a/crates/canisters/directory/src/lib.rs
+++ b/crates/canisters/directory/src/lib.rs
@@ -11,8 +11,8 @@ mod test_utils;
 
 use candid::Principal;
 use did::directory::{
-    DirectoryInstallArgs, GetUserResponse, RetrySignUpResponse, SignUpRequest, SignUpResponse,
-    UserCanisterResponse, WhoAmIResponse,
+    DirectoryInstallArgs, GetUserArgs, GetUserResponse, RetrySignUpResponse, SignUpRequest,
+    SignUpResponse, UserCanisterResponse, WhoAmIResponse,
 };
 
 #[ic_cdk::init]
@@ -31,8 +31,8 @@ fn inspect_message() {
 }
 
 #[ic_cdk::query]
-fn get_user(handle: String) -> GetUserResponse {
-    api::get_user(&handle)
+fn get_user(args: GetUserArgs) -> GetUserResponse {
+    api::get_user(args)
 }
 
 #[ic_cdk::update]

--- a/crates/canisters/user/src/adapters.rs
+++ b/crates/canisters/user/src/adapters.rs
@@ -1,4 +1,5 @@
 //! Adapter traits abstracting external IC calls for testability.
 
+pub mod directory;
 pub mod federation;
 pub mod schnorr;

--- a/crates/canisters/user/src/adapters/directory.rs
+++ b/crates/canisters/user/src/adapters/directory.rs
@@ -1,0 +1,130 @@
+//! Directory canister client adapter.
+
+#[cfg(test)]
+pub mod mock;
+
+use candid::Principal;
+
+use crate::error::CanisterResult;
+
+/// Resolve a principal to its handle via the Directory Canister.
+///
+/// Returns `Ok(Some(handle))` if the principal is registered,
+/// `Ok(None)` if the principal is not registered,
+/// or an error if the call itself failed.
+///
+/// Dispatches to the mock client in tests and to the real
+/// inter-canister client on wasm targets.
+pub async fn resolve_handle(_principal: Principal) -> CanisterResult<Option<String>> {
+    #[cfg(test)]
+    {
+        mock::DirectoryCanisterMockClient
+            .resolve_handle(_principal)
+            .await
+            .map_err(crate::error::CanisterError::from)
+    }
+    #[cfg(target_family = "wasm")]
+    {
+        let directory_canister = crate::settings::get_directory_canister()?;
+        IcDirectoryCanisterClient::from(directory_canister)
+            .resolve_handle(_principal)
+            .await
+            .map_err(crate::error::CanisterError::from)
+    }
+    #[cfg(not(any(target_family = "wasm", test)))]
+    {
+        panic!("resolve_handle is not implemented for non-wasm, non-test targets");
+    }
+}
+
+/// Abstraction over the directory canister API.
+#[cfg(any(target_family = "wasm", test))]
+pub trait DirectoryCanister: Send + Sync + Sized {
+    /// Resolve a principal to its handle. Returns `Ok(None)` if not registered.
+    fn resolve_handle(
+        &self,
+        principal: Principal,
+    ) -> impl Future<Output = Result<Option<String>, DirectoryCanisterClientError>>;
+}
+
+/// Errors returned by [`DirectoryCanister`] operations.
+#[derive(Debug, Clone, thiserror::Error)]
+#[cfg(any(target_family = "wasm", test))]
+pub enum DirectoryCanisterClientError {
+    /// The inter-canister call failed.
+    #[error("inter-canister call failed: {0}")]
+    #[allow(dead_code, reason = "constructed only in wasm builds")]
+    CallFailed(String),
+    /// The response could not be decoded.
+    #[error("decode failed: {0}")]
+    #[allow(dead_code, reason = "constructed only in wasm builds")]
+    DecodeFailed(String),
+}
+
+/// Production implementation that delegates to `ic_cdk` calls.
+#[cfg(target_family = "wasm")]
+pub struct IcDirectoryCanisterClient {
+    canister_id: candid::Principal,
+}
+
+#[cfg(target_family = "wasm")]
+impl From<candid::Principal> for IcDirectoryCanisterClient {
+    fn from(canister_id: candid::Principal) -> Self {
+        Self { canister_id }
+    }
+}
+
+#[cfg(target_family = "wasm")]
+impl DirectoryCanister for IcDirectoryCanisterClient {
+    async fn resolve_handle(
+        &self,
+        principal: Principal,
+    ) -> Result<Option<String>, DirectoryCanisterClientError> {
+        use did::directory::{GetUserArgs, GetUserResponse};
+
+        ic_utils::log!(
+            "IcDirectoryCanisterClient::resolve_handle: resolving principal {principal}"
+        );
+
+        let args = GetUserArgs::Principal(principal);
+
+        let raw = ic_cdk::call::Call::bounded_wait(self.canister_id, "get_user")
+            .with_arg(args)
+            .await
+            .map_err(|e| {
+                ic_utils::log!(
+                    "DirectoryCanisterClientError::resolve_handle: call failed: {e:?}"
+                );
+                DirectoryCanisterClientError::CallFailed(format!("{e:?}"))
+            })?;
+
+        let response = candid::decode_one::<GetUserResponse>(&raw).map_err(|e| {
+            ic_utils::log!(
+                "DirectoryCanisterClientError::resolve_handle: decode failed: {e}"
+            );
+            DirectoryCanisterClientError::DecodeFailed(e.to_string())
+        })?;
+
+        match response {
+            GetUserResponse::Ok(user) => {
+                ic_utils::log!(
+                    "IcDirectoryCanisterClient::resolve_handle: resolved to {}",
+                    user.handle
+                );
+                Ok(Some(user.handle))
+            }
+            GetUserResponse::Err(did::directory::GetUserError::NotFound) => {
+                ic_utils::log!(
+                    "IcDirectoryCanisterClient::resolve_handle: principal not registered"
+                );
+                Ok(None)
+            }
+            GetUserResponse::Err(e) => {
+                ic_utils::log!(
+                    "IcDirectoryCanisterClient::resolve_handle: directory error: {e:?}"
+                );
+                Err(DirectoryCanisterClientError::CallFailed(format!("{e:?}")))
+            }
+        }
+    }
+}

--- a/crates/canisters/user/src/adapters/directory.rs
+++ b/crates/canisters/user/src/adapters/directory.rs
@@ -92,16 +92,12 @@ impl DirectoryCanister for IcDirectoryCanisterClient {
             .with_arg(args)
             .await
             .map_err(|e| {
-                ic_utils::log!(
-                    "DirectoryCanisterClientError::resolve_handle: call failed: {e:?}"
-                );
+                ic_utils::log!("DirectoryCanisterClientError::resolve_handle: call failed: {e:?}");
                 DirectoryCanisterClientError::CallFailed(format!("{e:?}"))
             })?;
 
         let response = candid::decode_one::<GetUserResponse>(&raw).map_err(|e| {
-            ic_utils::log!(
-                "DirectoryCanisterClientError::resolve_handle: decode failed: {e}"
-            );
+            ic_utils::log!("DirectoryCanisterClientError::resolve_handle: decode failed: {e}");
             DirectoryCanisterClientError::DecodeFailed(e.to_string())
         })?;
 
@@ -120,9 +116,7 @@ impl DirectoryCanister for IcDirectoryCanisterClient {
                 Ok(None)
             }
             GetUserResponse::Err(e) => {
-                ic_utils::log!(
-                    "IcDirectoryCanisterClient::resolve_handle: directory error: {e:?}"
-                );
+                ic_utils::log!("IcDirectoryCanisterClient::resolve_handle: directory error: {e:?}");
                 Err(DirectoryCanisterClientError::CallFailed(format!("{e:?}")))
             }
         }

--- a/crates/canisters/user/src/adapters/directory/mock.rs
+++ b/crates/canisters/user/src/adapters/directory/mock.rs
@@ -1,0 +1,15 @@
+use candid::Principal;
+
+use crate::adapters::directory::DirectoryCanister;
+
+#[derive(Debug)]
+pub struct DirectoryCanisterMockClient;
+
+impl DirectoryCanister for DirectoryCanisterMockClient {
+    async fn resolve_handle(
+        &self,
+        _principal: Principal,
+    ) -> Result<Option<String>, crate::adapters::directory::DirectoryCanisterClientError> {
+        Ok(Some("testuser".to_string()))
+    }
+}

--- a/crates/canisters/user/src/api.rs
+++ b/crates/canisters/user/src/api.rs
@@ -176,7 +176,7 @@ pub async fn reject_follow(args: RejectFollowArgs) -> RejectFollowResponse {
 mod tests {
 
     use super::*;
-    use crate::test_utils::{admin, federation, setup};
+    use crate::test_utils::{admin, directory, federation, setup};
 
     #[test]
     fn test_should_init_canister() {
@@ -211,7 +211,7 @@ mod tests {
         post_upgrade(UserInstallArgs::Init {
             owner: admin(),
             federation_canister: federation(),
-            directory_canister: federation(),
+            directory_canister: directory(),
             handle: "rey_canisteryo".to_string(),
             public_url: "https://mastic.social".to_string(),
         });

--- a/crates/canisters/user/src/api.rs
+++ b/crates/canisters/user/src/api.rs
@@ -5,9 +5,10 @@ pub mod inspect;
 use did::user::{
     AcceptFollowArgs, AcceptFollowResponse, FollowUserArgs, FollowUserResponse,
     GetFollowRequestsArgs, GetFollowRequestsResponse, GetFollowersArgs, GetFollowersResponse,
-    GetFollowingArgs, GetFollowingResponse, GetProfileResponse, PublishStatusArgs,
-    PublishStatusResponse, ReadFeedArgs, ReadFeedResponse, ReceiveActivityArgs,
-    ReceiveActivityResponse, RejectFollowArgs, RejectFollowResponse, UserInstallArgs,
+    GetFollowingArgs, GetFollowingResponse, GetProfileResponse, GetStatusesArgs,
+    GetStatusesResponse, PublishStatusArgs, PublishStatusResponse, ReadFeedArgs, ReadFeedResponse,
+    ReceiveActivityArgs, ReceiveActivityResponse, RejectFollowArgs, RejectFollowResponse,
+    UserInstallArgs,
 };
 use ic_dbms_canister::prelude::DBMS_CONTEXT;
 
@@ -18,6 +19,7 @@ pub fn init(args: UserInstallArgs) {
     let UserInstallArgs::Init {
         owner,
         federation_canister,
+        directory_canister,
         handle,
         public_url,
     } = args
@@ -43,6 +45,12 @@ pub fn init(args: UserInstallArgs) {
     ic_utils::log!("Setting federation canister to {federation_canister}");
     if let Err(err) = crate::settings::set_federation_canister(federation_canister) {
         ic_utils::trap!("Failed to set federation canister: {:?}", err);
+    }
+
+    // set directory canister
+    ic_utils::log!("Setting directory canister to {directory_canister}");
+    if let Err(err) = crate::settings::set_directory_canister(directory_canister) {
+        ic_utils::trap!("Failed to set directory canister: {:?}", err);
     }
 
     // set public url
@@ -115,6 +123,13 @@ pub fn get_following(args: GetFollowingArgs) -> GetFollowingResponse {
 /// Gets the user profile.
 pub fn get_profile() -> GetProfileResponse {
     crate::domain::profile::get_profile()
+}
+
+/// Gets a paginated list of the user's statuses.
+pub async fn get_statuses(args: GetStatusesArgs) -> GetStatusesResponse {
+    let caller = ic_utils::caller();
+
+    crate::domain::status::get_statuses(args, caller).await
 }
 
 /// Publishes a new status.
@@ -196,6 +211,7 @@ mod tests {
         post_upgrade(UserInstallArgs::Init {
             owner: admin(),
             federation_canister: federation(),
+            directory_canister: federation(),
             handle: "rey_canisteryo".to_string(),
             public_url: "https://mastic.social".to_string(),
         });

--- a/crates/canisters/user/src/domain/feed/read_feed.rs
+++ b/crates/canisters/user/src/domain/feed/read_feed.rs
@@ -45,7 +45,6 @@ pub fn read_feed(ReadFeedArgs { limit, offset }: ReadFeedArgs) -> ReadFeedRespon
 /// Sorting, offset and limit are fully handled at the database level,
 /// keeping memory usage bounded regardless of feed size.
 fn read_feed_inner(limit: u64, offset: u64) -> CanisterResult<Vec<FeedItem>> {
-    let owner = crate::settings::get_owner_principal()?;
     let own_profile = crate::domain::profile::ProfileRepository::get_profile()?;
     let owner_actor_uri = crate::domain::urls::actor_uri(&own_profile.handle.0)?;
 
@@ -77,7 +76,7 @@ fn read_feed_inner(limit: u64, offset: u64) -> CanisterResult<Vec<FeedItem>> {
             };
 
             let item = match source {
-                FeedSource::Outbox => hydrate_outbox(&db, id, owner),
+                FeedSource::Outbox => hydrate_outbox(&db, id, &owner_actor_uri),
                 FeedSource::Inbox => hydrate_inbox(&db, id, &owner_actor_uri),
             };
 
@@ -91,7 +90,7 @@ fn read_feed_inner(limit: u64, offset: u64) -> CanisterResult<Vec<FeedItem>> {
 }
 
 /// Loads a status from the `statuses` table and wraps it as a [`FeedItem`].
-fn hydrate_outbox(db: &impl Database, id: u64, owner: candid::Principal) -> Option<FeedItem> {
+fn hydrate_outbox(db: &impl Database, id: u64, owner_actor_uri: &str) -> Option<FeedItem> {
     let query = Query::builder()
         .all()
         .and_where(Filter::eq("id", Value::from(id)))
@@ -108,7 +107,7 @@ fn hydrate_outbox(db: &impl Database, id: u64, owner: candid::Principal) -> Opti
         status: Status {
             id,
             content,
-            author: owner,
+            author: owner_actor_uri.to_string(),
             created_at,
             visibility: db_vis.into(),
         },
@@ -141,13 +140,13 @@ fn hydrate_inbox(db: &impl Database, id: u64, owner_actor_uri: &str) -> Option<F
         return None;
     }
 
+    let author_uri = activity.actor.clone().unwrap_or_default();
+
     Some(FeedItem {
         status: Status {
             id,
             content,
-            // Remote authors do not have an IC principal; use anonymous as a
-            // placeholder until directory-based resolution is implemented.
-            author: candid::Principal::anonymous(),
+            author: author_uri,
             created_at,
             visibility,
         },
@@ -459,7 +458,7 @@ mod tests {
 
         assert_eq!(items.len(), 1);
         assert_eq!(items[0].status.content, "Remote status");
-        assert_eq!(items[0].status.author, candid::Principal::anonymous());
+        assert_eq!(items[0].status.author, "https://remote.example/users/bob");
     }
 
     #[test]
@@ -556,8 +555,10 @@ mod tests {
         }));
 
         assert_eq!(items.len(), 1);
-        let owner = crate::settings::get_owner_principal().expect("owner");
-        assert_eq!(items[0].status.author, owner);
+        assert_eq!(
+            items[0].status.author,
+            "https://mastic.social/users/rey_canisteryo"
+        );
     }
 
     #[test]

--- a/crates/canisters/user/src/domain/follower/repository.rs
+++ b/crates/canisters/user/src/domain/follower/repository.rs
@@ -39,6 +39,23 @@ impl FollowerRepository {
         })
     }
 
+    /// Checks if the given actor URI is a [`Follower`] of the user.
+    pub fn is_follower(actor_uri: &str) -> CanisterResult<bool> {
+        DBMS_CONTEXT.with(|ctx| {
+            let db = WasmDbmsDatabase::oneshot(ctx, Schema);
+
+            db.select::<Follower>(
+                Query::builder()
+                    .all()
+                    .and_where(Filter::eq("actor_uri", actor_uri.into()))
+                    .limit(1)
+                    .build(),
+            )
+            .map(|records| !records.is_empty())
+            .map_err(CanisterError::from)
+        })
+    }
+
     /// Get the list of [`Follower`]s of the user.
     pub fn get_paginated(offset: usize, limit: usize) -> CanisterResult<Vec<Follower>> {
         DBMS_CONTEXT.with(|ctx| {

--- a/crates/canisters/user/src/domain/status.rs
+++ b/crates/canisters/user/src/domain/status.rs
@@ -1,10 +1,12 @@
 //! Status domain
 
+mod get_statuses;
 mod publish;
 mod repository;
 
-pub use self::publish::publish_status;
-pub use self::repository::StatusRepository;
-
 /// Maximum allowed length for the status content.
 pub const MAX_STATUS_LENGTH: usize = 500;
+
+pub use self::get_statuses::get_statuses;
+pub use self::publish::publish_status;
+pub use self::repository::StatusRepository;

--- a/crates/canisters/user/src/domain/status/get_statuses.rs
+++ b/crates/canisters/user/src/domain/status/get_statuses.rs
@@ -1,0 +1,123 @@
+//! Get statuses flow logic.
+
+use candid::Principal;
+use did::common::{Status, Visibility};
+use did::user::{GetStatusesArgs, GetStatusesError, GetStatusesResponse};
+
+use crate::domain::follower::FollowerRepository;
+use crate::domain::status::StatusRepository;
+use crate::error::CanisterResult;
+
+enum CallerRelationship {
+    Owner,
+    Follower,
+    Other,
+}
+
+/// Gets a paginated list of the user's statuses.
+///
+/// Returned [`Status`]es are ordered from the most recent to the oldest.
+///
+/// Visibility is applied to the returned statuses:
+///
+/// - Owner: see all statuses.
+/// - Follower: see `Public`, `Unlisted`, and `FollowersOnly` statuses.
+/// - Anonymous/Other: see `Public` and `Unlisted` statuses.
+pub async fn get_statuses(args: GetStatusesArgs, caller: Principal) -> GetStatusesResponse {
+    ic_utils::log!("Getting statuses for caller: {caller}",);
+
+    if args.limit > crate::domain::MAX_PAGE_LIMIT {
+        return GetStatusesResponse::Err(GetStatusesError::LimitExceeded);
+    }
+
+    match get_statuses_inner(args, caller).await {
+        Ok(response) => response,
+        Err(err) => {
+            ic_utils::log!("Error getting statuses: {err}");
+            GetStatusesResponse::Err(GetStatusesError::Internal(err.to_string()))
+        }
+    }
+}
+
+/// Internal implementation of `get_statuses`, which returns a `CanisterResult` to properly handle errors.
+async fn get_statuses_inner(
+    GetStatusesArgs { limit, offset }: GetStatusesArgs,
+    caller: Principal,
+) -> CanisterResult<GetStatusesResponse> {
+    let relationship = determine_relationship(caller).await?;
+
+    // build owner actor URI
+    let own_profile = crate::domain::profile::ProfileRepository::get_profile()?;
+    let owner_actor_uri = crate::domain::urls::actor_uri(&own_profile.handle.0)?;
+
+    // query statuses
+    let visibility_filter = visibility_filter_for_relationship(relationship);
+    StatusRepository::get_paginated_by_visibility(
+        &visibility_filter,
+        offset as usize,
+        limit as usize,
+    )
+    .map(|statuses| {
+        statuses
+            .into_iter()
+            .map(|s| status_to_did(&owner_actor_uri, s))
+            .collect()
+    })
+    .map(GetStatusesResponse::Ok)
+}
+
+/// Determines the relationship of the caller with the user, which affects the visibility of statuses.
+async fn determine_relationship(caller: Principal) -> CanisterResult<CallerRelationship> {
+    // short-circuit if caller is anonymous
+    if caller == Principal::anonymous() {
+        ic_utils::log!("Caller is anonymous");
+        return Ok(CallerRelationship::Other);
+    }
+
+    // check if caller is the owner
+    if caller == crate::settings::get_owner_principal()? {
+        ic_utils::log!("Caller {caller} is the owner");
+        return Ok(CallerRelationship::Owner);
+    }
+
+    // resove handle
+    let handle: String = todo!();
+    ic_utils::log!("Resolved handle for caller {caller}: {handle}");
+    let actor_uri = crate::domain::urls::actor_uri(&handle)?;
+
+    if FollowerRepository::is_follower(&actor_uri)? {
+        ic_utils::log!("Caller {caller} is a follower");
+        return Ok(CallerRelationship::Follower);
+    }
+
+    ic_utils::log!("Caller {caller} is not a follower");
+    Ok(CallerRelationship::Other)
+}
+
+/// Returns the list of [`Visibility`]es that the caller is allowed to see based on their relationship with the user.
+fn visibility_filter_for_relationship(relationship: CallerRelationship) -> Vec<Visibility> {
+    match relationship {
+        CallerRelationship::Owner => vec![
+            Visibility::Public,
+            Visibility::Unlisted,
+            Visibility::FollowersOnly,
+            Visibility::Direct,
+        ],
+        CallerRelationship::Follower => vec![
+            Visibility::Public,
+            Visibility::Unlisted,
+            Visibility::FollowersOnly,
+        ],
+        CallerRelationship::Other => vec![Visibility::Public, Visibility::Unlisted],
+    }
+}
+
+fn status_to_did(owner_actor_uri: &str, status: crate::schema::Status) -> Status {
+    Status {
+        id: status.id.0,
+        content: status.content.0,
+        visibility: status.visibility.into(),
+        created_at: status.created_at.0,
+        author: owner_actor_uri.to_string(),
+    }
+}

--- a/crates/canisters/user/src/domain/status/get_statuses.rs
+++ b/crates/canisters/user/src/domain/status/get_statuses.rs
@@ -128,3 +128,283 @@ fn status_to_did(owner_actor_uri: &str, status: crate::schema::Status) -> Status
         author: owner_actor_uri.to_string(),
     }
 }
+
+#[cfg(test)]
+mod tests {
+
+    use did::common::Visibility;
+    use did::user::{GetStatusesArgs, GetStatusesError, GetStatusesResponse};
+    use ic_dbms_canister::prelude::DBMS_CONTEXT;
+    use wasm_dbms::WasmDbmsDatabase;
+    use wasm_dbms_api::prelude::Database;
+
+    use super::get_statuses;
+    use crate::schema::{
+        Follower, FollowerInsertRequest, Schema, Status, StatusInsertRequest,
+        Visibility as DbVisibility,
+    };
+    use crate::test_utils::{admin, alice, setup};
+
+    fn insert_status(id: u64, content: &str, visibility: Visibility, created_at: u64) {
+        DBMS_CONTEXT.with(|ctx| {
+            let db = WasmDbmsDatabase::oneshot(ctx, Schema);
+            db.insert::<Status>(StatusInsertRequest {
+                id: id.into(),
+                content: content.into(),
+                visibility: DbVisibility::from(visibility),
+                created_at: created_at.into(),
+            })
+            .expect("should insert status");
+        });
+    }
+
+    fn insert_follower(actor_uri: &str) {
+        DBMS_CONTEXT.with(|ctx| {
+            let db = WasmDbmsDatabase::oneshot(ctx, Schema);
+            db.insert::<Follower>(FollowerInsertRequest {
+                actor_uri: actor_uri.into(),
+                created_at: ic_utils::now().into(),
+            })
+            .expect("should insert follower");
+        });
+    }
+
+    fn unwrap_ok(response: GetStatusesResponse) -> Vec<did::common::Status> {
+        let GetStatusesResponse::Ok(items) = response else {
+            panic!("expected Ok, got {response:?}");
+        };
+        items
+    }
+
+    #[tokio::test]
+    async fn test_should_return_empty_when_no_statuses() {
+        setup();
+
+        let items = unwrap_ok(
+            get_statuses(
+                GetStatusesArgs {
+                    limit: 10,
+                    offset: 0,
+                },
+                admin(),
+            )
+            .await,
+        );
+
+        assert!(items.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_should_return_limit_exceeded() {
+        setup();
+
+        let response = get_statuses(
+            GetStatusesArgs {
+                limit: crate::domain::MAX_PAGE_LIMIT + 1,
+                offset: 0,
+            },
+            admin(),
+        )
+        .await;
+
+        assert_eq!(
+            response,
+            GetStatusesResponse::Err(GetStatusesError::LimitExceeded)
+        );
+    }
+
+    #[tokio::test]
+    async fn test_should_return_statuses_ordered_by_created_at_desc() {
+        setup();
+        insert_status(1, "First", Visibility::Public, 1000);
+        insert_status(2, "Second", Visibility::Public, 2000);
+        insert_status(3, "Third", Visibility::Public, 3000);
+
+        let items = unwrap_ok(
+            get_statuses(
+                GetStatusesArgs {
+                    limit: 10,
+                    offset: 0,
+                },
+                admin(),
+            )
+            .await,
+        );
+
+        assert_eq!(items.len(), 3);
+        assert_eq!(items[0].content, "Third");
+        assert_eq!(items[1].content, "Second");
+        assert_eq!(items[2].content, "First");
+    }
+
+    #[tokio::test]
+    async fn test_should_paginate_with_offset_and_limit() {
+        setup();
+        for i in 1..=5 {
+            insert_status(i, &format!("Status {i}"), Visibility::Public, i * 1000);
+        }
+
+        // skip 1, take 2 → should get statuses 4 and 3 (newest-first)
+        let items = unwrap_ok(
+            get_statuses(
+                GetStatusesArgs {
+                    limit: 2,
+                    offset: 1,
+                },
+                admin(),
+            )
+            .await,
+        );
+
+        assert_eq!(items.len(), 2);
+        assert_eq!(items[0].content, "Status 4");
+        assert_eq!(items[1].content, "Status 3");
+    }
+
+    #[tokio::test]
+    async fn test_owner_should_see_all_visibilities() {
+        setup();
+        insert_status(1, "Public", Visibility::Public, 1000);
+        insert_status(2, "Unlisted", Visibility::Unlisted, 2000);
+        insert_status(3, "FollowersOnly", Visibility::FollowersOnly, 3000);
+        insert_status(4, "Direct", Visibility::Direct, 4000);
+
+        let items = unwrap_ok(
+            get_statuses(
+                GetStatusesArgs {
+                    limit: 10,
+                    offset: 0,
+                },
+                admin(),
+            )
+            .await,
+        );
+
+        assert_eq!(items.len(), 4);
+    }
+
+    #[tokio::test]
+    async fn test_follower_should_see_public_unlisted_followers_only() {
+        setup();
+        // The mock directory adapter returns "testuser" for any non-owner, non-anonymous caller.
+        // Insert a follower with that actor URI.
+        insert_follower("https://mastic.social/users/testuser");
+
+        insert_status(1, "Public", Visibility::Public, 1000);
+        insert_status(2, "Unlisted", Visibility::Unlisted, 2000);
+        insert_status(3, "FollowersOnly", Visibility::FollowersOnly, 3000);
+        insert_status(4, "Direct", Visibility::Direct, 4000);
+
+        let items = unwrap_ok(
+            get_statuses(
+                GetStatusesArgs {
+                    limit: 10,
+                    offset: 0,
+                },
+                alice(),
+            )
+            .await,
+        );
+
+        assert_eq!(items.len(), 3);
+        let visibilities: Vec<_> = items.iter().map(|s| s.visibility).collect();
+        assert!(visibilities.contains(&Visibility::Public));
+        assert!(visibilities.contains(&Visibility::Unlisted));
+        assert!(visibilities.contains(&Visibility::FollowersOnly));
+        assert!(!visibilities.contains(&Visibility::Direct));
+    }
+
+    #[tokio::test]
+    async fn test_anonymous_should_see_only_public_and_unlisted() {
+        setup();
+        insert_status(1, "Public", Visibility::Public, 1000);
+        insert_status(2, "Unlisted", Visibility::Unlisted, 2000);
+        insert_status(3, "FollowersOnly", Visibility::FollowersOnly, 3000);
+        insert_status(4, "Direct", Visibility::Direct, 4000);
+
+        let items = unwrap_ok(
+            get_statuses(
+                GetStatusesArgs {
+                    limit: 10,
+                    offset: 0,
+                },
+                candid::Principal::anonymous(),
+            )
+            .await,
+        );
+
+        assert_eq!(items.len(), 2);
+        let visibilities: Vec<_> = items.iter().map(|s| s.visibility).collect();
+        assert!(visibilities.contains(&Visibility::Public));
+        assert!(visibilities.contains(&Visibility::Unlisted));
+    }
+
+    #[tokio::test]
+    async fn test_non_follower_should_see_only_public_and_unlisted() {
+        setup();
+        // alice resolves to "testuser" via mock but is NOT in the followers table
+
+        insert_status(1, "Public", Visibility::Public, 1000);
+        insert_status(2, "Unlisted", Visibility::Unlisted, 2000);
+        insert_status(3, "FollowersOnly", Visibility::FollowersOnly, 3000);
+        insert_status(4, "Direct", Visibility::Direct, 4000);
+
+        let items = unwrap_ok(
+            get_statuses(
+                GetStatusesArgs {
+                    limit: 10,
+                    offset: 0,
+                },
+                alice(),
+            )
+            .await,
+        );
+
+        assert_eq!(items.len(), 2);
+        let visibilities: Vec<_> = items.iter().map(|s| s.visibility).collect();
+        assert!(visibilities.contains(&Visibility::Public));
+        assert!(visibilities.contains(&Visibility::Unlisted));
+    }
+
+    #[tokio::test]
+    async fn test_should_set_author_to_owner_actor_uri() {
+        setup();
+        insert_status(1, "Hello", Visibility::Public, 1000);
+
+        let items = unwrap_ok(
+            get_statuses(
+                GetStatusesArgs {
+                    limit: 10,
+                    offset: 0,
+                },
+                admin(),
+            )
+            .await,
+        );
+
+        assert_eq!(items.len(), 1);
+        assert_eq!(
+            items[0].author,
+            "https://mastic.social/users/rey_canisteryo"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_should_return_empty_page_beyond_data() {
+        setup();
+        insert_status(1, "Only status", Visibility::Public, 1000);
+
+        let items = unwrap_ok(
+            get_statuses(
+                GetStatusesArgs {
+                    limit: 10,
+                    offset: 100,
+                },
+                admin(),
+            )
+            .await,
+        );
+
+        assert!(items.is_empty());
+    }
+}

--- a/crates/canisters/user/src/domain/status/get_statuses.rs
+++ b/crates/canisters/user/src/domain/status/get_statuses.rs
@@ -139,24 +139,8 @@ mod tests {
     use wasm_dbms_api::prelude::Database;
 
     use super::get_statuses;
-    use crate::schema::{
-        Follower, FollowerInsertRequest, Schema, Status, StatusInsertRequest,
-        Visibility as DbVisibility,
-    };
-    use crate::test_utils::{admin, alice, setup};
-
-    fn insert_status(id: u64, content: &str, visibility: Visibility, created_at: u64) {
-        DBMS_CONTEXT.with(|ctx| {
-            let db = WasmDbmsDatabase::oneshot(ctx, Schema);
-            db.insert::<Status>(StatusInsertRequest {
-                id: id.into(),
-                content: content.into(),
-                visibility: DbVisibility::from(visibility),
-                created_at: created_at.into(),
-            })
-            .expect("should insert status");
-        });
-    }
+    use crate::schema::{Follower, FollowerInsertRequest, Schema};
+    use crate::test_utils::{admin, alice, insert_status, setup};
 
     fn insert_follower(actor_uri: &str) {
         DBMS_CONTEXT.with(|ctx| {

--- a/crates/canisters/user/src/domain/status/get_statuses.rs
+++ b/crates/canisters/user/src/domain/status/get_statuses.rs
@@ -80,9 +80,16 @@ async fn determine_relationship(caller: Principal) -> CanisterResult<CallerRelat
         return Ok(CallerRelationship::Owner);
     }
 
-    // resove handle
-    let handle: String = todo!();
+    // resolve handle via directory
+    let handle = match crate::adapters::directory::resolve_handle(caller).await? {
+        Some(handle) => handle,
+        None => {
+            ic_utils::log!("Caller {caller} is not registered in the directory");
+            return Ok(CallerRelationship::Other);
+        }
+    };
     ic_utils::log!("Resolved handle for caller {caller}: {handle}");
+
     let actor_uri = crate::domain::urls::actor_uri(&handle)?;
 
     if FollowerRepository::is_follower(&actor_uri)? {

--- a/crates/canisters/user/src/domain/status/publish.rs
+++ b/crates/canisters/user/src/domain/status/publish.rs
@@ -64,11 +64,15 @@ async fn save_status_and_publish_to_federation(
     let snowflake_id = StatusRepository::create(content.clone(), visibility, created_at)?;
     ic_utils::log!("Status created with ID: {snowflake_id}");
 
+    // build owner actor URI
+    let own_profile = crate::domain::profile::ProfileRepository::get_profile()?;
+    let owner_actor_uri = crate::domain::urls::actor_uri(&own_profile.handle.0)?;
+
     // make status object
     let status = Status {
         id: snowflake_id.into(),
         content,
-        author: ic_utils::caller(),
+        author: owner_actor_uri,
         created_at,
         visibility,
     };
@@ -95,7 +99,7 @@ async fn save_status_and_publish_to_federation(
 /// The `target_inbox` is derived by appending `/inbox` to the follower's
 /// actor URI, following the standard ActivityPub convention.
 fn make_follower_activity(follower: &Follower, status: &Status) -> SendActivityArgsObject {
-    let actor = status.author.to_text();
+    let actor = status.author.clone();
     let (to, cc) = visibility_addressing(&status.visibility);
 
     let note = BaseObject {
@@ -201,7 +205,7 @@ mod tests {
         };
         assert_eq!(status.content, "Hello, Fediverse!");
         assert_eq!(status.visibility, Visibility::Public);
-        assert_eq!(status.author, ic_utils::caller());
+        assert_eq!(status.author, "https://mastic.social/users/rey_canisteryo");
         assert!(status.id > 0);
         assert_eq!(count_statuses(), 1);
     }
@@ -415,7 +419,7 @@ mod tests {
         let status = Status {
             id: 42,
             content: "Hello!".to_string(),
-            author: ic_utils::caller(),
+            author: "https://mastic.social/users/rey_canisteryo".to_string(),
             created_at: 1_000_000,
             visibility: Visibility::Public,
         };
@@ -429,7 +433,7 @@ mod tests {
         assert_eq!(activity.base.kind, ActivityType::Create);
         assert_eq!(
             activity.actor.as_deref(),
-            Some(ic_utils::caller().to_text().as_str())
+            Some("https://mastic.social/users/rey_canisteryo")
         );
 
         let ActivityObject::Object(note) = activity.object.expect("should have object") else {
@@ -449,7 +453,7 @@ mod tests {
         let status = Status {
             id: 1,
             content: "Public post".to_string(),
-            author: ic_utils::caller(),
+            author: "https://mastic.social/users/rey_canisteryo".to_string(),
             created_at: 0,
             visibility: Visibility::Public,
         };
@@ -474,7 +478,7 @@ mod tests {
         let status = Status {
             id: 1,
             content: "Unlisted post".to_string(),
-            author: ic_utils::caller(),
+            author: "https://mastic.social/users/rey_canisteryo".to_string(),
             created_at: 0,
             visibility: Visibility::Unlisted,
         };
@@ -499,7 +503,7 @@ mod tests {
         let status = Status {
             id: 1,
             content: "Followers only post".to_string(),
-            author: ic_utils::caller(),
+            author: "https://mastic.social/users/rey_canisteryo".to_string(),
             created_at: 0,
             visibility: Visibility::FollowersOnly,
         };
@@ -521,7 +525,7 @@ mod tests {
         let status = Status {
             id: 1,
             content: "Direct post".to_string(),
-            author: ic_utils::caller(),
+            author: "https://mastic.social/users/rey_canisteryo".to_string(),
             created_at: 0,
             visibility: Visibility::Direct,
         };

--- a/crates/canisters/user/src/domain/status/repository.rs
+++ b/crates/canisters/user/src/domain/status/repository.rs
@@ -9,6 +9,7 @@ use crate::domain::snowflake::Snowflake;
 use crate::error::CanisterResult;
 use crate::schema::{
     FeedEntry, FeedEntryInsertRequest, FeedSource, Schema, Status, StatusInsertRequest,
+    StatusRecord,
 };
 
 /// Interface for the [`Status`] repository.
@@ -52,5 +53,36 @@ impl StatusRepository {
         })?;
 
         Ok(snowflake_id)
+    }
+
+    /// Get a paginated list of [`Status`]es with the given visibility, ordered from the most recent to the oldest.
+    ///
+    /// This function is used to implement the `get_statuses` API, and the returned statuses are filtered based on the relationship of the caller with the user (owner, follower, or other).
+    pub fn get_paginated_by_visibility(
+        visibility: &[Visibility],
+        offset: usize,
+        limit: usize,
+    ) -> CanisterResult<Vec<Status>> {
+        DBMS_CONTEXT.with(|ctx| {
+            let db = WasmDbmsDatabase::oneshot(ctx, Schema);
+
+            let mut query = Query::builder().all().limit(limit).offset(offset);
+            for v in visibility {
+                let visibility = crate::schema::Visibility::from(*v);
+                query = query.and_where(Filter::eq("visibility", visibility.into()));
+            }
+
+            let results = db.select::<Status>(query.build())?;
+            Ok(results.into_iter().map(Self::record_to_status).collect())
+        })
+    }
+
+    fn record_to_status(record: StatusRecord) -> Status {
+        Status {
+            id: record.id.expect("must have field"),
+            content: record.content.expect("must have field"),
+            visibility: record.visibility.expect("must have field"),
+            created_at: record.created_at.expect("must have field"),
+        }
     }
 }

--- a/crates/canisters/user/src/domain/status/repository.rs
+++ b/crates/canisters/user/src/domain/status/repository.rs
@@ -66,10 +66,14 @@ impl StatusRepository {
         DBMS_CONTEXT.with(|ctx| {
             let db = WasmDbmsDatabase::oneshot(ctx, Schema);
 
-            let mut query = Query::builder().all().limit(limit).offset(offset);
+            let mut query = Query::builder()
+                .all()
+                .limit(limit)
+                .offset(offset)
+                .order_by_desc("created_at");
             for v in visibility {
                 let visibility = crate::schema::Visibility::from(*v);
-                query = query.and_where(Filter::eq("visibility", visibility.into()));
+                query = query.or_where(Filter::eq("visibility", visibility.into()));
             }
 
             let results = db.select::<Status>(query.build())?;
@@ -84,5 +88,166 @@ impl StatusRepository {
             visibility: record.visibility.expect("must have field"),
             created_at: record.created_at.expect("must have field"),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    use did::common::Visibility;
+    use ic_dbms_canister::prelude::DBMS_CONTEXT;
+    use wasm_dbms::WasmDbmsDatabase;
+    use wasm_dbms_api::prelude::Database;
+
+    use super::StatusRepository;
+    use crate::schema::{Schema, Status, StatusInsertRequest, Visibility as DbVisibility};
+    use crate::test_utils::setup;
+
+    fn insert_status(id: u64, content: &str, visibility: Visibility, created_at: u64) {
+        DBMS_CONTEXT.with(|ctx| {
+            let db = WasmDbmsDatabase::oneshot(ctx, Schema);
+            db.insert::<Status>(StatusInsertRequest {
+                id: id.into(),
+                content: content.into(),
+                visibility: DbVisibility::from(visibility),
+                created_at: created_at.into(),
+            })
+            .expect("should insert status");
+        });
+    }
+
+    #[test]
+    fn test_should_return_empty_when_no_statuses() {
+        setup();
+
+        let result = StatusRepository::get_paginated_by_visibility(&[Visibility::Public], 0, 10)
+            .expect("should query");
+
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn test_should_return_statuses_ordered_by_created_at_desc() {
+        setup();
+        insert_status(1, "Old", Visibility::Public, 1000);
+        insert_status(2, "Mid", Visibility::Public, 2000);
+        insert_status(3, "New", Visibility::Public, 3000);
+
+        let result = StatusRepository::get_paginated_by_visibility(&[Visibility::Public], 0, 10)
+            .expect("should query");
+
+        assert_eq!(result.len(), 3);
+        assert_eq!(result[0].created_at.0, 3000);
+        assert_eq!(result[1].created_at.0, 2000);
+        assert_eq!(result[2].created_at.0, 1000);
+    }
+
+    #[test]
+    fn test_should_paginate_with_offset_and_limit() {
+        setup();
+        for i in 1..=5 {
+            insert_status(i, &format!("Status {i}"), Visibility::Public, i * 1000);
+        }
+
+        // skip 1, take 2 → newest-first: 5,4,3,2,1 → skip 1 → 4,3
+        let result = StatusRepository::get_paginated_by_visibility(&[Visibility::Public], 1, 2)
+            .expect("should query");
+
+        assert_eq!(result.len(), 2);
+        assert_eq!(result[0].created_at.0, 4000);
+        assert_eq!(result[1].created_at.0, 3000);
+    }
+
+    #[test]
+    fn test_should_filter_by_single_visibility() {
+        setup();
+        insert_status(1, "Public", Visibility::Public, 1000);
+        insert_status(2, "Unlisted", Visibility::Unlisted, 2000);
+        insert_status(3, "FollowersOnly", Visibility::FollowersOnly, 3000);
+        insert_status(4, "Direct", Visibility::Direct, 4000);
+
+        let result = StatusRepository::get_paginated_by_visibility(&[Visibility::Public], 0, 10)
+            .expect("should query");
+
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].content.0, "Public");
+    }
+
+    #[test]
+    fn test_should_filter_by_multiple_visibilities() {
+        setup();
+        insert_status(1, "Public", Visibility::Public, 1000);
+        insert_status(2, "Unlisted", Visibility::Unlisted, 2000);
+        insert_status(3, "FollowersOnly", Visibility::FollowersOnly, 3000);
+        insert_status(4, "Direct", Visibility::Direct, 4000);
+
+        let result = StatusRepository::get_paginated_by_visibility(
+            &[
+                Visibility::Public,
+                Visibility::Unlisted,
+                Visibility::FollowersOnly,
+            ],
+            0,
+            10,
+        )
+        .expect("should query");
+
+        assert_eq!(result.len(), 3);
+        // ordered newest-first
+        assert_eq!(result[0].content.0, "FollowersOnly");
+        assert_eq!(result[1].content.0, "Unlisted");
+        assert_eq!(result[2].content.0, "Public");
+    }
+
+    #[test]
+    fn test_should_filter_all_visibilities() {
+        setup();
+        insert_status(1, "Public", Visibility::Public, 1000);
+        insert_status(2, "Unlisted", Visibility::Unlisted, 2000);
+        insert_status(3, "FollowersOnly", Visibility::FollowersOnly, 3000);
+        insert_status(4, "Direct", Visibility::Direct, 4000);
+
+        let result = StatusRepository::get_paginated_by_visibility(
+            &[
+                Visibility::Public,
+                Visibility::Unlisted,
+                Visibility::FollowersOnly,
+                Visibility::Direct,
+            ],
+            0,
+            10,
+        )
+        .expect("should query");
+
+        assert_eq!(result.len(), 4);
+    }
+
+    #[test]
+    fn test_should_return_empty_page_beyond_data() {
+        setup();
+        insert_status(1, "Only one", Visibility::Public, 1000);
+
+        let result = StatusRepository::get_paginated_by_visibility(&[Visibility::Public], 100, 10)
+            .expect("should query");
+
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn test_create_should_insert_status_and_feed_entry() {
+        setup();
+
+        let snowflake =
+            StatusRepository::create("Hello world".to_string(), Visibility::Public, 42_000)
+                .expect("should create");
+
+        // verify the status was inserted
+        let statuses = StatusRepository::get_paginated_by_visibility(&[Visibility::Public], 0, 10)
+            .expect("should query");
+
+        assert_eq!(statuses.len(), 1);
+        assert_eq!(statuses[0].id, snowflake.into());
+        assert_eq!(statuses[0].content.0, "Hello world");
+        assert_eq!(statuses[0].created_at.0, 42_000);
     }
 }

--- a/crates/canisters/user/src/domain/status/repository.rs
+++ b/crates/canisters/user/src/domain/status/repository.rs
@@ -95,26 +95,9 @@ impl StatusRepository {
 mod tests {
 
     use did::common::Visibility;
-    use ic_dbms_canister::prelude::DBMS_CONTEXT;
-    use wasm_dbms::WasmDbmsDatabase;
-    use wasm_dbms_api::prelude::Database;
 
     use super::StatusRepository;
-    use crate::schema::{Schema, Status, StatusInsertRequest, Visibility as DbVisibility};
-    use crate::test_utils::setup;
-
-    fn insert_status(id: u64, content: &str, visibility: Visibility, created_at: u64) {
-        DBMS_CONTEXT.with(|ctx| {
-            let db = WasmDbmsDatabase::oneshot(ctx, Schema);
-            db.insert::<Status>(StatusInsertRequest {
-                id: id.into(),
-                content: content.into(),
-                visibility: DbVisibility::from(visibility),
-                created_at: created_at.into(),
-            })
-            .expect("should insert status");
-        });
-    }
+    use crate::test_utils::{insert_status, setup};
 
     #[test]
     fn test_should_return_empty_when_no_statuses() {

--- a/crates/canisters/user/src/error.rs
+++ b/crates/canisters/user/src/error.rs
@@ -7,6 +7,10 @@ pub enum CanisterError {
     /// Database error
     #[error("Database error: {0}")]
     Database(#[from] wasm_dbms_api::prelude::DbmsError),
+    /// Directory error
+    #[error("Directory call failed: {0}")]
+    #[cfg(any(target_family = "wasm", test))]
+    Directory(#[from] crate::adapters::directory::DirectoryCanisterClientError),
     /// Federation error
     #[error("Federation call failed: {0}")]
     #[cfg(any(target_family = "wasm", test))]

--- a/crates/canisters/user/src/lib.rs
+++ b/crates/canisters/user/src/lib.rs
@@ -62,7 +62,7 @@ fn get_profile() -> GetProfileResponse {
     api::get_profile()
 }
 
-#[ic_cdk::query]
+#[ic_cdk::query(composite = true)]
 async fn get_statuses(args: GetStatusesArgs) -> GetStatusesResponse {
     api::get_statuses(args).await
 }

--- a/crates/canisters/user/src/lib.rs
+++ b/crates/canisters/user/src/lib.rs
@@ -11,9 +11,10 @@ mod test_utils;
 use did::user::{
     AcceptFollowArgs, AcceptFollowResponse, FollowUserArgs, FollowUserResponse,
     GetFollowRequestsArgs, GetFollowRequestsResponse, GetFollowersArgs, GetFollowersResponse,
-    GetFollowingArgs, GetFollowingResponse, GetProfileResponse, PublishStatusArgs,
-    PublishStatusResponse, ReadFeedArgs, ReadFeedResponse, ReceiveActivityArgs,
-    ReceiveActivityResponse, RejectFollowArgs, RejectFollowResponse, UserInstallArgs,
+    GetFollowingArgs, GetFollowingResponse, GetProfileResponse, GetStatusesArgs,
+    GetStatusesResponse, PublishStatusArgs, PublishStatusResponse, ReadFeedArgs, ReadFeedResponse,
+    ReceiveActivityArgs, ReceiveActivityResponse, RejectFollowArgs, RejectFollowResponse,
+    UserInstallArgs,
 };
 
 #[ic_cdk::init]
@@ -59,6 +60,11 @@ fn get_following(args: GetFollowingArgs) -> GetFollowingResponse {
 #[ic_cdk::query]
 fn get_profile() -> GetProfileResponse {
     api::get_profile()
+}
+
+#[ic_cdk::query]
+async fn get_statuses(args: GetStatusesArgs) -> GetStatusesResponse {
+    api::get_statuses(args).await
 }
 
 #[ic_cdk::update]

--- a/crates/canisters/user/src/settings.rs
+++ b/crates/canisters/user/src/settings.rs
@@ -13,6 +13,8 @@ const SETTING_FEDERATION_CANISTER: u16 = 0;
 const SETTING_OWNER_PRINCIPAL: u16 = 1;
 /// Setting key for the public URL.
 const SETTING_PUBLIC_URL: u16 = 2;
+/// Setting key for the directory canister principal.
+const SETTING_DIRECTORY_CANISTER: u16 = 3;
 
 /// Gets the principal of the federation canister.
 pub fn get_federation_canister() -> CanisterResult<Principal> {
@@ -70,6 +72,34 @@ pub fn set_owner_principal(principal: Principal) -> CanisterResult<()> {
         .map_err(CanisterError::from)
 }
 
+/// Gets the principal of the directory canister.
+pub fn get_directory_canister() -> CanisterResult<Principal> {
+    DBMS_CONTEXT
+        .with(|ctx| {
+            Settings::get_required_settings_value(
+                ctx,
+                Schema,
+                SETTING_DIRECTORY_CANISTER,
+                Settings::get_as_principal,
+            )
+        })
+        .map_err(CanisterError::from)
+}
+
+/// Sets the principal of the directory canister.
+pub fn set_directory_canister(principal: Principal) -> CanisterResult<()> {
+    DBMS_CONTEXT
+        .with(|ctx| {
+            Settings::set_config_key(
+                ctx,
+                Schema,
+                SETTING_DIRECTORY_CANISTER,
+                principal.as_slice().to_vec().as_slice(),
+            )
+        })
+        .map_err(CanisterError::from)
+}
+
 /// Gets the public URL of the Mastic instance.
 pub fn get_public_url() -> CanisterResult<String> {
     DBMS_CONTEXT
@@ -110,6 +140,20 @@ mod tests {
         assert_eq!(
             get_federation_canister().expect("should read federation canister after overwrite"),
             new_federation
+        );
+    }
+
+    #[test]
+    fn test_should_overwrite_directory_canister_setting() {
+        setup();
+
+        let new_directory =
+            Principal::from_text("b77ix-eeaaa-aaaaa-qaada-cai").expect("valid principal");
+        set_directory_canister(new_directory).expect("should set directory canister");
+
+        assert_eq!(
+            get_directory_canister().expect("should read directory canister after overwrite"),
+            new_directory
         );
     }
 

--- a/crates/canisters/user/src/settings.rs
+++ b/crates/canisters/user/src/settings.rs
@@ -73,6 +73,10 @@ pub fn set_owner_principal(principal: Principal) -> CanisterResult<()> {
 }
 
 /// Gets the principal of the directory canister.
+#[cfg_attr(
+    not(any(target_family = "wasm", test)),
+    expect(dead_code, reason = "called only from wasm adapter")
+)]
 pub fn get_directory_canister() -> CanisterResult<Principal> {
     DBMS_CONTEXT
         .with(|ctx| {

--- a/crates/canisters/user/src/test_utils.rs
+++ b/crates/canisters/user/src/test_utils.rs
@@ -32,3 +32,22 @@ pub fn setup() {
         public_url: "https://mastic.social".to_string(),
     });
 }
+
+pub fn insert_status(id: u64, content: &str, visibility: did::common::Visibility, created_at: u64) {
+    use ic_dbms_canister::prelude::DBMS_CONTEXT;
+    use wasm_dbms::WasmDbmsDatabase;
+    use wasm_dbms_api::prelude::Database;
+
+    use crate::schema::{Schema, Status, StatusInsertRequest, Visibility as DbVisibility};
+
+    DBMS_CONTEXT.with(|ctx| {
+        let db = WasmDbmsDatabase::oneshot(ctx, Schema);
+        db.insert::<Status>(StatusInsertRequest {
+            id: id.into(),
+            content: content.into(),
+            visibility: DbVisibility::from(visibility),
+            created_at: created_at.into(),
+        })
+        .expect("should insert status");
+    });
+}

--- a/crates/canisters/user/src/test_utils.rs
+++ b/crates/canisters/user/src/test_utils.rs
@@ -19,10 +19,15 @@ pub fn bob() -> Principal {
     Principal::from_text("br5f7-7uaaa-aaaaa-qaaca-cai").unwrap()
 }
 
+pub fn directory() -> Principal {
+    Principal::from_text("bw4dl-smaaa-aaaaa-qaacq-cai").unwrap()
+}
+
 pub fn setup() {
     crate::api::init(UserInstallArgs::Init {
         owner: admin(),
         federation_canister: federation(),
+        directory_canister: directory(),
         handle: "rey_canisteryo".to_string(),
         public_url: "https://mastic.social".to_string(),
     });

--- a/crates/libs/did/src/common.rs
+++ b/crates/libs/did/src/common.rs
@@ -47,8 +47,8 @@ pub struct Status {
     pub id: u64,
     /// The text content of the status.
     pub content: String,
-    /// The principal of the User Canister that authored this status.
-    pub author: candid::Principal,
+    /// The actor URI of the status author (e.g. `https://mastic.social/users/alice`).
+    pub author: String,
     /// Timestamp (milliseconds since epoch) of when the status was created.
     pub created_at: u64,
     /// The visibility setting of the status, controlling its audience.
@@ -61,10 +61,10 @@ pub struct Status {
 pub struct FeedItem {
     /// The status associated with this feed item.
     pub status: Status,
-    /// If this feed item was boosted (reblogged) by another user, the principal
-    /// of the User Canister that performed the boost. Otherwise [`None`].
+    /// If this feed item was boosted (reblogged) by another user, the actor URI
+    /// of the user that performed the boost. Otherwise [`None`].
     ///
     /// It works like this: if Alice creates a status, and Bob boosts it,
-    /// then a new Feed Item is created with `boosted_by` set to Bob's principal.
-    pub boosted_by: Option<candid::Principal>,
+    /// then a new Feed Item is created with `boosted_by` set to Bob's actor URI.
+    pub boosted_by: Option<String>,
 }

--- a/crates/libs/did/src/common/tests.rs
+++ b/crates/libs/did/src/common/tests.rs
@@ -51,7 +51,7 @@ fn test_should_roundtrip_status() {
     let status = Status {
         id: 4,
         content: "Hello, world!".to_string(),
-        author: candid::Principal::anonymous(),
+        author: "https://mastic.social/users/alice".to_string(),
         created_at: 1_000_000_000,
         visibility: Visibility::Public,
     };
@@ -66,11 +66,11 @@ fn test_should_roundtrip_feed_item() {
         status: Status {
             id: 4,
             content: "A post".to_string(),
-            author: candid::Principal::anonymous(),
+            author: "https://mastic.social/users/alice".to_string(),
             created_at: 42,
             visibility: Visibility::FollowersOnly,
         },
-        boosted_by: Some(candid::Principal::anonymous()),
+        boosted_by: Some("https://mastic.social/users/bob".to_string()),
     };
     let bytes = Encode!(&item).unwrap();
     let decoded = Decode!(&bytes, FeedItem).unwrap();
@@ -83,7 +83,7 @@ fn test_should_roundtrip_feed_item_without_boost() {
         status: Status {
             id: 4,
             content: "A post".to_string(),
-            author: candid::Principal::anonymous(),
+            author: "https://mastic.social/users/alice".to_string(),
             created_at: 42,
             visibility: Visibility::Unlisted,
         },

--- a/crates/libs/did/src/directory.rs
+++ b/crates/libs/did/src/directory.rs
@@ -136,10 +136,13 @@ pub enum UserCanisterResponse {
 }
 
 /// Request arguments for the `get_user` method.
+/// Look up a user by either their handle or their IC principal.
 #[derive(Debug, Clone, PartialEq, Eq, CandidType, Serialize, Deserialize)]
-pub struct GetUserArgs {
-    /// The handle to look up.
-    pub handle: String,
+pub enum GetUserArgs {
+    /// Look up a user by their handle.
+    Handle(String),
+    /// Look up a user by their IC principal.
+    Principal(candid::Principal),
 }
 
 /// Data returned by the `get_user` method on success.

--- a/crates/libs/did/src/directory/tests.rs
+++ b/crates/libs/did/src/directory/tests.rs
@@ -91,10 +91,16 @@ fn test_should_roundtrip_user_canister_response_err() {
 }
 
 #[test]
-fn test_should_roundtrip_get_user_args() {
-    let args = GetUserArgs {
-        handle: "alice".to_string(),
-    };
+fn test_should_roundtrip_get_user_args_handle() {
+    let args = GetUserArgs::Handle("alice".to_string());
+    let bytes = Encode!(&args).unwrap();
+    let decoded = Decode!(&bytes, GetUserArgs).unwrap();
+    assert_eq!(args, decoded);
+}
+
+#[test]
+fn test_should_roundtrip_get_user_args_principal() {
+    let args = GetUserArgs::Principal(candid::Principal::anonymous());
     let bytes = Encode!(&args).unwrap();
     let decoded = Decode!(&bytes, GetUserArgs).unwrap();
     assert_eq!(args, decoded);

--- a/crates/libs/did/src/user.rs
+++ b/crates/libs/did/src/user.rs
@@ -17,6 +17,8 @@ pub enum UserInstallArgs {
         owner: candid::Principal,
         /// Principal of the Federation Canister used for outbound ActivityPub delivery.
         federation_canister: candid::Principal,
+        /// Principal of the Directory Canister used for principal→handle resolution.
+        directory_canister: candid::Principal,
         /// User handle
         handle: String,
         /// The public URL of the Mastic instance (e.g. `https://mastic.social`)
@@ -442,6 +444,31 @@ pub enum GetLikedError {
 pub enum GetLikedResponse {
     Ok(Vec<String>),
     Err(GetLikedError),
+}
+
+/// Request arguments for the `get_statuses` method.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, CandidType, Serialize, Deserialize)]
+pub struct GetStatusesArgs {
+    /// Number of results to skip (for pagination).
+    pub offset: u64,
+    /// Maximum number of results to return.
+    pub limit: u64,
+}
+
+/// Error types for the `get_statuses` method.
+#[derive(Debug, Clone, PartialEq, Eq, CandidType, Serialize, Deserialize)]
+pub enum GetStatusesError {
+    /// Limit exceeds maximum allowed page size.
+    LimitExceeded,
+    /// Internal error occurred while fetching statuses.
+    Internal(String),
+}
+
+/// Response type for the `get_statuses` method.
+#[derive(Debug, Clone, PartialEq, Eq, CandidType, Serialize, Deserialize)]
+pub enum GetStatusesResponse {
+    Ok(Vec<Status>),
+    Err(GetStatusesError),
 }
 
 /// Request arguments for the `read_feed` method.

--- a/crates/libs/did/src/user/tests.rs
+++ b/crates/libs/did/src/user/tests.rs
@@ -7,6 +7,7 @@ fn test_should_roundtrip_user_install_args_init() {
     let args = UserInstallArgs::Init {
         owner: candid::Principal::anonymous(),
         federation_canister: candid::Principal::anonymous(),
+        directory_canister: candid::Principal::anonymous(),
         handle: "rey_canisteryo".to_string(),
         public_url: "https://mastic.social".to_string(),
     };
@@ -539,6 +540,31 @@ fn test_should_roundtrip_get_liked_response_err() {
     let resp = GetLikedResponse::Err(GetLikedError::Unauthorized);
     let bytes = Encode!(&resp).unwrap();
     let decoded = Decode!(&bytes, GetLikedResponse).unwrap();
+    assert_eq!(resp, decoded);
+}
+
+#[test]
+fn test_should_roundtrip_get_statuses_args() {
+    let args = GetStatusesArgs {
+        offset: 0,
+        limit: 20,
+    };
+    let bytes = Encode!(&args).unwrap();
+    let decoded = Decode!(&bytes, GetStatusesArgs).unwrap();
+    assert_eq!(args, decoded);
+}
+
+#[test]
+fn test_should_roundtrip_get_statuses_response_ok() {
+    let resp = GetStatusesResponse::Ok(vec![crate::common::Status {
+        id: 2,
+        content: "Hello".to_string(),
+        author: candid::Principal::anonymous(),
+        created_at: 42,
+        visibility: crate::common::Visibility::Public,
+    }]);
+    let bytes = Encode!(&resp).unwrap();
+    let decoded = Decode!(&bytes, GetStatusesResponse).unwrap();
     assert_eq!(resp, decoded);
 }
 

--- a/crates/libs/did/src/user/tests.rs
+++ b/crates/libs/did/src/user/tests.rs
@@ -569,6 +569,19 @@ fn test_should_roundtrip_get_statuses_response_ok() {
 }
 
 #[test]
+fn test_should_roundtrip_get_statuses_response_err() {
+    for error in [
+        GetStatusesError::LimitExceeded,
+        GetStatusesError::Internal("db error".to_string()),
+    ] {
+        let resp = GetStatusesResponse::Err(error);
+        let bytes = Encode!(&resp).unwrap();
+        let decoded = Decode!(&bytes, GetStatusesResponse).unwrap();
+        assert_eq!(resp, decoded);
+    }
+}
+
+#[test]
 fn test_should_roundtrip_read_feed_args() {
     let args = ReadFeedArgs {
         offset: 0,

--- a/crates/libs/did/src/user/tests.rs
+++ b/crates/libs/did/src/user/tests.rs
@@ -346,7 +346,7 @@ fn test_should_roundtrip_publish_status_response_ok() {
     let resp = PublishStatusResponse::Ok(crate::common::Status {
         id: 2,
         content: "Hello".to_string(),
-        author: candid::Principal::anonymous(),
+        author: "https://mastic.social/users/alice".to_string(),
         created_at: 42,
         visibility: crate::common::Visibility::Public,
     });
@@ -559,7 +559,7 @@ fn test_should_roundtrip_get_statuses_response_ok() {
     let resp = GetStatusesResponse::Ok(vec![crate::common::Status {
         id: 2,
         content: "Hello".to_string(),
-        author: candid::Principal::anonymous(),
+        author: "https://mastic.social/users/alice".to_string(),
         created_at: 42,
         visibility: crate::common::Visibility::Public,
     }]);
@@ -585,7 +585,7 @@ fn test_should_roundtrip_read_feed_response_ok() {
         status: crate::common::Status {
             id: 2,
             content: "Hello".to_string(),
-            author: candid::Principal::anonymous(),
+            author: "https://mastic.social/users/alice".to_string(),
             created_at: 42,
             visibility: crate::common::Visibility::Public,
         },

--- a/docs/src/architecture/database-schema.md
+++ b/docs/src/architecture/database-schema.md
@@ -81,6 +81,8 @@ for the full specification.
 | :-- | :---------------------------- | :--------- | :----------------------------------- |
 | `0` | `SETTING_FEDERATION_CANISTER` | `BLOB`     | Principal of the Federation canister |
 | `1` | `SETTING_OWNER_PRINCIPAL`     | `BLOB`     | Principal of the canister owner      |
+| `2` | `SETTING_PUBLIC_URL`          | `TEXT`     | Public URL of the Mastic instance    |
+| `3` | `SETTING_DIRECTORY_CANISTER`  | `BLOB`     | Principal of the Directory canister  |
 
 ### `profiles` Table
 

--- a/docs/src/directory.did
+++ b/docs/src/directory.did
@@ -21,6 +21,14 @@ type GetUser = record {
   // The matched user's handle.
   handle : text;
 };
+// Request arguments for the `get_user` method.
+// Look up a user by either their handle or their IC principal.
+type GetUserArgs = variant {
+  // Look up a user by their IC principal.
+  Principal : principal;
+  // Look up a user by their handle.
+  Handle : text;
+};
 // Error types for the `get_user` method.
 type GetUserError = variant {
   // The provided handle is invalid (e.g. empty or contains disallowed characters).
@@ -110,7 +118,7 @@ type WhoAmIError = variant {
 // information or an error if they are not registered.
 type WhoAmIResponse = variant { Ok : WhoAmI; Err : WhoAmIError };
 service : (DirectoryInstallArgs) -> {
-  get_user : (text) -> (GetUserResponse) query;
+  get_user : (GetUserArgs) -> (GetUserResponse) query;
   retry_sign_up : () -> (RetrySignUpResponse);
   sign_up : (SignUpRequest) -> (SignUpResponse);
   user_canister : (opt principal) -> (UserCanisterResponse) query;

--- a/docs/src/user.did
+++ b/docs/src/user.did
@@ -19,12 +19,12 @@ type AcceptFollowResponse = variant { Ok; Err : AcceptFollowError };
 type FeedItem = record {
   // The status associated with this feed item.
   status : Status;
-  // If this feed item was boosted (reblogged) by another user, the principal
-  // of the User Canister that performed the boost. Otherwise [`None`].
+  // If this feed item was boosted (reblogged) by another user, the actor URI
+  // of the user that performed the boost. Otherwise [`None`].
   // 
   // It works like this: if Alice creates a status, and Bob boosts it,
-  // then a new Feed Item is created with `boosted_by` set to Bob's principal.
-  boosted_by : opt principal;
+  // then a new Feed Item is created with `boosted_by` set to Bob's actor URI.
+  boosted_by : opt text;
 };
 // Request arguments for the `follow_user` method.
 type FollowUserArgs = record {
@@ -88,6 +88,22 @@ type GetProfileError = variant {
 };
 // Response type for the `get_profile` method.
 type GetProfileResponse = variant { Ok : UserProfile; Err : GetProfileError };
+// Request arguments for the `get_statuses` method.
+type GetStatusesArgs = record {
+  // Number of results to skip (for pagination).
+  offset : nat64;
+  // Maximum number of results to return.
+  limit : nat64;
+};
+// Error types for the `get_statuses` method.
+type GetStatusesError = variant {
+  // Internal error occurred while fetching statuses.
+  Internal : text;
+  // Limit exceeds maximum allowed page size.
+  LimitExceeded;
+};
+// Response type for the `get_statuses` method.
+type GetStatusesResponse = variant { Ok : vec Status; Err : GetStatusesError };
 // Request arguments for the `publish_status` method.
 type PublishStatusArgs = record {
   // The text content of the new post.
@@ -151,8 +167,8 @@ type Status = record {
   content : text;
   // Timestamp (milliseconds since epoch) of when the status was created.
   created_at : nat64;
-  // The principal of the User Canister that authored this status.
-  author : principal;
+  // The actor URI of the status author (e.g. `https://mastic.social/users/alice`).
+  author : text;
   // The visibility setting of the status, controlling its audience.
   visibility : Visibility;
 };
@@ -170,6 +186,8 @@ type UserInstallArgs = variant {
     owner : principal;
     // User handle
     handle : text;
+    // Principal of the Directory Canister used for principal→handle resolution.
+    directory_canister : principal;
   };
 };
 // A user's public profile information. Stored in the User Canister and returned
@@ -208,6 +226,7 @@ service : (UserInstallArgs) -> {
   get_followers : (GetFollowersArgs) -> (GetFollowersResponse) query;
   get_following : (GetFollowersArgs) -> (GetFollowersResponse) query;
   get_profile : () -> (GetProfileResponse) query;
+  get_statuses : (GetStatusesArgs) -> (GetStatusesResponse) query;
   publish_status : (PublishStatusArgs) -> (PublishStatusResponse);
   read_feed : (ReadFeedArgs) -> (ReadFeedResponse) query;
   receive_activity : (ReceiveActivityArgs) -> (ReceiveActivityResponse);

--- a/docs/src/user.did
+++ b/docs/src/user.did
@@ -226,7 +226,7 @@ service : (UserInstallArgs) -> {
   get_followers : (GetFollowersArgs) -> (GetFollowersResponse) query;
   get_following : (GetFollowersArgs) -> (GetFollowersResponse) query;
   get_profile : () -> (GetProfileResponse) query;
-  get_statuses : (GetStatusesArgs) -> (GetStatusesResponse) query;
+  get_statuses : (GetStatusesArgs) -> (GetStatusesResponse) composite_query;
   publish_status : (PublishStatusArgs) -> (PublishStatusResponse);
   read_feed : (ReadFeedArgs) -> (ReadFeedResponse) query;
   receive_activity : (ReceiveActivityArgs) -> (ReceiveActivityResponse);

--- a/integration-tests/src/lib.rs
+++ b/integration-tests/src/lib.rs
@@ -75,6 +75,7 @@ impl CanisterSetup for MasticCanisterSetup {
         let user_init_args = Encode!(&UserInstallArgs::Init {
             owner: rey_canisteryo(),
             federation_canister,
+            directory_canister,
             handle: "rey_canisteryo".to_string(),
             public_url: PUBLIC_URL.to_string(),
         })


### PR DESCRIPTION
## Summary

- Implement `get_statuses` public query on User Canister with visibility filtering based on caller relationship (owner/follower/other)
- Change `GetUserArgs` from struct to enum with `Handle(String)` | `Principal(Principal)` variants on Directory Canister
- Add `directory_canister` to User Canister init args and settings for inter-canister principal→handle resolution
- Add Directory adapter (trait + mock + wasm impl) following the federation adapter pattern
- Replace `Principal` with actor URI `String` in `Status.author` and `FeedItem.boosted_by`

## Test plan

- [x] StatusRepository unit tests: ordering, pagination, visibility filtering (8 tests)
- [x] get_statuses flow tests: owner/follower/anonymous/non-follower visibility, pagination, ordering (10 tests)
- [x] Directory get_user tests updated for both Handle and Principal variants
- [x] All DID roundtrip tests updated for new types
- [x] All existing tests pass (335 total)
- [x] Clippy clean, all 3 canisters build

Closes #60

🤖 Generated with [Claude Code](https://claude.com/claude-code)