### PR TITLE
feat(federation): implement activity routing for local targets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 name: build_and_test
 
 env:
-  RUST_VERSION: 1.94.1
+  RUST_VERSION: 1.95.0
 
 on:
   push:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,5 @@
 name: build_and_test
 
-env:
-  RUST_VERSION: 1.94.1
-
 on:
   push:
     branches:
@@ -53,14 +50,12 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: $RUST_VERSION
           components: rustfmt, clippy
           target: wasm32-unknown-unknown
 
       - name: Install Rust (wasm32-unknown-unknown target)
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: $RUST_VERSION
           target: wasm32-unknown-unknown
           components: rustfmt, clippy
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: build_and_test
 
+env:
+  RUST_VERSION: 1.94.1
+
 on:
   push:
     branches:
@@ -50,12 +53,14 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
         with:
+          toolchain: $RUST_VERSION
           components: rustfmt, clippy
           target: wasm32-unknown-unknown
 
       - name: Install Rust (wasm32-unknown-unknown target)
         uses: dtolnay/rust-toolchain@stable
         with:
+          toolchain: $RUST_VERSION
           target: wasm32-unknown-unknown
           components: rustfmt, clippy
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,8 +41,8 @@ just build_directory        # Build only the directory canister
 just build_federation       # Build only the federation canister
 just build_user             # Build only the user canister
 just test                   # Run unit tests
-just integration_test       # Run pocket-ic integration tests
-just test_all               # Run all tests (unit + integration)
+just integration_test       # Run pocket-ic integration tests (always run `just build_all` first to ensure WASM artifacts are up to date)
+just test_all               # Run all tests (unit + integration) (always run `just build_all` first to ensure WASM artifacts are up to date)
 just check_code             # Run nightly rustfmt --check + clippy -D warnings
 just fmt                    # Format code (stable)
 just fmt_nightly            # Format code (nightly, used in CI)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -954,6 +954,9 @@ dependencies = [
  "ic-utils",
  "serde",
  "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "url",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ serde_bytes = "0.11"
 serde_json = "1"
 thiserror = "2"
 tokio = { version = "1", features = ["full"] }
+url = "2"
 wasm-dbms = "0.8"
 wasm-dbms-api = "0.8"
 wasm-dbms-memory = "0.8"

--- a/crates/canisters/directory/src/adapters.rs
+++ b/crates/canisters/directory/src/adapters.rs
@@ -1,3 +1,4 @@
 //! Adapter traits abstracting external IC calls for testability.
 
+pub mod federation_canister;
 pub mod management_canister;

--- a/crates/canisters/directory/src/adapters/federation_canister.rs
+++ b/crates/canisters/directory/src/adapters/federation_canister.rs
@@ -1,0 +1,106 @@
+//! Federation canister adapter trait and implementations.
+//!
+//! Abstracts federation canister calls (`register_user`) behind a trait so that
+//! domain logic can be unit-tested without a running replica.
+
+#[cfg(not(target_family = "wasm"))]
+pub mod mock;
+
+use std::future::Future;
+
+use candid::Principal;
+
+/// Abstraction over the federation canister API.
+///
+/// Currently exposes only user registration, which the directory canister calls
+/// after successfully installing a new user canister. Extend this trait if
+/// additional federation calls become necessary.
+pub trait FederationCanister: Send + Sync + Sized {
+    /// Registers a user with the federation canister so it can route
+    /// ActivityPub traffic to the correct user canister.
+    fn register_user(
+        &self,
+        user_id: Principal,
+        user_handle: String,
+        user_canister_id: Principal,
+    ) -> impl Future<Output = Result<(), FederationCanisterError>>;
+}
+
+/// Errors returned by [`FederationCanister`] operations.
+#[derive(Debug, Clone, thiserror::Error)]
+pub enum FederationCanisterError {
+    /// The inter-canister call failed.
+    #[error("inter-canister call failed: {0}")]
+    #[allow(dead_code, reason = "constructed only in wasm builds")]
+    #[cfg(any(target_family = "wasm", test))]
+    CallFailed(String),
+    /// The response could not be decoded.
+    #[error("decode failed: {0}")]
+    #[allow(dead_code, reason = "constructed only in wasm builds")]
+    #[cfg(target_family = "wasm")]
+    DecodeFailed(String),
+}
+
+/// Production implementation that delegates to `ic_cdk` calls.
+#[cfg(target_family = "wasm")]
+pub struct IcFederationCanisterClient {
+    canister_id: Principal,
+}
+
+#[cfg(target_family = "wasm")]
+impl From<Principal> for IcFederationCanisterClient {
+    fn from(canister_id: Principal) -> Self {
+        Self { canister_id }
+    }
+}
+
+#[cfg(target_family = "wasm")]
+impl FederationCanister for IcFederationCanisterClient {
+    async fn register_user(
+        &self,
+        user_id: Principal,
+        user_handle: String,
+        user_canister_id: Principal,
+    ) -> Result<(), FederationCanisterError> {
+        use did::federation::{RegisterUserArgs, RegisterUserResponse};
+
+        ic_utils::log!(
+            "IcFederationCanisterClient::register_user: registering user {user_id} \
+             with handle {user_handle:?} and canister {user_canister_id}"
+        );
+
+        let args = RegisterUserArgs {
+            user_id,
+            user_handle,
+            user_canister_id,
+        };
+
+        let raw = ic_cdk::call::Call::bounded_wait(self.canister_id, "register_user")
+            .with_arg(args)
+            .await
+            .map_err(|e| {
+                ic_utils::log!("IcFederationCanisterClient::register_user: call failed: {e:?}");
+                FederationCanisterError::CallFailed(format!("{e:?}"))
+            })?;
+
+        let response = candid::decode_one::<RegisterUserResponse>(&raw).map_err(|e| {
+            ic_utils::log!("IcFederationCanisterClient::register_user: decode failed: {e}");
+            FederationCanisterError::DecodeFailed(e.to_string())
+        })?;
+
+        match response {
+            RegisterUserResponse::Ok => {
+                ic_utils::log!(
+                    "IcFederationCanisterClient::register_user: user {user_id} registered"
+                );
+                Ok(())
+            }
+            RegisterUserResponse::Err(e) => {
+                ic_utils::log!(
+                    "IcFederationCanisterClient::register_user: federation error: {e:?}"
+                );
+                Err(FederationCanisterError::CallFailed(format!("{e:?}")))
+            }
+        }
+    }
+}

--- a/crates/canisters/directory/src/adapters/federation_canister/mock.rs
+++ b/crates/canisters/directory/src/adapters/federation_canister/mock.rs
@@ -1,0 +1,20 @@
+//! Mock implementation of [`FederationCanister`] for unit tests.
+
+use candid::Principal;
+
+use super::{FederationCanister, FederationCanisterError};
+
+/// A test-only [`FederationCanister`] that always succeeds.
+#[derive(Debug)]
+pub struct MockFederationCanisterClient;
+
+impl FederationCanister for MockFederationCanisterClient {
+    async fn register_user(
+        &self,
+        _user_id: Principal,
+        _user_handle: String,
+        _user_canister_id: Principal,
+    ) -> Result<(), FederationCanisterError> {
+        Ok(())
+    }
+}

--- a/crates/canisters/directory/src/domain/users/sign_up.rs
+++ b/crates/canisters/directory/src/domain/users/sign_up.rs
@@ -161,10 +161,15 @@ fn alice() -> Principal {
 fn start_sign_up_state_machine(_user_id: Principal, handle: String) {
     #[cfg(target_family = "wasm")]
     {
+        let federation_canister_id = crate::settings::get_federation_canister()
+            .expect("federation canister must be configured");
         state::SignUpStateMachine::start(
             _user_id,
             handle,
             crate::adapters::management_canister::IcManagementCanisterClient,
+            crate::adapters::federation_canister::IcFederationCanisterClient::from(
+                federation_canister_id,
+            ),
         );
     }
     #[cfg(not(target_family = "wasm"))]
@@ -176,6 +181,7 @@ fn start_sign_up_state_machine(_user_id: Principal, handle: String) {
                 canister_self: Principal::from_text("br5f7-7uaaa-aaaaa-qaaca-cai").unwrap(),
                 created_canister_id: Principal::from_text("bkyz2-fmaaa-aaaaa-qaaaq-cai").unwrap(),
             },
+            crate::adapters::federation_canister::mock::MockFederationCanisterClient,
         );
     }
 }

--- a/crates/canisters/directory/src/domain/users/sign_up/state.rs
+++ b/crates/canisters/directory/src/domain/users/sign_up/state.rs
@@ -6,6 +6,7 @@ use candid::Principal;
 use did::user::UserInstallArgs;
 use ic_management_canister_types::CanisterSettings;
 
+use crate::adapters::federation_canister::FederationCanister;
 use crate::adapters::management_canister::ManagementCanister;
 use crate::domain::users::repository::UserRepository;
 use crate::error::CanisterResult;
@@ -63,6 +64,10 @@ enum SignUpState {
     ///
     /// The state machine is ready to install the user canister wasm and initialize the canister with the user's information.
     InstallWasm { canister_id: Principal },
+    /// The user canister has been installed.
+    ///
+    /// The state machine should register the user with the federation canister so it can route ActivityPub traffic.
+    RegisterUser { canister_id: Principal },
     /// Commit changes to the directory canister to mark the user as active and associate them with their canister ID.
     CommitSignUp(SignUpResult),
 }
@@ -78,26 +83,30 @@ enum StepResult {
 
 /// State machine for the user sign up process.
 ///
-/// Generic over `C` so that the management canister dependency can be replaced
-/// with a mock during unit tests.
-pub struct SignUpStateMachine<C>
+/// Generic over `M` (management canister) and `F` (federation canister) so that
+/// both dependencies can be replaced with mocks during unit tests.
+pub struct SignUpStateMachine<M, F>
 where
-    C: ManagementCanister + 'static,
+    M: ManagementCanister + 'static,
+    F: FederationCanister + 'static,
 {
     /// The user for which the sign up process is being executed.
     user_id: Principal,
     /// User handle
     handle: String,
     /// Adapter for management canister calls.
-    client: C,
+    management: M,
+    /// Adapter for federation canister calls.
+    federation: F,
 }
 
-impl<C> SignUpStateMachine<C>
+impl<M, F> SignUpStateMachine<M, F>
 where
-    C: ManagementCanister + 'static,
+    M: ManagementCanister + 'static,
+    F: FederationCanister + 'static,
 {
     /// Start a new sign up process for a user by initializing their state in the `USER_SIGN_UP_STATES` thread-local storage.
-    pub fn start(user_id: Principal, handle: String, client: C) {
+    pub fn start(user_id: Principal, handle: String, management: M, federation: F) {
         ic_utils::log!("Starting sign up process for user {user_id}",);
         // if there is already an entry for the user, return early to prevent starting multiple sign up processes for the same user
         let already_exists =
@@ -113,7 +122,8 @@ where
         Self {
             user_id,
             handle,
-            client,
+            management,
+            federation,
         }
         .tick();
     }
@@ -178,6 +188,7 @@ where
         let new_state = match state {
             SignUpState::CreateCanister => self.create_canister().await,
             SignUpState::InstallWasm { canister_id } => self.install_wasm(canister_id).await,
+            SignUpState::RegisterUser { canister_id } => self.register_user(canister_id).await,
             SignUpState::CommitSignUp(SignUpResult::Success { canister_id }) => {
                 match self.commit_sign_up(canister_id) {
                     Ok(()) => return StepResult::Finished,
@@ -211,7 +222,7 @@ where
 
     /// Create a canister for the user by sending a request to the management canister.
     async fn create_canister(&self) -> SignUpState {
-        let controller = self.client.canister_self();
+        let controller = self.management.canister_self();
 
         let settings = Some(CanisterSettings {
             controllers: Some(vec![controller]),
@@ -220,7 +231,7 @@ where
 
         #[allow(irrefutable_let_patterns)]
         let Ok(canister_id) = self
-            .client
+            .management
             .create_canister(settings, INITIAL_USER_CANISTER_CYCLES)
             .await
         else {
@@ -256,7 +267,7 @@ where
         };
 
         if self
-            .client
+            .management
             .install_code(canister_id, USER_CANISTER_WASM, init_args)
             .await
             .is_err()
@@ -266,6 +277,22 @@ where
         };
 
         // success, move to next state
+        SignUpState::RegisterUser { canister_id }
+    }
+
+    /// Register the user with the federation canister so it can route ActivityPub traffic.
+    async fn register_user(&self, canister_id: Principal) -> SignUpState {
+        if self
+            .federation
+            .register_user(self.user_id, self.handle.clone(), canister_id)
+            .await
+            .is_err()
+        {
+            // failed, return same state to retry
+            return SignUpState::RegisterUser { canister_id };
+        }
+
+        // success, move to commit
         SignUpState::CommitSignUp(SignUpResult::Success { canister_id })
     }
 
@@ -290,17 +317,18 @@ mod tests {
     use candid::Principal;
 
     use super::*;
+    use crate::adapters::federation_canister::FederationCanisterError;
     use crate::adapters::management_canister::ManagementCanisterError;
     use crate::test_utils::{rey_canisteryo, setup};
 
     /// Configurable mock for [`ManagementCanister`].
-    struct TestClient {
+    struct TestManagementClient {
         canister_self: Principal,
         create_result: Result<Principal, ManagementCanisterError>,
         install_result: Result<(), ManagementCanisterError>,
     }
 
-    impl TestClient {
+    impl TestManagementClient {
         /// Return a client where all operations succeed.
         fn ok(created_canister_id: Principal) -> Self {
             Self {
@@ -321,7 +349,7 @@ mod tests {
         }
     }
 
-    impl ManagementCanister for TestClient {
+    impl ManagementCanister for TestManagementClient {
         async fn create_canister(
             &self,
             _settings: Option<CanisterSettings>,
@@ -348,15 +376,48 @@ mod tests {
         }
     }
 
+    /// Configurable mock for [`FederationCanister`].
+    struct TestFederationClient {
+        register_result: Result<(), FederationCanisterError>,
+    }
+
+    impl TestFederationClient {
+        fn ok() -> Self {
+            Self {
+                register_result: Ok(()),
+            }
+        }
+
+        fn with_register_err(mut self) -> Self {
+            self.register_result = Err(FederationCanisterError::CallFailed("test".to_string()));
+            self
+        }
+    }
+
+    impl FederationCanister for TestFederationClient {
+        async fn register_user(
+            &self,
+            _user_id: Principal,
+            _user_handle: String,
+            _user_canister_id: Principal,
+        ) -> Result<(), FederationCanisterError> {
+            self.register_result.clone()
+        }
+    }
+
     fn user_canister() -> Principal {
         Principal::from_text("b77ix-eeaaa-aaaaa-qaada-cai").unwrap()
     }
 
-    fn machine(client: TestClient) -> SignUpStateMachine<TestClient> {
+    fn machine(
+        mgmt: TestManagementClient,
+        fed: TestFederationClient,
+    ) -> SignUpStateMachine<TestManagementClient, TestFederationClient> {
         SignUpStateMachine {
             user_id: rey_canisteryo(),
-            client,
             handle: "rey_canisteryo".to_string(),
+            management: mgmt,
+            federation: fed,
         }
     }
 
@@ -364,7 +425,10 @@ mod tests {
 
     #[tokio::test]
     async fn test_create_canister_should_advance_to_install_wasm() {
-        let sm = machine(TestClient::ok(user_canister()));
+        let sm = machine(
+            TestManagementClient::ok(user_canister()),
+            TestFederationClient::ok(),
+        );
 
         let result = sm.create_canister().await;
 
@@ -378,7 +442,10 @@ mod tests {
 
     #[tokio::test]
     async fn test_create_canister_should_retry_on_failure() {
-        let sm = machine(TestClient::ok(user_canister()).with_create_err());
+        let sm = machine(
+            TestManagementClient::ok(user_canister()).with_create_err(),
+            TestFederationClient::ok(),
+        );
 
         let result = sm.create_canister().await;
 
@@ -388,24 +455,30 @@ mod tests {
     // -- install_wasm step ----------------------------------------------------
 
     #[tokio::test]
-    async fn test_install_wasm_should_advance_to_commit() {
+    async fn test_install_wasm_should_advance_to_register_user() {
         setup();
-        let sm = machine(TestClient::ok(user_canister()));
+        let sm = machine(
+            TestManagementClient::ok(user_canister()),
+            TestFederationClient::ok(),
+        );
 
         let result = sm.install_wasm(user_canister()).await;
 
         assert_eq!(
             result,
-            SignUpState::CommitSignUp(SignUpResult::Success {
+            SignUpState::RegisterUser {
                 canister_id: user_canister()
-            })
+            }
         );
     }
 
     #[tokio::test]
     async fn test_install_wasm_should_retry_on_install_failure() {
         setup();
-        let sm = machine(TestClient::ok(user_canister()).with_install_err());
+        let sm = machine(
+            TestManagementClient::ok(user_canister()).with_install_err(),
+            TestFederationClient::ok(),
+        );
 
         let result = sm.install_wasm(user_canister()).await;
 
@@ -417,11 +490,50 @@ mod tests {
         );
     }
 
+    // -- register_user step ---------------------------------------------------
+
+    #[tokio::test]
+    async fn test_register_user_should_advance_to_commit() {
+        let sm = machine(
+            TestManagementClient::ok(user_canister()),
+            TestFederationClient::ok(),
+        );
+
+        let result = sm.register_user(user_canister()).await;
+
+        assert_eq!(
+            result,
+            SignUpState::CommitSignUp(SignUpResult::Success {
+                canister_id: user_canister()
+            })
+        );
+    }
+
+    #[tokio::test]
+    async fn test_register_user_should_retry_on_failure() {
+        let sm = machine(
+            TestManagementClient::ok(user_canister()),
+            TestFederationClient::ok().with_register_err(),
+        );
+
+        let result = sm.register_user(user_canister()).await;
+
+        assert_eq!(
+            result,
+            SignUpState::RegisterUser {
+                canister_id: user_canister()
+            }
+        );
+    }
+
     // -- step: full state transitions -----------------------------------------
 
     #[tokio::test]
     async fn test_step_should_advance_from_create_to_install() {
-        let sm = machine(TestClient::ok(user_canister()));
+        let sm = machine(
+            TestManagementClient::ok(user_canister()),
+            TestFederationClient::ok(),
+        );
         let current = SignUpStateStep::default();
 
         let result = sm.step(current).await;
@@ -438,8 +550,64 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_step_should_advance_from_install_to_register_user() {
+        setup();
+        let sm = machine(
+            TestManagementClient::ok(user_canister()),
+            TestFederationClient::ok(),
+        );
+        let current = SignUpStateStep {
+            state: SignUpState::InstallWasm {
+                canister_id: user_canister(),
+            },
+            retries: 0,
+        };
+
+        let result = sm.step(current).await;
+
+        assert_eq!(
+            result,
+            StepResult::Continue(SignUpStateStep {
+                state: SignUpState::RegisterUser {
+                    canister_id: user_canister()
+                },
+                retries: 0,
+            })
+        );
+    }
+
+    #[tokio::test]
+    async fn test_step_should_advance_from_register_user_to_commit() {
+        let sm = machine(
+            TestManagementClient::ok(user_canister()),
+            TestFederationClient::ok(),
+        );
+        let current = SignUpStateStep {
+            state: SignUpState::RegisterUser {
+                canister_id: user_canister(),
+            },
+            retries: 0,
+        };
+
+        let result = sm.step(current).await;
+
+        assert_eq!(
+            result,
+            StepResult::Continue(SignUpStateStep {
+                state: SignUpState::CommitSignUp(SignUpResult::Success {
+                    canister_id: user_canister()
+                }),
+                retries: 0,
+            })
+        );
+    }
+
+    #[tokio::test]
     async fn test_step_should_increment_retries_on_same_state() {
-        let sm = machine(TestClient::ok(user_canister()).with_create_err());
+        let sm = machine(
+            TestManagementClient::ok(user_canister()).with_create_err(),
+            TestFederationClient::ok(),
+        );
         let current = SignUpStateStep {
             state: SignUpState::CreateCanister,
             retries: 2,
@@ -457,8 +625,37 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_step_should_increment_retries_on_register_user_failure() {
+        let sm = machine(
+            TestManagementClient::ok(user_canister()),
+            TestFederationClient::ok().with_register_err(),
+        );
+        let current = SignUpStateStep {
+            state: SignUpState::RegisterUser {
+                canister_id: user_canister(),
+            },
+            retries: 1,
+        };
+
+        let result = sm.step(current).await;
+
+        assert_eq!(
+            result,
+            StepResult::Continue(SignUpStateStep {
+                state: SignUpState::RegisterUser {
+                    canister_id: user_canister()
+                },
+                retries: 2,
+            })
+        );
+    }
+
+    #[tokio::test]
     async fn test_step_should_transition_to_failure_on_max_retries() {
-        let sm = machine(TestClient::ok(user_canister()).with_create_err());
+        let sm = machine(
+            TestManagementClient::ok(user_canister()).with_create_err(),
+            TestFederationClient::ok(),
+        );
         let current = SignUpStateStep {
             state: SignUpState::CreateCanister,
             retries: MAX_RETRIES,
@@ -476,8 +673,35 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_step_should_transition_register_user_to_failure_on_max_retries() {
+        let sm = machine(
+            TestManagementClient::ok(user_canister()),
+            TestFederationClient::ok().with_register_err(),
+        );
+        let current = SignUpStateStep {
+            state: SignUpState::RegisterUser {
+                canister_id: user_canister(),
+            },
+            retries: MAX_RETRIES,
+        };
+
+        let result = sm.step(current).await;
+
+        assert_eq!(
+            result,
+            StepResult::Continue(SignUpStateStep {
+                state: SignUpState::CommitSignUp(SignUpResult::Failure),
+                retries: 0,
+            })
+        );
+    }
+
+    #[tokio::test]
     async fn test_step_should_finish_when_commit_failure_exhausts_retries() {
-        let sm = machine(TestClient::ok(user_canister()));
+        let sm = machine(
+            TestManagementClient::ok(user_canister()),
+            TestFederationClient::ok(),
+        );
         let current = SignUpStateStep {
             state: SignUpState::CommitSignUp(SignUpResult::Failure),
             retries: MAX_RETRIES,
@@ -491,7 +715,10 @@ mod tests {
     #[tokio::test]
     async fn test_step_should_finish_on_successful_commit() {
         setup();
-        let sm = machine(TestClient::ok(user_canister()));
+        let sm = machine(
+            TestManagementClient::ok(user_canister()),
+            TestFederationClient::ok(),
+        );
         // the user must exist in the DB for commit to succeed
         UserRepository::sign_up(rey_canisteryo(), "alice".to_string())
             .expect("sign_up should succeed");
@@ -511,7 +738,10 @@ mod tests {
     #[tokio::test]
     async fn test_step_should_finish_on_successful_commit_failure() {
         setup();
-        let sm = machine(TestClient::ok(user_canister()));
+        let sm = machine(
+            TestManagementClient::ok(user_canister()),
+            TestFederationClient::ok(),
+        );
         UserRepository::sign_up(rey_canisteryo(), "alice".to_string())
             .expect("sign_up should succeed");
 
@@ -528,8 +758,11 @@ mod tests {
     #[tokio::test]
     async fn test_step_should_retry_commit_on_missing_user() {
         setup();
-        // do NOT insert the user — commit will fail
-        let sm = machine(TestClient::ok(user_canister()));
+        // do NOT insert the user -- commit will fail
+        let sm = machine(
+            TestManagementClient::ok(user_canister()),
+            TestFederationClient::ok(),
+        );
 
         let current = SignUpStateStep {
             state: SignUpState::CommitSignUp(SignUpResult::Success {

--- a/crates/canisters/federation/Cargo.toml
+++ b/crates/canisters/federation/Cargo.toml
@@ -17,6 +17,11 @@ ic-stable-structures = { workspace = true }
 ic-utils = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+thiserror = { workspace = true }
+url = { workspace = true }
+
+[dev-dependencies]
+tokio = { workspace = true }
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/crates/canisters/federation/src/adapters.rs
+++ b/crates/canisters/federation/src/adapters.rs
@@ -1,0 +1,10 @@
+//! Adapter traits abstracting external IC calls for testability.
+//!
+//! Each sub-module defines a trait describing an inter-canister surface
+//! the Federation Canister depends on, a production implementation that
+//! delegates to `ic_cdk::call` on `wasm32-unknown-unknown` targets, and a
+//! mock implementation used by unit tests on native targets. Domain code
+//! selects the appropriate implementation via `cfg` gating so the same
+//! call sites work in both environments.
+
+pub mod user;

--- a/crates/canisters/federation/src/adapters/user.rs
+++ b/crates/canisters/federation/src/adapters/user.rs
@@ -1,0 +1,114 @@
+//! User canister client adapter.
+//!
+//! Abstracts user canister calls (`receive_activity`) behind a trait so that
+//! domain logic can be unit-tested without a running replica. Production
+//! code uses [`IcUserCanisterClient`] on wasm targets; unit tests use
+//! [`mock::MockUserCanisterClient`] on native targets.
+
+#[cfg(not(target_family = "wasm"))]
+pub mod mock;
+
+use did::user::ReceiveActivityArgs;
+
+/// Abstraction over the user canister API used by the Federation Canister.
+///
+/// Callers construct an implementation (e.g. [`IcUserCanisterClient`] or
+/// [`mock::MockUserCanisterClient`]) and invoke methods on it. Every method
+/// returns a typed [`Result`] to let domain code distinguish transport
+/// failures from canister-level rejections.
+pub trait UserCanister: Send + Sync + Sized {
+    /// Deliver an activity to the User Canister by calling its
+    /// `receive_activity` method.
+    ///
+    /// Returns `Ok(())` when the target canister accepts the activity.
+    /// Returns [`UserCanisterClientError::CallFailed`] or
+    /// [`UserCanisterClientError::DecodeFailed`] on transport-level
+    /// problems, and [`UserCanisterClientError::Rejected`] when the target
+    /// canister responds with a typed error.
+    fn receive_activity(
+        &self,
+        args: ReceiveActivityArgs,
+    ) -> impl Future<Output = Result<(), UserCanisterClientError>>;
+}
+
+/// Errors returned by [`UserCanister`] operations.
+#[derive(Debug, Clone, thiserror::Error)]
+pub enum UserCanisterClientError {
+    /// The inter-canister call failed.
+    #[error("inter-canister call failed: {0}")]
+    #[allow(dead_code, reason = "constructed only in wasm builds")]
+    CallFailed(String),
+    /// The response could not be decoded.
+    #[error("decode failed: {0}")]
+    #[allow(dead_code, reason = "constructed only in wasm builds")]
+    DecodeFailed(String),
+    /// The user canister rejected the activity.
+    #[error("user canister rejected the activity: {0}")]
+    #[allow(dead_code, reason = "constructed only in wasm builds")]
+    Rejected(String),
+}
+
+/// Production implementation of [`UserCanister`] that delegates to
+/// `ic_cdk::call` on wasm targets.
+///
+/// Construct with [`IcUserCanisterClient::from`] passing the target User
+/// Canister principal. Only available when compiling for
+/// `wasm32-unknown-unknown`.
+#[cfg(target_family = "wasm")]
+pub struct IcUserCanisterClient {
+    /// Principal of the target User Canister.
+    canister_id: candid::Principal,
+}
+
+#[cfg(target_family = "wasm")]
+impl From<candid::Principal> for IcUserCanisterClient {
+    /// Build a client that will call the User Canister identified by
+    /// `canister_id`.
+    fn from(canister_id: candid::Principal) -> Self {
+        Self { canister_id }
+    }
+}
+
+#[cfg(target_family = "wasm")]
+impl UserCanister for IcUserCanisterClient {
+    async fn receive_activity(
+        &self,
+        args: ReceiveActivityArgs,
+    ) -> Result<(), UserCanisterClientError> {
+        use did::user::ReceiveActivityResponse;
+
+        ic_utils::log!(
+            "IcUserCanisterClient::receive_activity: delivering activity to {}",
+            self.canister_id
+        );
+
+        let raw = ic_cdk::call::Call::bounded_wait(self.canister_id, "receive_activity")
+            .with_arg(args)
+            .await
+            .map_err(|e| {
+                ic_utils::log!("IcUserCanisterClient::receive_activity: call failed: {e:?}");
+                UserCanisterClientError::CallFailed(format!("{e:?}"))
+            })?;
+
+        let response = candid::decode_one::<ReceiveActivityResponse>(&raw).map_err(|e| {
+            ic_utils::log!("IcUserCanisterClient::receive_activity: decode failed: {e}");
+            UserCanisterClientError::DecodeFailed(e.to_string())
+        })?;
+
+        match response {
+            ReceiveActivityResponse::Ok => {
+                ic_utils::log!(
+                    "IcUserCanisterClient::receive_activity: activity delivered to {}",
+                    self.canister_id
+                );
+                Ok(())
+            }
+            ReceiveActivityResponse::Err(e) => {
+                ic_utils::log!(
+                    "IcUserCanisterClient::receive_activity: user canister error: {e:?}"
+                );
+                Err(UserCanisterClientError::Rejected(format!("{e:?}")))
+            }
+        }
+    }
+}

--- a/crates/canisters/federation/src/adapters/user/mock.rs
+++ b/crates/canisters/federation/src/adapters/user/mock.rs
@@ -1,0 +1,28 @@
+//! Mock implementation of [`UserCanister`] for unit tests.
+//!
+//! Only compiled on non-wasm targets (see the `#[cfg(not(target_family =
+//! "wasm"))]` gate on the `mock` module declaration in [`super`]). Tests
+//! that need alternative mock behavior (e.g. returning an error) should add
+//! additional mock types in this module instead of modifying the default
+//! always-Ok client.
+
+use did::user::ReceiveActivityArgs;
+
+use super::{UserCanister, UserCanisterClientError};
+
+/// A test-only [`UserCanister`] whose `receive_activity` implementation
+/// always returns `Ok(())`.
+///
+/// Use this when the behavior under test does not care about the User
+/// Canister response (only that the call was attempted).
+#[derive(Debug)]
+pub struct MockUserCanisterClient;
+
+impl UserCanister for MockUserCanisterClient {
+    async fn receive_activity(
+        &self,
+        _args: ReceiveActivityArgs,
+    ) -> Result<(), UserCanisterClientError> {
+        Ok(())
+    }
+}

--- a/crates/canisters/federation/src/api.rs
+++ b/crates/canisters/federation/src/api.rs
@@ -1,6 +1,8 @@
 //! API for the canister
 
-use did::federation::FederationInstallArgs;
+pub mod inspect;
+
+use did::federation::{FederationInstallArgs, RegisterUserArgs, RegisterUserResponse};
 
 /// Initialize the canister with the given arguments
 pub fn init(args: FederationInstallArgs) {
@@ -16,12 +18,12 @@ pub fn init(args: FederationInstallArgs) {
         "Federation canister initialized with directory canister: {directory_canister} and public URL: {public_url}",
     );
 
-    ic_utils::log!("Setting initial configuration...");
     crate::settings::set_directory_canister(directory_canister);
     ic_utils::log!(
         "Directory canister set to: {}",
         crate::settings::get_directory_canister()
     );
+
     crate::settings::set_public_url(public_url);
     ic_utils::log!("Public URL set to: {}", crate::settings::get_public_url());
 }
@@ -33,13 +35,46 @@ pub fn post_upgrade(args: FederationInstallArgs) {
     };
 }
 
+/// Register a new user with the given arguments, returning a response indicating success or failure
+pub fn register_user(args: RegisterUserArgs) -> RegisterUserResponse {
+    let caller = ic_utils::caller();
+    if !self::inspect::is_directory_canister(caller) {
+        ic_utils::trap!(
+            "Unauthorized caller: {caller}. Only the directory canister is allowed to register users.",
+        );
+    }
+
+    ic_utils::log!(
+        "Registering user with ID: {}, handle: {}, canister ID {}",
+        args.user_id,
+        args.user_handle,
+        args.user_canister_id
+    );
+
+    crate::directory::insert_user(args.user_id, args.user_handle, args.user_canister_id);
+
+    RegisterUserResponse::Ok
+}
+
 #[cfg(test)]
 mod tests {
 
-    use did::federation::FederationInstallArgs;
+    use candid::Principal;
+    use did::federation::{FederationInstallArgs, RegisterUserArgs, RegisterUserResponse};
 
     use super::*;
-    use crate::test_utils::{directory, public_url, setup};
+    use crate::test_utils::{alice, directory, public_url, setup};
+
+    /// Set up the canister so that the dummy test caller is treated as the
+    /// directory canister, allowing `register_user` to pass the authorization
+    /// check.
+    fn setup_with_caller_as_directory() {
+        let caller = ic_utils::caller();
+        init(FederationInstallArgs::Init {
+            directory_canister: caller,
+            public_url: public_url(),
+        });
+    }
 
     #[test]
     fn test_should_init_canister() {
@@ -68,6 +103,47 @@ mod tests {
         post_upgrade(FederationInstallArgs::Init {
             directory_canister: directory(),
             public_url: public_url(),
+        });
+    }
+
+    // M-UNIT-TEST: register_user inserts the user and returns Ok when called
+    // by the directory canister.
+    #[test]
+    fn test_should_register_user() {
+        setup_with_caller_as_directory();
+
+        let user_canister =
+            Principal::from_text("be2us-64aaa-aaaaa-qaabq-cai").expect("valid principal");
+
+        let response = register_user(RegisterUserArgs {
+            user_id: alice(),
+            user_handle: "alice".to_string(),
+            user_canister_id: user_canister,
+        });
+
+        assert_eq!(response, RegisterUserResponse::Ok);
+
+        let stored =
+            crate::directory::get_user_by_id(&alice()).expect("user should exist after register");
+        assert_eq!(stored.user_id, alice());
+        assert_eq!(stored.user_handle, "alice");
+        assert_eq!(stored.user_canister_id, user_canister);
+    }
+
+    // M-UNIT-TEST: register_user traps when the caller is not the directory
+    // canister.
+    #[test]
+    #[should_panic(expected = "Unauthorized caller")]
+    fn test_should_trap_on_register_user_with_unauthorized_caller() {
+        setup();
+
+        let user_canister =
+            Principal::from_text("be2us-64aaa-aaaaa-qaabq-cai").expect("valid principal");
+
+        register_user(RegisterUserArgs {
+            user_id: alice(),
+            user_handle: "alice".to_string(),
+            user_canister_id: user_canister,
         });
     }
 }

--- a/crates/canisters/federation/src/api.rs
+++ b/crates/canisters/federation/src/api.rs
@@ -2,7 +2,10 @@
 
 pub mod inspect;
 
-use did::federation::{FederationInstallArgs, RegisterUserArgs, RegisterUserResponse};
+use did::federation::{
+    FederationInstallArgs, RegisterUserArgs, RegisterUserResponse, SendActivityArgs,
+    SendActivityResponse,
+};
 
 /// Initialize the canister with the given arguments
 pub fn init(args: FederationInstallArgs) {
@@ -56,11 +59,25 @@ pub fn register_user(args: RegisterUserArgs) -> RegisterUserResponse {
     RegisterUserResponse::Ok
 }
 
+pub async fn send_activity(args: SendActivityArgs) -> SendActivityResponse {
+    let caller = ic_utils::caller();
+    if !self::inspect::is_user_canister(caller) {
+        ic_utils::trap!(
+            "Unauthorized caller: {caller}. Only registered User Canisters are allowed to send activities.",
+        );
+    }
+
+    crate::domain::activity::send_activity(args).await
+}
+
 #[cfg(test)]
 mod tests {
 
     use candid::Principal;
-    use did::federation::{FederationInstallArgs, RegisterUserArgs, RegisterUserResponse};
+    use did::federation::{
+        FederationInstallArgs, RegisterUserArgs, RegisterUserResponse, SendActivityArgs,
+        SendActivityArgsObject, SendActivityResponse, SendActivityResult,
+    };
 
     use super::*;
     use crate::test_utils::{alice, directory, public_url, setup};
@@ -145,5 +162,67 @@ mod tests {
             user_handle: "alice".to_string(),
             user_canister_id: user_canister,
         });
+    }
+
+    /// Seeds the default unit-test caller principal (returned by
+    /// [`ic_utils::caller`] on non-wasm targets) as a registered User
+    /// Canister in the directory so that `send_activity` authorization
+    /// passes.
+    fn seed_caller_as_user_canister() {
+        let caller = ic_utils::caller();
+        crate::directory::insert_user(caller, "caller".to_string(), caller);
+    }
+
+    fn remote_inbox_obj() -> SendActivityArgsObject {
+        SendActivityArgsObject {
+            activity_json: r#"{"type":"Create"}"#.to_string(),
+            target_inbox: "https://other.social/users/bob/inbox".to_string(),
+        }
+    }
+
+    // M-UNIT-TEST: send_activity returns Ok for a single remote target when
+    // the caller is a registered User Canister (remote delivery is skipped
+    // in Milestone 0).
+    #[tokio::test]
+    async fn test_should_accept_send_activity_from_registered_user_canister() {
+        setup();
+        seed_caller_as_user_canister();
+
+        let response = send_activity(SendActivityArgs::One(remote_inbox_obj())).await;
+
+        assert_eq!(response, SendActivityResponse::One(SendActivityResult::Ok));
+    }
+
+    // M-UNIT-TEST: send_activity aggregates a batch of remote targets into a
+    // Batch response with one Ok per input.
+    #[tokio::test]
+    async fn test_should_accept_batch_send_activity() {
+        setup();
+        seed_caller_as_user_canister();
+
+        let response = send_activity(SendActivityArgs::Batch(vec![
+            remote_inbox_obj(),
+            remote_inbox_obj(),
+        ]))
+        .await;
+
+        match response {
+            SendActivityResponse::Batch(results) => {
+                assert_eq!(results.len(), 2);
+                assert_eq!(results[0], SendActivityResult::Ok);
+                assert_eq!(results[1], SendActivityResult::Ok);
+            }
+            other => panic!("expected Batch response, got {other:?}"),
+        }
+    }
+
+    // M-UNIT-TEST: send_activity traps when the caller is not a registered
+    // User Canister.
+    #[tokio::test]
+    #[should_panic(expected = "Unauthorized caller")]
+    async fn test_should_trap_on_send_activity_with_unauthorized_caller() {
+        setup();
+
+        let _ = send_activity(SendActivityArgs::One(remote_inbox_obj())).await;
     }
 }

--- a/crates/canisters/federation/src/api/inspect.rs
+++ b/crates/canisters/federation/src/api/inspect.rs
@@ -5,6 +5,11 @@ pub fn is_directory_canister(principal: Principal) -> bool {
     principal == crate::settings::get_directory_canister()
 }
 
+/// Inspect whether the provided [`Principal`] is a registered User Canister.
+pub fn is_user_canister(principal: Principal) -> bool {
+    crate::directory::get_user_by_canister_id(&principal).is_some()
+}
+
 #[cfg(test)]
 mod tests {
 
@@ -16,5 +21,20 @@ mod tests {
 
         assert!(is_directory_canister(crate::test_utils::directory()));
         assert!(!is_directory_canister(crate::test_utils::alice()));
+    }
+
+    #[test]
+    fn test_should_check_if_user_canister() {
+        crate::test_utils::setup();
+
+        // add alice
+        crate::directory::insert_user(
+            crate::test_utils::alice(),
+            "alice".to_string(),
+            crate::test_utils::alice(),
+        );
+
+        assert!(is_user_canister(crate::test_utils::alice()));
+        assert!(!is_user_canister(crate::test_utils::directory()));
     }
 }

--- a/crates/canisters/federation/src/api/inspect.rs
+++ b/crates/canisters/federation/src/api/inspect.rs
@@ -1,0 +1,20 @@
+use candid::Principal;
+
+/// Inspect whether the provided [`Principal`] is the directory canister.
+pub fn is_directory_canister(principal: Principal) -> bool {
+    principal == crate::settings::get_directory_canister()
+}
+
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+
+    #[test]
+    fn test_should_check_if_directory_canister() {
+        crate::test_utils::setup();
+
+        assert!(is_directory_canister(crate::test_utils::directory()));
+        assert!(!is_directory_canister(crate::test_utils::alice()));
+    }
+}

--- a/crates/canisters/federation/src/directory.rs
+++ b/crates/canisters/federation/src/directory.rs
@@ -1,0 +1,214 @@
+//! Directory user data
+
+use std::cell::RefCell;
+
+use candid::Principal;
+use ic_stable_structures::memory_manager::VirtualMemory;
+use ic_stable_structures::{DefaultMemoryImpl, StableBTreeMap};
+
+use crate::memory::{
+    MEMORY_MANAGER, StorablePrincipal, USER_DATA_BY_HANDLE_MEMORY_ID, USER_DATA_BY_ID_MEMORY_ID,
+    USER_DATA_MEMORY_ID, UserData,
+};
+
+thread_local! {
+
+    /// Secondary index: maps a user's IC principal to the numeric key in [`USER_DATA`].
+    static USER_DATA_BY_ID: RefCell<StableBTreeMap<StorablePrincipal, u64, VirtualMemory<DefaultMemoryImpl>>> =
+        RefCell::new(StableBTreeMap::new(MEMORY_MANAGER.with(|mm| mm.get(USER_DATA_BY_ID_MEMORY_ID))));
+
+    /// Secondary index: maps a user handle (e.g. `"alice"`) to the numeric key in [`USER_DATA`].
+    static USER_DATA_BY_HANDLE: RefCell<StableBTreeMap<String, u64, VirtualMemory<DefaultMemoryImpl>>> =
+        RefCell::new(StableBTreeMap::new(MEMORY_MANAGER.with(|mm| mm.get(USER_DATA_BY_HANDLE_MEMORY_ID))));
+
+    /// Primary store: maps an auto-incremented numeric key to [`UserData`].
+    static USER_DATA: RefCell<StableBTreeMap<u64, UserData, VirtualMemory<DefaultMemoryImpl>>> =
+        RefCell::new(StableBTreeMap::new(MEMORY_MANAGER.with(|mm| mm.get(USER_DATA_MEMORY_ID))));
+
+}
+
+/// Insert a new user into the directory, returning the assigned user ID.
+pub fn insert_user(user_id: Principal, user_handle: String, user_canister_id: Principal) {
+    let next_id = USER_DATA.with_borrow(|m| m.len());
+
+    let user_data = UserData {
+        user_id,
+        user_handle: user_handle.clone(),
+        user_canister_id,
+    };
+
+    USER_DATA.with_borrow_mut(|data| data.insert(next_id, user_data));
+    USER_DATA_BY_ID.with_borrow_mut(|index| index.insert(StorablePrincipal(user_id), next_id));
+    USER_DATA_BY_HANDLE.with_borrow_mut(|index| index.insert(user_handle, next_id));
+}
+
+/// Get user data by user ID, returning `None` if no user with the given ID exists.
+#[allow(
+    dead_code,
+    reason = "will be used by activity routing in a later milestone"
+)]
+pub fn get_user_by_id(user_id: &Principal) -> Option<UserData> {
+    let key = USER_DATA_BY_ID.with_borrow(|data| data.get(&StorablePrincipal(*user_id)))?;
+
+    USER_DATA.with_borrow(|data| data.get(&key))
+}
+
+/// Get user data by handle, returning `None` if no user with the given handle exists.
+#[allow(
+    dead_code,
+    reason = "will be used by activity routing in a later milestone"
+)]
+pub fn get_user_by_handle(user_handle: &String) -> Option<UserData> {
+    let key = USER_DATA_BY_HANDLE.with_borrow(|data| data.get(user_handle))?;
+
+    USER_DATA.with_borrow(|data| data.get(&key))
+}
+
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+
+    /// Clears all three thread-local maps so tests are independent of execution order.
+    fn reset_state() {
+        USER_DATA.with_borrow_mut(|m| {
+            let keys: Vec<_> = m.iter().map(|entry| *entry.key()).collect();
+            for k in keys {
+                m.remove(&k);
+            }
+        });
+        USER_DATA_BY_ID.with_borrow_mut(|m| {
+            let keys: Vec<_> = m.iter().map(|entry| *entry.key()).collect();
+            for k in keys {
+                m.remove(&k);
+            }
+        });
+        USER_DATA_BY_HANDLE.with_borrow_mut(|m| {
+            let keys: Vec<_> = m.iter().map(|entry| entry.key().clone()).collect();
+            for k in keys {
+                m.remove(&k);
+            }
+        });
+    }
+
+    fn alice_principal() -> Principal {
+        Principal::from_text("mfufu-x6j4c-gomzb-geilq").unwrap()
+    }
+
+    fn alice_canister() -> Principal {
+        Principal::from_text("bkyz2-fmaaa-aaaaa-qaaaq-cai").unwrap()
+    }
+
+    fn bob_principal() -> Principal {
+        Principal::from_text("bs5l3-6b3zu-dpqyj-p2x4a-jyg4k-goneb-afof2-y5d62-skt67-3756q-dqe")
+            .unwrap()
+    }
+
+    fn bob_canister() -> Principal {
+        Principal::from_text("be2us-64aaa-aaaaa-qaabq-cai").unwrap()
+    }
+
+    // M-UNIT-TEST: insert_user stores data retrievable by both ID and handle.
+    #[test]
+    fn test_should_insert_and_retrieve_user_by_id() {
+        reset_state();
+
+        insert_user(alice_principal(), "alice".to_string(), alice_canister());
+
+        let user = get_user_by_id(&alice_principal()).expect("user should exist");
+        assert_eq!(user.user_id, alice_principal());
+        assert_eq!(user.user_handle, "alice");
+        assert_eq!(user.user_canister_id, alice_canister());
+    }
+
+    // M-UNIT-TEST: insert_user stores data retrievable by handle.
+    #[test]
+    fn test_should_insert_and_retrieve_user_by_handle() {
+        reset_state();
+
+        insert_user(alice_principal(), "alice".to_string(), alice_canister());
+
+        let user =
+            get_user_by_handle(&"alice".to_string()).expect("user should be found by handle");
+        assert_eq!(user.user_id, alice_principal());
+        assert_eq!(user.user_handle, "alice");
+        assert_eq!(user.user_canister_id, alice_canister());
+    }
+
+    // M-UNIT-TEST: get_user_by_id returns None for an unknown principal.
+    #[test]
+    fn test_should_return_none_for_unknown_id() {
+        reset_state();
+
+        assert!(get_user_by_id(&alice_principal()).is_none());
+    }
+
+    // M-UNIT-TEST: get_user_by_handle returns None for an unknown handle.
+    #[test]
+    fn test_should_return_none_for_unknown_handle() {
+        reset_state();
+
+        assert!(get_user_by_handle(&"nonexistent".to_string()).is_none());
+    }
+
+    // M-UNIT-TEST: multiple users can be inserted and retrieved independently.
+    #[test]
+    fn test_should_insert_multiple_users() {
+        reset_state();
+
+        insert_user(alice_principal(), "alice".to_string(), alice_canister());
+        insert_user(bob_principal(), "bob".to_string(), bob_canister());
+
+        let alice = get_user_by_id(&alice_principal()).expect("alice should exist");
+        assert_eq!(alice.user_handle, "alice");
+        assert_eq!(alice.user_canister_id, alice_canister());
+
+        let bob = get_user_by_id(&bob_principal()).expect("bob should exist");
+        assert_eq!(bob.user_handle, "bob");
+        assert_eq!(bob.user_canister_id, bob_canister());
+    }
+
+    // M-UNIT-TEST: both indexes point to the same user for the same insert.
+    #[test]
+    fn test_should_return_consistent_data_across_indexes() {
+        reset_state();
+
+        insert_user(alice_principal(), "alice".to_string(), alice_canister());
+
+        let by_id = get_user_by_id(&alice_principal()).expect("by_id lookup");
+        let by_handle = get_user_by_handle(&"alice".to_string()).expect("by_handle lookup");
+
+        assert_eq!(by_id, by_handle);
+    }
+
+    // M-UNIT-TEST: auto-incremented keys are unique across inserts.
+    #[test]
+    fn test_should_assign_sequential_keys() {
+        reset_state();
+
+        insert_user(alice_principal(), "alice".to_string(), alice_canister());
+        insert_user(bob_principal(), "bob".to_string(), bob_canister());
+
+        let alice_key =
+            USER_DATA_BY_ID.with_borrow(|m| m.get(&StorablePrincipal(alice_principal())));
+        let bob_key = USER_DATA_BY_ID.with_borrow(|m| m.get(&StorablePrincipal(bob_principal())));
+
+        assert_eq!(alice_key, Some(0));
+        assert_eq!(bob_key, Some(1));
+    }
+
+    // M-UNIT-TEST: retrieving bob does not return alice's data.
+    #[test]
+    fn test_should_not_cross_contaminate_users() {
+        reset_state();
+
+        insert_user(alice_principal(), "alice".to_string(), alice_canister());
+        insert_user(bob_principal(), "bob".to_string(), bob_canister());
+
+        let alice = get_user_by_handle(&"alice".to_string()).unwrap();
+        let bob = get_user_by_handle(&"bob".to_string()).unwrap();
+
+        assert_ne!(alice.user_id, bob.user_id);
+        assert_ne!(alice.user_canister_id, bob.user_canister_id);
+    }
+}

--- a/crates/canisters/federation/src/directory.rs
+++ b/crates/canisters/federation/src/directory.rs
@@ -7,8 +7,8 @@ use ic_stable_structures::memory_manager::VirtualMemory;
 use ic_stable_structures::{DefaultMemoryImpl, StableBTreeMap};
 
 use crate::memory::{
-    MEMORY_MANAGER, StorablePrincipal, USER_DATA_BY_HANDLE_MEMORY_ID, USER_DATA_BY_ID_MEMORY_ID,
-    USER_DATA_MEMORY_ID, UserData,
+    MEMORY_MANAGER, StorablePrincipal, USER_DATA_BY_CANISTER_ID_MEMORY_ID,
+    USER_DATA_BY_HANDLE_MEMORY_ID, USER_DATA_BY_ID_MEMORY_ID, USER_DATA_MEMORY_ID, UserData,
 };
 
 thread_local! {
@@ -20,6 +20,11 @@ thread_local! {
     /// Secondary index: maps a user handle (e.g. `"alice"`) to the numeric key in [`USER_DATA`].
     static USER_DATA_BY_HANDLE: RefCell<StableBTreeMap<String, u64, VirtualMemory<DefaultMemoryImpl>>> =
         RefCell::new(StableBTreeMap::new(MEMORY_MANAGER.with(|mm| mm.get(USER_DATA_BY_HANDLE_MEMORY_ID))));
+
+    /// Secondary index: maps a User Canister principal to the numeric key in [`USER_DATA`].
+    /// Used by `send_activity` to authorize inbound calls.
+    static USER_DATA_BY_CANISTER_ID: RefCell<StableBTreeMap<StorablePrincipal, u64, VirtualMemory<DefaultMemoryImpl>>> =
+        RefCell::new(StableBTreeMap::new(MEMORY_MANAGER.with(|mm| mm.get(USER_DATA_BY_CANISTER_ID_MEMORY_ID))));
 
     /// Primary store: maps an auto-incremented numeric key to [`UserData`].
     static USER_DATA: RefCell<StableBTreeMap<u64, UserData, VirtualMemory<DefaultMemoryImpl>>> =
@@ -40,6 +45,17 @@ pub fn insert_user(user_id: Principal, user_handle: String, user_canister_id: Pr
     USER_DATA.with_borrow_mut(|data| data.insert(next_id, user_data));
     USER_DATA_BY_ID.with_borrow_mut(|index| index.insert(StorablePrincipal(user_id), next_id));
     USER_DATA_BY_HANDLE.with_borrow_mut(|index| index.insert(user_handle, next_id));
+    USER_DATA_BY_CANISTER_ID
+        .with_borrow_mut(|index| index.insert(StorablePrincipal(user_canister_id), next_id));
+}
+
+/// Get user data by User Canister principal, returning `None` if no user with
+/// the given canister principal exists.
+pub fn get_user_by_canister_id(user_canister_id: &Principal) -> Option<UserData> {
+    let key = USER_DATA_BY_CANISTER_ID
+        .with_borrow(|data| data.get(&StorablePrincipal(*user_canister_id)))?;
+
+    USER_DATA.with_borrow(|data| data.get(&key))
 }
 
 /// Get user data by user ID, returning `None` if no user with the given ID exists.
@@ -54,10 +70,6 @@ pub fn get_user_by_id(user_id: &Principal) -> Option<UserData> {
 }
 
 /// Get user data by handle, returning `None` if no user with the given handle exists.
-#[allow(
-    dead_code,
-    reason = "will be used by activity routing in a later milestone"
-)]
 pub fn get_user_by_handle(user_handle: &String) -> Option<UserData> {
     let key = USER_DATA_BY_HANDLE.with_borrow(|data| data.get(user_handle))?;
 

--- a/crates/canisters/federation/src/domain.rs
+++ b/crates/canisters/federation/src/domain.rs
@@ -1,0 +1,3 @@
+//! Federation canister domain logic.
+
+pub mod activity;

--- a/crates/canisters/federation/src/domain/activity.rs
+++ b/crates/canisters/federation/src/domain/activity.rs
@@ -1,0 +1,5 @@
+//! Activity domain
+
+mod send_activity;
+
+pub use self::send_activity::send_activity;

--- a/crates/canisters/federation/src/domain/activity/send_activity.rs
+++ b/crates/canisters/federation/src/domain/activity/send_activity.rs
@@ -1,0 +1,284 @@
+//! Domain logic for the `send_activity` flow.
+//!
+//! The Federation Canister acts as a dumb router for locally-originated
+//! activities: User Canister code (installed and controlled by the
+//! Directory Canister) is trusted to pre-filter recipients according to
+//! the status's visibility, so this module performs no visibility
+//! enforcement and does not parse the activity JSON. It parses the target
+//! inbox URL, resolves local targets via the Directory Canister, and
+//! forwards the opaque `activity_json` to the target User Canister. Remote
+//! targets are logged and skipped (remote HTTP delivery is Milestone 2).
+
+use did::federation::{
+    SendActivityArgs, SendActivityArgsObject, SendActivityError, SendActivityResponse,
+    SendActivityResult,
+};
+use did::user::ReceiveActivityArgs;
+use url::Url;
+
+/// Entry point for the `send_activity` canister method.
+///
+/// Dispatches each [`SendActivityArgsObject`] through
+/// [`send_activity_inner`] and aggregates the per-activity results.
+pub async fn send_activity(args: SendActivityArgs) -> SendActivityResponse {
+    match args {
+        SendActivityArgs::One(activity_args) => {
+            SendActivityResponse::One(send_activity_inner(activity_args).await)
+        }
+        SendActivityArgs::Batch(activities) => {
+            let mut results = Vec::with_capacity(activities.len());
+            for activity_args in activities {
+                results.push(send_activity_inner(activity_args).await);
+            }
+            SendActivityResponse::Batch(results)
+        }
+    }
+}
+
+/// Routes a single activity to its target inbox.
+///
+/// Parses `target_inbox`, classifies it as local or remote, and for local
+/// targets resolves the User Canister principal via the Directory Canister
+/// and invokes `receive_activity` on it. Remote targets are logged and
+/// skipped. The activity JSON is forwarded to the target canister
+/// unchanged.
+async fn send_activity_inner(args: SendActivityArgsObject) -> SendActivityResult {
+    let target = match Url::parse(&args.target_inbox) {
+        Ok(url) => url,
+        Err(err) => {
+            ic_utils::log!(
+                "send_activity_inner: invalid target_inbox {:?}: {err}",
+                args.target_inbox
+            );
+            return SendActivityResult::Err(SendActivityError::InvalidTargetInbox(err.to_string()));
+        }
+    };
+
+    let public_url_raw = crate::settings::get_public_url();
+    let public_url = match Url::parse(&public_url_raw) {
+        Ok(url) => url,
+        Err(err) => {
+            ic_utils::log!(
+                "send_activity_inner: public_url {public_url_raw:?} is not a valid URL: {err}"
+            );
+            return SendActivityResult::Err(SendActivityError::DeliveryFailed(format!(
+                "public_url misconfigured: {err}"
+            )));
+        }
+    };
+
+    if !is_local_target(&target, &public_url) {
+        ic_utils::log!(
+            "send_activity_inner: skipping remote target {target} (Mastic is currently local-only)"
+        );
+        // TODO: forward to remote instance when multi-instance support is implemented.
+        return SendActivityResult::Ok;
+    }
+
+    let handle = match extract_handle(&target) {
+        Some(handle) => handle,
+        None => {
+            ic_utils::log!("send_activity_inner: unexpected path shape for local inbox {target}");
+            return SendActivityResult::Err(SendActivityError::InvalidTargetInbox(format!(
+                "unexpected path shape: {}",
+                target.path()
+            )));
+        }
+    };
+
+    let Some(user) = crate::directory::get_user_by_handle(&handle) else {
+        ic_utils::log!("send_activity_inner: unknown local handle {handle}");
+        return SendActivityResult::Err(SendActivityError::UnknownLocalUser(handle));
+    };
+
+    let receive_args = ReceiveActivityArgs {
+        activity_json: args.activity_json,
+    };
+
+    deliver(user.user_canister_id, receive_args).await
+}
+
+/// Returns `true` when the `target` inbox is hosted on this Mastic instance.
+fn is_local_target(target: &Url, public_url: &Url) -> bool {
+    target.host_str() == public_url.host_str()
+        && target.port_or_known_default() == public_url.port_or_known_default()
+}
+
+/// Extracts the handle from an inbox URL whose path is exactly
+/// `/users/{handle}/inbox`, returning `None` on any other path shape.
+fn extract_handle(target: &Url) -> Option<String> {
+    let mut segments = target.path_segments()?;
+    let users = segments.next()?;
+    let handle = segments.next()?;
+    let inbox = segments.next()?;
+    if segments.next().is_some() || users != "users" || inbox != "inbox" || handle.is_empty() {
+        return None;
+    }
+    Some(handle.to_string())
+}
+
+/// Invokes `receive_activity` on the target User Canister and translates
+/// the client-level outcome into a [`SendActivityResult`].
+///
+/// On non-wasm targets this uses
+/// [`crate::adapters::user::mock::MockUserCanisterClient`] so unit tests
+/// can exercise the routing logic without a replica. On wasm targets it
+/// uses [`crate::adapters::user::IcUserCanisterClient`] which performs the
+/// actual inter-canister call.
+#[cfg(not(target_family = "wasm"))]
+async fn deliver(
+    _user_canister_id: candid::Principal,
+    args: ReceiveActivityArgs,
+) -> SendActivityResult {
+    use crate::adapters::user::mock::MockUserCanisterClient;
+    use crate::adapters::user::{UserCanister, UserCanisterClientError};
+
+    match MockUserCanisterClient.receive_activity(args).await {
+        Ok(()) => SendActivityResult::Ok,
+        Err(UserCanisterClientError::Rejected(e)) => {
+            SendActivityResult::Err(SendActivityError::Rejected(e))
+        }
+        Err(e) => SendActivityResult::Err(SendActivityError::DeliveryFailed(e.to_string())),
+    }
+}
+
+/// Wasm implementation of [`deliver`] that performs the real
+/// inter-canister call via [`crate::adapters::user::IcUserCanisterClient`].
+#[cfg(target_family = "wasm")]
+async fn deliver(
+    user_canister_id: candid::Principal,
+    args: ReceiveActivityArgs,
+) -> SendActivityResult {
+    use crate::adapters::user::{IcUserCanisterClient, UserCanister, UserCanisterClientError};
+
+    match IcUserCanisterClient::from(user_canister_id)
+        .receive_activity(args)
+        .await
+    {
+        Ok(()) => SendActivityResult::Ok,
+        Err(UserCanisterClientError::Rejected(e)) => {
+            SendActivityResult::Err(SendActivityError::Rejected(e))
+        }
+        Err(e) => SendActivityResult::Err(SendActivityError::DeliveryFailed(e.to_string())),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use candid::Principal;
+
+    use super::*;
+    use crate::test_utils::{public_url, setup};
+
+    fn alice_canister() -> Principal {
+        Principal::from_text("bkyz2-fmaaa-aaaaa-qaaaq-cai").unwrap()
+    }
+
+    fn alice_user_principal() -> Principal {
+        Principal::from_text("mfufu-x6j4c-gomzb-geilq").unwrap()
+    }
+
+    fn seed_alice() {
+        crate::directory::insert_user(
+            alice_user_principal(),
+            "alice".to_string(),
+            alice_canister(),
+        );
+    }
+
+    fn obj(target_inbox: &str) -> SendActivityArgsObject {
+        SendActivityArgsObject {
+            activity_json: r#"{"type":"Create"}"#.to_string(),
+            target_inbox: target_inbox.to_string(),
+        }
+    }
+
+    // M-UNIT-TEST: an unparseable target_inbox yields InvalidTargetInbox.
+    #[tokio::test]
+    async fn test_should_reject_bad_target_inbox_url() {
+        setup();
+
+        let result = send_activity_inner(obj("not a url")).await;
+
+        assert!(matches!(
+            result,
+            SendActivityResult::Err(SendActivityError::InvalidTargetInbox(_))
+        ));
+    }
+
+    // M-UNIT-TEST: a remote target (different host) is skipped with Ok.
+    #[tokio::test]
+    async fn test_should_skip_remote_target() {
+        setup();
+
+        let result = send_activity_inner(obj("https://other.social/users/alice/inbox")).await;
+
+        assert_eq!(result, SendActivityResult::Ok);
+    }
+
+    // M-UNIT-TEST: a local URL whose path is not /users/{handle}/inbox is
+    // rejected as InvalidTargetInbox.
+    #[tokio::test]
+    async fn test_should_reject_unexpected_local_path() {
+        setup();
+
+        let result = send_activity_inner(obj(&format!("{}/foo/bar", public_url()))).await;
+
+        assert!(matches!(
+            result,
+            SendActivityResult::Err(SendActivityError::InvalidTargetInbox(_))
+        ));
+    }
+
+    // M-UNIT-TEST: a local inbox whose handle is not in the directory yields
+    // UnknownLocalUser.
+    #[tokio::test]
+    async fn test_should_reject_unknown_local_handle() {
+        setup();
+
+        let result = send_activity_inner(obj(&format!("{}/users/ghost/inbox", public_url()))).await;
+
+        assert!(matches!(
+            result,
+            SendActivityResult::Err(SendActivityError::UnknownLocalUser(ref h)) if h == "ghost"
+        ));
+    }
+
+    // M-UNIT-TEST: a known local handle is routed and returns Ok when the
+    // target user canister accepts the activity.
+    #[tokio::test]
+    async fn test_should_deliver_to_known_local_handle() {
+        setup();
+        seed_alice();
+
+        let result = send_activity_inner(obj(&format!("{}/users/alice/inbox", public_url()))).await;
+
+        assert_eq!(result, SendActivityResult::Ok);
+    }
+
+    // M-UNIT-TEST: a batch call aggregates per-item routing results.
+    #[tokio::test]
+    async fn test_should_aggregate_batch_results() {
+        setup();
+        seed_alice();
+
+        let args = SendActivityArgs::Batch(vec![
+            obj(&format!("{}/users/alice/inbox", public_url())),
+            obj(&format!("{}/users/ghost/inbox", public_url())),
+        ]);
+
+        let response = send_activity(args).await;
+
+        match response {
+            SendActivityResponse::Batch(results) => {
+                assert_eq!(results.len(), 2);
+                assert_eq!(results[0], SendActivityResult::Ok);
+                assert!(matches!(
+                    results[1],
+                    SendActivityResult::Err(SendActivityError::UnknownLocalUser(ref h)) if h == "ghost"
+                ));
+            }
+            other => panic!("expected Batch response, got {other:?}"),
+        }
+    }
+}

--- a/crates/canisters/federation/src/inspect.rs
+++ b/crates/canisters/federation/src/inspect.rs
@@ -3,14 +3,26 @@
 pub fn inspect() {
     let method_name = ic_cdk::api::msg_method_name();
 
-    if method_name == "register_user" {
-        let caller = ic_utils::caller();
-        if !crate::api::inspect::is_directory_canister(caller) {
-            ic_cdk::api::msg_reject(
-                "Unauthorized caller. Only the directory canister can call this method.",
-            );
-            return;
+    match method_name.as_str() {
+        "register_user" => {
+            let caller = ic_utils::caller();
+            if !crate::api::inspect::is_directory_canister(caller) {
+                ic_cdk::api::msg_reject(
+                    "Unauthorized caller. Only the directory canister can call this method.",
+                );
+                return;
+            }
         }
+        "send_activity" => {
+            let caller = ic_utils::caller();
+            if !crate::api::inspect::is_user_canister(caller) {
+                ic_cdk::api::msg_reject(
+                    "Unauthorized caller. Only registered user canisters can call this method.",
+                );
+                return;
+            }
+        }
+        _ => {}
     }
 
     ic_cdk::api::accept_message();

--- a/crates/canisters/federation/src/inspect.rs
+++ b/crates/canisters/federation/src/inspect.rs
@@ -1,0 +1,17 @@
+//! Inspect module for user canister calls.
+
+pub fn inspect() {
+    let method_name = ic_cdk::api::msg_method_name();
+
+    if method_name == "register_user" {
+        let caller = ic_utils::caller();
+        if !crate::api::inspect::is_directory_canister(caller) {
+            ic_cdk::api::msg_reject(
+                "Unauthorized caller. Only the directory canister can call this method.",
+            );
+            return;
+        }
+    }
+
+    ic_cdk::api::accept_message();
+}

--- a/crates/canisters/federation/src/lib.rs
+++ b/crates/canisters/federation/src/lib.rs
@@ -3,10 +3,12 @@ use did::federation::{
     SendActivityResponse,
 };
 
+mod adapters;
 mod api;
-#[allow(dead_code, reason = "will be used by WI-0.10 routing logic")]
+#[allow(dead_code, reason = "will be used by future activity processing")]
 mod conversions;
 mod directory;
+mod domain;
 mod inspect;
 mod memory;
 mod settings;
@@ -35,9 +37,8 @@ fn register_user(args: RegisterUserArgs) -> RegisterUserResponse {
 }
 
 #[ic_cdk::update]
-fn send_activity(_args: SendActivityArgs) -> SendActivityResponse {
-    // TODO: no-op for now. Implement in WI-0.10
-    SendActivityResponse::Ok
+async fn send_activity(args: SendActivityArgs) -> SendActivityResponse {
+    api::send_activity(args).await
 }
 
 ic_cdk::export_candid!();

--- a/crates/canisters/federation/src/lib.rs
+++ b/crates/canisters/federation/src/lib.rs
@@ -1,8 +1,13 @@
-use did::federation::{FederationInstallArgs, SendActivityArgs, SendActivityResponse};
+use did::federation::{
+    FederationInstallArgs, RegisterUserArgs, RegisterUserResponse, SendActivityArgs,
+    SendActivityResponse,
+};
 
 mod api;
 #[allow(dead_code, reason = "will be used by WI-0.10 routing logic")]
 mod conversions;
+mod directory;
+mod inspect;
 mod memory;
 mod settings;
 
@@ -17,6 +22,16 @@ fn init(args: FederationInstallArgs) {
 #[ic_cdk::post_upgrade]
 fn post_upgrade(args: FederationInstallArgs) {
     api::post_upgrade(args);
+}
+
+#[ic_cdk::inspect_message]
+fn inspect_message() {
+    inspect::inspect();
+}
+
+#[ic_cdk::update]
+fn register_user(args: RegisterUserArgs) -> RegisterUserResponse {
+    api::register_user(args)
 }
 
 #[ic_cdk::update]

--- a/crates/canisters/federation/src/memory.rs
+++ b/crates/canisters/federation/src/memory.rs
@@ -1,15 +1,22 @@
 //! Memory management for the federation canister.
 
 mod principal;
+mod user_data;
 
 use ic_stable_structures::DefaultMemoryImpl;
 use ic_stable_structures::memory_manager::{MemoryId, MemoryManager as IcMemoryManager};
 
 pub use self::principal::StorablePrincipal;
+pub use self::user_data::UserData;
 
 // Settings memory ids
 pub const DIRECTORY_CANISTER_MEMORY_ID: MemoryId = MemoryId::new(0);
 pub const PUBLIC_URL_MEMORY_ID: MemoryId = MemoryId::new(1);
+
+// users
+pub const USER_DATA_BY_ID_MEMORY_ID: MemoryId = MemoryId::new(10);
+pub const USER_DATA_BY_HANDLE_MEMORY_ID: MemoryId = MemoryId::new(11);
+pub const USER_DATA_MEMORY_ID: MemoryId = MemoryId::new(12);
 
 thread_local! {
     /// Memory manager

--- a/crates/canisters/federation/src/memory.rs
+++ b/crates/canisters/federation/src/memory.rs
@@ -17,6 +17,7 @@ pub const PUBLIC_URL_MEMORY_ID: MemoryId = MemoryId::new(1);
 pub const USER_DATA_BY_ID_MEMORY_ID: MemoryId = MemoryId::new(10);
 pub const USER_DATA_BY_HANDLE_MEMORY_ID: MemoryId = MemoryId::new(11);
 pub const USER_DATA_MEMORY_ID: MemoryId = MemoryId::new(12);
+pub const USER_DATA_BY_CANISTER_ID_MEMORY_ID: MemoryId = MemoryId::new(13);
 
 thread_local! {
     /// Memory manager

--- a/crates/canisters/federation/src/memory/user_data.rs
+++ b/crates/canisters/federation/src/memory/user_data.rs
@@ -1,0 +1,144 @@
+use std::borrow::Cow;
+
+use candid::Principal;
+use ic_stable_structures::Storable;
+
+use crate::memory::StorablePrincipal;
+
+const MAX_HANDLE_LEN: usize = 30;
+
+/// Per-user data cached in the federation canister for fast lookups.
+///
+/// Wire layout (fixed-size regions, length-prefixed principals):
+///
+/// ```text
+/// [1 B len][29 B user_id padded][30 B handle padded][1 B len][29 B canister_id padded]
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UserData {
+    pub user_id: Principal,
+    pub user_handle: String,
+    pub user_canister_id: Principal,
+}
+
+impl UserData {
+    /// Encode a principal as 1-byte length prefix + bytes + zero-padding to 29 bytes.
+    fn encode_principal(buf: &mut Vec<u8>, principal: Principal) {
+        let storable = StorablePrincipal::from(principal);
+        let raw = storable.to_bytes();
+        buf.push(raw.len() as u8);
+        buf.extend_from_slice(&raw);
+        // pad to fixed width
+        buf.resize(
+            buf.len() + StorablePrincipal::MAX_PRINCIPAL_LENGTH_IN_BYTES - raw.len(),
+            0,
+        );
+    }
+
+    /// Decode a principal from a 1 + 29 byte window.
+    fn decode_principal(window: &[u8]) -> Principal {
+        let len = window[0] as usize;
+        *StorablePrincipal::from_bytes(Cow::Borrowed(&window[1..1 + len])).as_principal()
+    }
+}
+
+/// Size of one length-prefixed principal field.
+const PRINCIPAL_FIELD_SIZE: u32 = 1 + StorablePrincipal::MAX_PRINCIPAL_LENGTH_IN_BYTES as u32;
+
+impl Storable for UserData {
+    const BOUND: ic_stable_structures::storable::Bound =
+        ic_stable_structures::storable::Bound::Bounded {
+            max_size: PRINCIPAL_FIELD_SIZE * 2 + MAX_HANDLE_LEN as u32,
+            is_fixed_size: true,
+        };
+
+    fn to_bytes(&self) -> Cow<'_, [u8]> {
+        let mut buf =
+            Vec::with_capacity((PRINCIPAL_FIELD_SIZE * 2 + MAX_HANDLE_LEN as u32) as usize);
+
+        Self::encode_principal(&mut buf, self.user_id);
+
+        let mut handle_buf = [0u8; MAX_HANDLE_LEN];
+        handle_buf[..self.user_handle.len()].copy_from_slice(self.user_handle.as_bytes());
+        buf.extend_from_slice(&handle_buf);
+
+        Self::encode_principal(&mut buf, self.user_canister_id);
+
+        Cow::Owned(buf)
+    }
+
+    fn into_bytes(self) -> Vec<u8> {
+        self.to_bytes().into_owned()
+    }
+
+    fn from_bytes(bytes: Cow<'_, [u8]>) -> Self {
+        let bytes = bytes.as_ref();
+        let pf = PRINCIPAL_FIELD_SIZE as usize;
+
+        let user_id = Self::decode_principal(&bytes[..pf]);
+
+        let handle_start = pf;
+        let handle_end = handle_start + MAX_HANDLE_LEN;
+        let user_handle = String::from_utf8_lossy(&bytes[handle_start..handle_end])
+            .trim_end_matches('\0')
+            .to_string();
+
+        let user_canister_id = Self::decode_principal(&bytes[handle_end..handle_end + pf]);
+
+        UserData {
+            user_id,
+            user_handle,
+            user_canister_id,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+
+    #[test]
+    fn test_should_roundtrip_user_data() {
+        let data = UserData {
+            user_id: Principal::from_text("mfufu-x6j4c-gomzb-geilq").unwrap(),
+            user_handle: "alice".to_string(),
+            user_canister_id: Principal::from_text("bkyz2-fmaaa-aaaaa-qaaaq-cai").unwrap(),
+        };
+
+        let bytes = data.to_bytes();
+        let decoded = UserData::from_bytes(bytes);
+
+        assert_eq!(data, decoded);
+    }
+
+    #[test]
+    fn test_should_roundtrip_user_data_with_max_handle() {
+        let data = UserData {
+            user_id: Principal::from_slice(&[7; 29]),
+            user_handle: "a]".repeat(15),
+            user_canister_id: Principal::from_slice(&[3; 10]),
+        };
+
+        let bytes = data.to_bytes();
+        let decoded = UserData::from_bytes(bytes);
+
+        assert_eq!(data, decoded);
+    }
+
+    #[test]
+    fn test_should_produce_fixed_size_encoding() {
+        let short = UserData {
+            user_id: Principal::from_slice(&[1; 5]),
+            user_handle: "a".to_string(),
+            user_canister_id: Principal::from_slice(&[2; 5]),
+        };
+        let long = UserData {
+            user_id: Principal::from_slice(&[1; 29]),
+            user_handle: "abcdefghijklmnopqrstuvwxyz1234".to_string(),
+            user_canister_id: Principal::from_slice(&[2; 29]),
+        };
+
+        assert_eq!(short.to_bytes().len(), long.to_bytes().len());
+    }
+}

--- a/crates/canisters/federation/src/test_utils.rs
+++ b/crates/canisters/federation/src/test_utils.rs
@@ -7,6 +7,10 @@ pub fn directory() -> Principal {
     Principal::from_text("bs5l3-6b3zu-dpqyj-p2x4a-jyg4k-goneb-afof2-y5d62-skt67-3756q-dqe").unwrap()
 }
 
+pub fn alice() -> Principal {
+    Principal::from_text("bkyz2-fmaaa-aaaaa-qaaaq-cai").unwrap()
+}
+
 pub fn public_url() -> String {
     "https://mastic.social".to_string()
 }

--- a/crates/canisters/user/src/adapters/federation.rs
+++ b/crates/canisters/user/src/adapters/federation.rs
@@ -76,7 +76,7 @@ impl FederationCanister for IcFederationCanisterClient {
         &self,
         args: SendActivityArgs,
     ) -> Result<(), FederationCanisterClientError> {
-        use did::federation::SendActivityResponse;
+        use did::federation::{SendActivityResponse, SendActivityResult};
 
         ic_utils::log!("IcFederationCanisterClient::send_activity: sending send_activity request");
 
@@ -93,19 +93,21 @@ impl FederationCanister for IcFederationCanisterClient {
             FederationCanisterClientError::DecodeFailed(e.to_string())
         })?;
 
-        match response {
-            SendActivityResponse::Ok => {
-                ic_utils::log!(
-                    "IcFederationCanisterClient::send_activity: sent activity successfully"
-                );
-                Ok(())
-            }
-            SendActivityResponse::Err(e) => {
+        let results: Vec<SendActivityResult> = match response {
+            SendActivityResponse::One(result) => vec![result],
+            SendActivityResponse::Batch(results) => results,
+        };
+
+        for result in results {
+            if let SendActivityResult::Err(e) = result {
                 ic_utils::log!(
                     "IcFederationCanisterClient::send_activity: federation error: {e:?}"
                 );
-                Err(FederationCanisterClientError::CallFailed(format!("{e:?}")))
+                return Err(FederationCanisterClientError::CallFailed(format!("{e:?}")));
             }
         }
+
+        ic_utils::log!("IcFederationCanisterClient::send_activity: sent activity successfully");
+        Ok(())
     }
 }

--- a/crates/canisters/user/src/domain/status/publish.rs
+++ b/crates/canisters/user/src/domain/status/publish.rs
@@ -10,25 +10,34 @@ use did::user::{PublishStatusArgs, PublishStatusError, PublishStatusResponse};
 use crate::domain::follower::FollowerRepository;
 use crate::domain::status::StatusRepository;
 use crate::error::CanisterResult;
-use crate::schema::{Follower, StatusContentSanitizer};
+use crate::schema::StatusContentSanitizer;
 
 /// The ActivityStreams public addressing constant.
 const AS_PUBLIC: &str = "https://www.w3.org/ns/activitystreams#Public";
 
-/// Publish a new status with the given content and visibility.
+/// Publish a new status with the given content, visibility, and mentions.
 ///
 /// The publish flow consists in:
 ///
-/// 1. Sanitize and validate the content
-/// 2. Create a new status in the database with the given content and visibility, and get the generated ID.
-/// 3. Publish a new activity to federation, for each follower of the user, with a `Create(Note)` activity.
+/// 1. Sanitize and validate the content; reject empty, too-long, or
+///    [`Visibility::Direct`] with no mentioned recipients.
+/// 2. Create the status in the database and mint its snowflake ID.
+/// 3. Compute the recipient list from the visibility:
+///    - [`Visibility::Direct`]: the explicitly mentioned actors.
+///    - All other visibilities: the author's followers.
+/// 4. Emit one `Create(Note)` activity per recipient to the Federation
+///    Canister as a single batch.
 pub async fn publish_status(
     PublishStatusArgs {
         content,
         visibility,
+        mentions,
     }: PublishStatusArgs,
 ) -> PublishStatusResponse {
-    ic_utils::log!("Publishing status with content: {content} and visibility: {visibility:?}");
+    ic_utils::log!(
+        "Publishing status with content: {content}, visibility: {visibility:?}, \
+         mentions: {mentions:?}"
+    );
 
     let content = StatusContentSanitizer::sanitize_content(&content);
     if content.is_empty() {
@@ -39,8 +48,12 @@ pub async fn publish_status(
         ic_utils::log!("Status content exceeds max length");
         return PublishStatusResponse::Err(PublishStatusError::ContentTooLong);
     }
+    if visibility == Visibility::Direct && mentions.is_empty() {
+        ic_utils::log!("Direct status has no mentioned recipients");
+        return PublishStatusResponse::Err(PublishStatusError::NoRecipients);
+    }
 
-    match save_status_and_publish_to_federation(content, visibility).await {
+    match save_status_and_publish_to_federation(content, visibility, mentions).await {
         Ok(status) => PublishStatusResponse::Ok(status),
         Err(e) => {
             ic_utils::log!("Error publishing status: {e}");
@@ -55,10 +68,8 @@ pub async fn publish_status(
 async fn save_status_and_publish_to_federation(
     content: String,
     visibility: Visibility,
+    mentions: Vec<String>,
 ) -> CanisterResult<Status> {
-    // get all followers
-    let followers = FollowerRepository::get_followers()?;
-
     // insert
     let created_at = ic_utils::now();
     let snowflake_id = StatusRepository::create(content.clone(), visibility, created_at)?;
@@ -77,10 +88,20 @@ async fn save_status_and_publish_to_federation(
         visibility,
     };
 
-    let mut activities = Vec::with_capacity(followers.len());
-    for follower in followers {
-        activities.push(make_follower_activity(&follower, &status));
-    }
+    let recipients = match visibility {
+        Visibility::Direct => mentions.clone(),
+        Visibility::Public | Visibility::Unlisted | Visibility::FollowersOnly => {
+            FollowerRepository::get_followers()?
+                .into_iter()
+                .map(|f| f.actor_uri.0)
+                .collect()
+        }
+    };
+
+    let activities: Vec<SendActivityArgsObject> = recipients
+        .iter()
+        .map(|recipient_uri| make_activity(recipient_uri, &status, &mentions))
+        .collect();
     ic_utils::log!(
         "Prepared {len} activities for federation",
         len = activities.len()
@@ -94,13 +115,19 @@ async fn save_status_and_publish_to_federation(
 }
 
 /// Build a [`SendActivityArgsObject`] containing a `Create(Note)` activity
-/// addressed to a single follower.
+/// addressed to a single recipient actor.
 ///
-/// The `target_inbox` is derived by appending `/inbox` to the follower's
-/// actor URI, following the standard ActivityPub convention.
-fn make_follower_activity(follower: &Follower, status: &Status) -> SendActivityArgsObject {
+/// The `target_inbox` is derived by appending `/inbox` to the recipient's
+/// actor URI, following the standard ActivityPub convention. The activity's
+/// `to`/`cc` fields are set per [`visibility_addressing`] and augmented
+/// with the caller-supplied `mentions`.
+fn make_activity(
+    recipient_uri: &str,
+    status: &Status,
+    mentions: &[String],
+) -> SendActivityArgsObject {
     let actor = status.author.clone();
-    let (to, cc) = visibility_addressing(&status.visibility);
+    let (to, cc) = visibility_addressing(&status.visibility, mentions);
 
     let note = BaseObject {
         id: Some(status.id.to_string()),
@@ -135,21 +162,39 @@ fn make_follower_activity(follower: &Follower, status: &Status) -> SendActivityA
 
     SendActivityArgsObject {
         activity_json,
-        target_inbox: format!("{actor_uri}/inbox", actor_uri = follower.actor_uri),
+        target_inbox: format!("{recipient_uri}/inbox"),
     }
 }
 
 /// Map a [`Visibility`] value to the ActivityPub `to` and `cc` fields.
 ///
 /// Returns `(to, cc)` as optional [`OneOrMany<String>`] values following
-/// Mastodon's addressing conventions.
+/// Mastodon's addressing conventions. `mentions` are added to the
+/// appropriate field so the mentioned actors are notified:
+///
+/// - [`Visibility::Public`]: `to = [AS_PUBLIC]`, `cc = mentions`.
+/// - [`Visibility::Unlisted`]: `to = mentions`, `cc = [AS_PUBLIC]`.
+/// - [`Visibility::FollowersOnly`]: `to = mentions`, `cc = None`.
+/// - [`Visibility::Direct`]: `to = mentions`, `cc = None`.
 fn visibility_addressing(
     visibility: &Visibility,
+    mentions: &[String],
 ) -> (Option<OneOrMany<String>>, Option<OneOrMany<String>>) {
+    let mentions = vec_to_one_or_many(mentions);
     match visibility {
-        Visibility::Public => (Some(OneOrMany::One(AS_PUBLIC.to_string())), None),
-        Visibility::Unlisted => (None, Some(OneOrMany::One(AS_PUBLIC.to_string()))),
-        Visibility::FollowersOnly | Visibility::Direct => (None, None),
+        Visibility::Public => (Some(OneOrMany::One(AS_PUBLIC.to_string())), mentions),
+        Visibility::Unlisted => (mentions, Some(OneOrMany::One(AS_PUBLIC.to_string()))),
+        Visibility::FollowersOnly | Visibility::Direct => (mentions, None),
+    }
+}
+
+/// Convert a slice of strings into an optional [`OneOrMany`], returning
+/// `None` when the slice is empty.
+fn vec_to_one_or_many(items: &[String]) -> Option<OneOrMany<String>> {
+    match items.len() {
+        0 => None,
+        1 => Some(OneOrMany::One(items[0].clone())),
+        _ => Some(OneOrMany::Many(items.to_vec())),
     }
 }
 
@@ -167,6 +212,8 @@ mod tests {
     use super::*;
     use crate::schema::{Follower, FollowerInsertRequest, Schema};
     use crate::test_utils::setup;
+
+    const BOB_URI: &str = "https://remote.example/users/bob";
 
     /// Helper to insert a follower into the database for testing.
     fn insert_follower(actor_uri: &str) {
@@ -197,6 +244,7 @@ mod tests {
         let response = publish_status(PublishStatusArgs {
             content: "Hello, Fediverse!".to_string(),
             visibility: Visibility::Public,
+            mentions: vec![],
         })
         .await;
 
@@ -219,6 +267,7 @@ mod tests {
         let response = publish_status(PublishStatusArgs {
             content: "Status with followers".to_string(),
             visibility: Visibility::Public,
+            mentions: vec![],
         })
         .await;
 
@@ -236,6 +285,7 @@ mod tests {
         let response = publish_status(PublishStatusArgs {
             content: String::new(),
             visibility: Visibility::Public,
+            mentions: vec![],
         })
         .await;
 
@@ -253,6 +303,7 @@ mod tests {
         let response = publish_status(PublishStatusArgs {
             content: "   \t\n  ".to_string(),
             visibility: Visibility::Public,
+            mentions: vec![],
         })
         .await;
 
@@ -271,6 +322,7 @@ mod tests {
         let response = publish_status(PublishStatusArgs {
             content: long_content,
             visibility: Visibility::Public,
+            mentions: vec![],
         })
         .await;
 
@@ -289,6 +341,7 @@ mod tests {
         let response = publish_status(PublishStatusArgs {
             content: exact_content.clone(),
             visibility: Visibility::Public,
+            mentions: vec![],
         })
         .await;
 
@@ -305,6 +358,7 @@ mod tests {
         let response = publish_status(PublishStatusArgs {
             content: "  Hello, world!  ".to_string(),
             visibility: Visibility::Public,
+            mentions: vec![],
         })
         .await;
 
@@ -326,9 +380,15 @@ mod tests {
         ];
 
         for vis in visibilities {
+            let mentions = if vis == Visibility::Direct {
+                vec![BOB_URI.to_string()]
+            } else {
+                vec![]
+            };
             let response = publish_status(PublishStatusArgs {
                 content: format!("Status with {vis:?}"),
                 visibility: vis,
+                mentions,
             })
             .await;
 
@@ -350,6 +410,7 @@ mod tests {
         let response = publish_status(PublishStatusArgs {
             content: emoji_content.clone(),
             visibility: Visibility::Public,
+            mentions: vec![],
         })
         .await;
 
@@ -367,6 +428,7 @@ mod tests {
         let response = publish_status(PublishStatusArgs {
             content: emoji_content,
             visibility: Visibility::Public,
+            mentions: vec![],
         })
         .await;
 
@@ -386,6 +448,7 @@ mod tests {
             let response = publish_status(PublishStatusArgs {
                 content: format!("Status {i}"),
                 visibility: Visibility::Public,
+                mentions: vec![],
             })
             .await;
 
@@ -410,12 +473,18 @@ mod tests {
         }
     }
 
+    fn public_status(visibility: Visibility) -> Status {
+        Status {
+            id: 1,
+            content: format!("{visibility:?} post"),
+            author: "https://mastic.social/users/rey_canisteryo".to_string(),
+            created_at: 0,
+            visibility,
+        }
+    }
+
     #[test]
-    fn test_make_follower_activity_should_build_create_note() {
-        let follower = crate::schema::Follower {
-            actor_uri: "https://remote.example/users/bob".to_string().into(),
-            created_at: 0u64.into(),
-        };
+    fn test_make_activity_should_build_create_note() {
         let status = Status {
             id: 42,
             content: "Hello!".to_string(),
@@ -424,9 +493,9 @@ mod tests {
             visibility: Visibility::Public,
         };
 
-        let args = make_follower_activity(&follower, &status);
+        let args = make_activity(BOB_URI, &status, &[]);
 
-        assert_eq!(args.target_inbox, "https://remote.example/users/bob/inbox");
+        assert_eq!(args.target_inbox, format!("{BOB_URI}/inbox"));
 
         let activity: activitypub::activity::Activity =
             serde_json::from_str(&args.activity_json).expect("should deserialize activity");
@@ -445,20 +514,8 @@ mod tests {
     }
 
     #[test]
-    fn test_make_follower_activity_should_set_public_addressing() {
-        let follower = crate::schema::Follower {
-            actor_uri: "https://remote.example/users/bob".to_string().into(),
-            created_at: 0u64.into(),
-        };
-        let status = Status {
-            id: 1,
-            content: "Public post".to_string(),
-            author: "https://mastic.social/users/rey_canisteryo".to_string(),
-            created_at: 0,
-            visibility: Visibility::Public,
-        };
-
-        let args = make_follower_activity(&follower, &status);
+    fn test_make_activity_should_set_public_addressing() {
+        let args = make_activity(BOB_URI, &public_status(Visibility::Public), &[]);
         let activity: activitypub::activity::Activity =
             serde_json::from_str(&args.activity_json).expect("should deserialize");
 
@@ -470,20 +527,8 @@ mod tests {
     }
 
     #[test]
-    fn test_make_follower_activity_should_set_unlisted_addressing() {
-        let follower = crate::schema::Follower {
-            actor_uri: "https://remote.example/users/bob".to_string().into(),
-            created_at: 0u64.into(),
-        };
-        let status = Status {
-            id: 1,
-            content: "Unlisted post".to_string(),
-            author: "https://mastic.social/users/rey_canisteryo".to_string(),
-            created_at: 0,
-            visibility: Visibility::Unlisted,
-        };
-
-        let args = make_follower_activity(&follower, &status);
+    fn test_make_activity_should_set_unlisted_addressing() {
+        let args = make_activity(BOB_URI, &public_status(Visibility::Unlisted), &[]);
         let activity: activitypub::activity::Activity =
             serde_json::from_str(&args.activity_json).expect("should deserialize");
 
@@ -495,20 +540,8 @@ mod tests {
     }
 
     #[test]
-    fn test_make_follower_activity_should_set_followers_only_addressing() {
-        let follower = crate::schema::Follower {
-            actor_uri: "https://remote.example/users/bob".to_string().into(),
-            created_at: 0u64.into(),
-        };
-        let status = Status {
-            id: 1,
-            content: "Followers only post".to_string(),
-            author: "https://mastic.social/users/rey_canisteryo".to_string(),
-            created_at: 0,
-            visibility: Visibility::FollowersOnly,
-        };
-
-        let args = make_follower_activity(&follower, &status);
+    fn test_make_activity_should_set_followers_only_addressing() {
+        let args = make_activity(BOB_URI, &public_status(Visibility::FollowersOnly), &[]);
         let activity: activitypub::activity::Activity =
             serde_json::from_str(&args.activity_json).expect("should deserialize");
 
@@ -517,52 +550,107 @@ mod tests {
     }
 
     #[test]
-    fn test_make_follower_activity_should_set_direct_addressing() {
-        let follower = crate::schema::Follower {
-            actor_uri: "https://remote.example/users/bob".to_string().into(),
-            created_at: 0u64.into(),
-        };
-        let status = Status {
-            id: 1,
-            content: "Direct post".to_string(),
-            author: "https://mastic.social/users/rey_canisteryo".to_string(),
-            created_at: 0,
-            visibility: Visibility::Direct,
-        };
-
-        let args = make_follower_activity(&follower, &status);
+    fn test_make_activity_should_set_direct_addressing_with_mentions() {
+        let args = make_activity(
+            BOB_URI,
+            &public_status(Visibility::Direct),
+            &[BOB_URI.to_string()],
+        );
         let activity: activitypub::activity::Activity =
             serde_json::from_str(&args.activity_json).expect("should deserialize");
 
-        assert!(activity.base.to.is_none());
+        assert_eq!(activity.base.to, Some(OneOrMany::One(BOB_URI.to_string())));
         assert!(activity.base.cc.is_none());
     }
 
     #[test]
-    fn test_visibility_addressing_public() {
-        let (to, cc) = visibility_addressing(&Visibility::Public);
+    fn test_make_activity_should_include_mentions_in_cc_for_public() {
+        let mentions = vec![BOB_URI.to_string()];
+        let args = make_activity(BOB_URI, &public_status(Visibility::Public), &mentions);
+        let activity: activitypub::activity::Activity =
+            serde_json::from_str(&args.activity_json).expect("should deserialize");
+
+        assert_eq!(
+            activity.base.to,
+            Some(OneOrMany::One(AS_PUBLIC.to_string()))
+        );
+        assert_eq!(activity.base.cc, Some(OneOrMany::One(BOB_URI.to_string())));
+    }
+
+    #[test]
+    fn test_visibility_addressing_public_no_mentions() {
+        let (to, cc) = visibility_addressing(&Visibility::Public, &[]);
         assert_eq!(to, Some(OneOrMany::One(AS_PUBLIC.to_string())));
         assert!(cc.is_none());
     }
 
     #[test]
-    fn test_visibility_addressing_unlisted() {
-        let (to, cc) = visibility_addressing(&Visibility::Unlisted);
+    fn test_visibility_addressing_unlisted_no_mentions() {
+        let (to, cc) = visibility_addressing(&Visibility::Unlisted, &[]);
         assert!(to.is_none());
         assert_eq!(cc, Some(OneOrMany::One(AS_PUBLIC.to_string())));
     }
 
     #[test]
-    fn test_visibility_addressing_followers_only() {
-        let (to, cc) = visibility_addressing(&Visibility::FollowersOnly);
+    fn test_visibility_addressing_followers_only_no_mentions() {
+        let (to, cc) = visibility_addressing(&Visibility::FollowersOnly, &[]);
         assert!(to.is_none());
         assert!(cc.is_none());
     }
 
     #[test]
-    fn test_visibility_addressing_direct() {
-        let (to, cc) = visibility_addressing(&Visibility::Direct);
-        assert!(to.is_none());
+    fn test_visibility_addressing_direct_with_mentions() {
+        let mentions = vec![BOB_URI.to_string()];
+        let (to, cc) = visibility_addressing(&Visibility::Direct, &mentions);
+        assert_eq!(to, Some(OneOrMany::One(BOB_URI.to_string())));
         assert!(cc.is_none());
+    }
+
+    #[test]
+    fn test_visibility_addressing_direct_with_multiple_mentions() {
+        let mentions = vec![
+            BOB_URI.to_string(),
+            "https://remote.example/users/carol".to_string(),
+        ];
+        let (to, cc) = visibility_addressing(&Visibility::Direct, &mentions);
+        assert_eq!(to, Some(OneOrMany::Many(mentions)));
+        assert!(cc.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_should_reject_direct_without_mentions() {
+        setup();
+
+        let response = publish_status(PublishStatusArgs {
+            content: "Secret".to_string(),
+            visibility: Visibility::Direct,
+            mentions: vec![],
+        })
+        .await;
+
+        assert_eq!(
+            response,
+            PublishStatusResponse::Err(PublishStatusError::NoRecipients),
+        );
+        assert_eq!(count_statuses(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_should_publish_direct_with_mentions() {
+        setup();
+        insert_follower("https://remote.example/users/carol");
+
+        let response = publish_status(PublishStatusArgs {
+            content: "Hi Bob".to_string(),
+            visibility: Visibility::Direct,
+            mentions: vec![BOB_URI.to_string()],
+        })
+        .await;
+
+        let PublishStatusResponse::Ok(status) = response else {
+            panic!("expected Ok, got {response:?}");
+        };
+        assert_eq!(status.visibility, Visibility::Direct);
+        assert_eq!(count_statuses(), 1);
     }
 }

--- a/crates/libs/did/src/federation.rs
+++ b/crates/libs/did/src/federation.rs
@@ -125,19 +125,41 @@ pub enum SendActivityArgs {
 }
 
 /// Error type returned by the `send_activity` method of the Federation canister.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, CandidType, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, CandidType, Serialize, Deserialize)]
 pub enum SendActivityError {
-    /// the caller is not a registered User Canister.
-    Unauthorized,
-    /// the HTTP request to the target inbox failed.
-    DeliveryFailed,
-    /// the JSON could not be parsed as a valid ActivityPub activity.
-    InvalidActivity,
+    /// The `target_inbox` URL failed to parse or has an unexpected path shape.
+    InvalidTargetInbox(String),
+    /// The local inbox references a handle that is not registered in the
+    /// Directory Canister.
+    UnknownLocalUser(String),
+    /// The inter-canister call to the target User Canister failed (transport
+    /// or decode).
+    DeliveryFailed(String),
+    /// The target User Canister accepted the call but rejected the activity.
+    Rejected(String),
+}
+
+/// Per-activity outcome of a `send_activity` call.
+///
+/// Carries the delivery result for a single [`SendActivityArgsObject`]. Batch
+/// calls return one result per input object, index-aligned with the request.
+#[derive(Debug, Clone, PartialEq, Eq, CandidType, Serialize, Deserialize)]
+pub enum SendActivityResult {
+    Ok,
+    Err(SendActivityError),
 }
 
 /// Response type for the `send_activity` method of the Federation canister.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, CandidType, Serialize, Deserialize)]
+///
+/// Mirrors the shape of [`SendActivityArgs`]: a [`SendActivityArgs::One`]
+/// request returns [`SendActivityResponse::One`], and a
+/// [`SendActivityArgs::Batch`] request returns [`SendActivityResponse::Batch`]
+/// with one [`SendActivityResult`] per input object in the same order.
+#[derive(Debug, Clone, PartialEq, Eq, CandidType, Serialize, Deserialize)]
 pub enum SendActivityResponse {
-    Ok,
-    Err(SendActivityError),
+    /// Outcome for a single activity delivery.
+    One(SendActivityResult),
+    /// Per-activity outcomes for a batch delivery, index-aligned with the
+    /// request.
+    Batch(Vec<SendActivityResult>),
 }

--- a/crates/libs/did/src/federation.rs
+++ b/crates/libs/did/src/federation.rs
@@ -3,7 +3,7 @@
 #[cfg(test)]
 mod tests;
 
-use candid::CandidType;
+use candid::{CandidType, Principal};
 use serde::{Deserialize, Serialize};
 
 /// Install arguments for the Federation canister.
@@ -83,6 +83,27 @@ pub struct Activity {
     pub cc: Vec<String>,
     /// Publication timestamp in RFC 3339 format.
     pub published: Option<String>,
+}
+
+/// Arguments for the `register_user` method of the Federation canister.
+#[derive(Debug, Clone, PartialEq, Eq, CandidType, Serialize, Deserialize)]
+pub struct RegisterUserArgs {
+    pub user_id: Principal,
+    pub user_handle: String,
+    pub user_canister_id: Principal,
+}
+
+/// Response type for the `register_user` method of the Federation canister.
+#[derive(Debug, Clone, PartialEq, Eq, CandidType, Serialize, Deserialize)]
+pub enum RegisterUserResponse {
+    Ok,
+    Err(RegisterUserError),
+}
+
+/// Error type returned by the `register_user` method of the Federation canister.
+#[derive(Debug, Clone, PartialEq, Eq, CandidType, Serialize, Deserialize)]
+pub enum RegisterUserError {
+    Internal(String),
 }
 
 /// An object sent to the `send_activity` inside of [`SendActivityArgs`] for a single activity.

--- a/crates/libs/did/src/federation/tests.rs
+++ b/crates/libs/did/src/federation/tests.rs
@@ -153,9 +153,10 @@ fn test_should_roundtrip_send_activity_args_batch() {
 #[test]
 fn test_should_roundtrip_send_activity_error() {
     for error in [
-        SendActivityError::Unauthorized,
-        SendActivityError::DeliveryFailed,
-        SendActivityError::InvalidActivity,
+        SendActivityError::InvalidTargetInbox("bad url".to_string()),
+        SendActivityError::UnknownLocalUser("alice".to_string()),
+        SendActivityError::DeliveryFailed("call trapped".to_string()),
+        SendActivityError::Rejected("user rejected".to_string()),
     ] {
         let bytes = Encode!(&error).unwrap();
         let decoded = Decode!(&bytes, SendActivityError).unwrap();
@@ -164,23 +165,50 @@ fn test_should_roundtrip_send_activity_error() {
 }
 
 #[test]
-fn test_should_roundtrip_send_activity_response_ok() {
-    let resp = SendActivityResponse::Ok;
+fn test_should_roundtrip_send_activity_result_ok() {
+    let result = SendActivityResult::Ok;
+    let bytes = Encode!(&result).unwrap();
+    let decoded = Decode!(&bytes, SendActivityResult).unwrap();
+    assert_eq!(result, decoded);
+}
+
+#[test]
+fn test_should_roundtrip_send_activity_result_err() {
+    for error in [
+        SendActivityError::InvalidTargetInbox("bad url".to_string()),
+        SendActivityError::UnknownLocalUser("alice".to_string()),
+        SendActivityError::DeliveryFailed("call trapped".to_string()),
+        SendActivityError::Rejected("user rejected".to_string()),
+    ] {
+        let result = SendActivityResult::Err(error);
+        let bytes = Encode!(&result).unwrap();
+        let decoded = Decode!(&bytes, SendActivityResult).unwrap();
+        assert_eq!(result, decoded);
+    }
+}
+
+// M-UNIT-TEST: SendActivityResponse::One round-trips through Candid encoding.
+#[test]
+fn test_should_roundtrip_send_activity_response_one() {
+    let resp = SendActivityResponse::One(SendActivityResult::Ok);
     let bytes = Encode!(&resp).unwrap();
     let decoded = Decode!(&bytes, SendActivityResponse).unwrap();
     assert_eq!(resp, decoded);
 }
 
+// M-UNIT-TEST: SendActivityResponse::Batch round-trips through Candid encoding
+// with a mix of success and error outcomes.
 #[test]
-fn test_should_roundtrip_send_activity_response_err() {
-    for error in [
-        SendActivityError::Unauthorized,
-        SendActivityError::DeliveryFailed,
-        SendActivityError::InvalidActivity,
-    ] {
-        let resp = SendActivityResponse::Err(error);
-        let bytes = Encode!(&resp).unwrap();
-        let decoded = Decode!(&bytes, SendActivityResponse).unwrap();
-        assert_eq!(resp, decoded);
-    }
+fn test_should_roundtrip_send_activity_response_batch() {
+    let resp = SendActivityResponse::Batch(vec![
+        SendActivityResult::Ok,
+        SendActivityResult::Err(SendActivityError::DeliveryFailed(
+            "call trapped".to_string(),
+        )),
+        SendActivityResult::Err(SendActivityError::UnknownLocalUser("alice".to_string())),
+        SendActivityResult::Err(SendActivityError::Rejected("user rejected".to_string())),
+    ]);
+    let bytes = Encode!(&resp).unwrap();
+    let decoded = Decode!(&bytes, SendActivityResponse).unwrap();
+    assert_eq!(resp, decoded);
 }

--- a/crates/libs/did/src/federation/tests.rs
+++ b/crates/libs/did/src/federation/tests.rs
@@ -79,6 +79,37 @@ fn test_should_roundtrip_federation_install_args_upgrade() {
     assert_eq!(args, decoded);
 }
 
+// M-UNIT-TEST: RegisterUserArgs round-trips through Candid encoding.
+#[test]
+fn test_should_roundtrip_register_user_args() {
+    let args = RegisterUserArgs {
+        user_id: candid::Principal::from_text("mfufu-x6j4c-gomzb-geilq").unwrap(),
+        user_handle: "alice".to_string(),
+        user_canister_id: candid::Principal::from_text("bkyz2-fmaaa-aaaaa-qaaaq-cai").unwrap(),
+    };
+    let bytes = Encode!(&args).unwrap();
+    let decoded = Decode!(&bytes, RegisterUserArgs).unwrap();
+    assert_eq!(args, decoded);
+}
+
+// M-UNIT-TEST: RegisterUserResponse::Ok round-trips through Candid encoding.
+#[test]
+fn test_should_roundtrip_register_user_response_ok() {
+    let resp = RegisterUserResponse::Ok;
+    let bytes = Encode!(&resp).unwrap();
+    let decoded = Decode!(&bytes, RegisterUserResponse).unwrap();
+    assert_eq!(resp, decoded);
+}
+
+// M-UNIT-TEST: RegisterUserResponse::Err round-trips through Candid encoding.
+#[test]
+fn test_should_roundtrip_register_user_response_err() {
+    let resp = RegisterUserResponse::Err(RegisterUserError::Internal("db failure".to_string()));
+    let bytes = Encode!(&resp).unwrap();
+    let decoded = Decode!(&bytes, RegisterUserResponse).unwrap();
+    assert_eq!(resp, decoded);
+}
+
 #[test]
 fn test_should_roundtrip_send_activity_args_object() {
     let args = SendActivityArgsObject {
@@ -96,6 +127,24 @@ fn test_should_roundtrip_send_activity_args() {
         activity_json: r#"{"type":"Create"}"#.to_string(),
         target_inbox: "https://remote.example/inbox".to_string(),
     });
+    let bytes = Encode!(&args).unwrap();
+    let decoded = Decode!(&bytes, SendActivityArgs).unwrap();
+    assert_eq!(args, decoded);
+}
+
+// M-UNIT-TEST: SendActivityArgs::Batch round-trips through Candid encoding.
+#[test]
+fn test_should_roundtrip_send_activity_args_batch() {
+    let args = SendActivityArgs::Batch(vec![
+        SendActivityArgsObject {
+            activity_json: r#"{"type":"Create"}"#.to_string(),
+            target_inbox: "https://remote.example/inbox".to_string(),
+        },
+        SendActivityArgsObject {
+            activity_json: r#"{"type":"Follow"}"#.to_string(),
+            target_inbox: "https://other.example/inbox".to_string(),
+        },
+    ]);
     let bytes = Encode!(&args).unwrap();
     let decoded = Decode!(&bytes, SendActivityArgs).unwrap();
     assert_eq!(args, decoded);

--- a/crates/libs/did/src/user.rs
+++ b/crates/libs/did/src/user.rs
@@ -277,6 +277,11 @@ pub struct PublishStatusArgs {
     pub content: String,
     /// Audience control for this status.
     pub visibility: Visibility,
+    /// Actor URIs explicitly mentioned by the author. Required (non-empty)
+    /// for [`Visibility::Direct`]; optional for other visibilities, where
+    /// the entries are carried as additional `cc` addressees so the
+    /// mentioned actors are notified.
+    pub mentions: Vec<String>,
 }
 
 /// Error types for the `publish_status` method.
@@ -288,6 +293,9 @@ pub enum PublishStatusError {
     ContentEmpty,
     /// The content exceeds the maximum allowed length.
     ContentTooLong,
+    /// A [`Visibility::Direct`] status was published without any mentioned
+    /// recipients.
+    NoRecipients,
     /// Internal error occurred while publishing the status.
     Internal(String),
 }

--- a/crates/libs/did/src/user/tests.rs
+++ b/crates/libs/did/src/user/tests.rs
@@ -335,6 +335,7 @@ fn test_should_roundtrip_publish_status_args() {
     let args = PublishStatusArgs {
         content: "Hello, world!".to_string(),
         visibility: crate::common::Visibility::Public,
+        mentions: vec!["https://mastic.social/users/alice".to_string()],
     };
     let bytes = Encode!(&args).unwrap();
     let decoded = Decode!(&bytes, PublishStatusArgs).unwrap();
@@ -361,6 +362,8 @@ fn test_should_roundtrip_publish_status_response_err() {
         PublishStatusError::Unauthorized,
         PublishStatusError::ContentEmpty,
         PublishStatusError::ContentTooLong,
+        PublishStatusError::NoRecipients,
+        PublishStatusError::Internal("db".to_string()),
     ] {
         let resp = PublishStatusResponse::Err(error);
         let bytes = Encode!(&resp).unwrap();

--- a/docs/src/federation.did
+++ b/docs/src/federation.did
@@ -36,15 +36,35 @@ type SendActivityArgsObject = record {
 };
 // Error type returned by the `send_activity` method of the Federation canister.
 type SendActivityError = variant {
-  // the caller is not a registered User Canister.
-  Unauthorized;
-  // the JSON could not be parsed as a valid ActivityPub activity.
-  InvalidActivity;
-  // the HTTP request to the target inbox failed.
-  DeliveryFailed;
+  // The local inbox references a handle that is not registered in the
+  // Directory Canister.
+  UnknownLocalUser : text;
+  // The `target_inbox` URL failed to parse or has an unexpected path shape.
+  InvalidTargetInbox : text;
+  // The target User Canister accepted the call but rejected the activity.
+  Rejected : text;
+  // The inter-canister call to the target User Canister failed (transport
+  // or decode).
+  DeliveryFailed : text;
 };
 // Response type for the `send_activity` method of the Federation canister.
-type SendActivityResponse = variant { Ok; Err : SendActivityError };
+// 
+// Mirrors the shape of [`SendActivityArgs`]: a [`SendActivityArgs::One`]
+// request returns [`SendActivityResponse::One`], and a
+// [`SendActivityArgs::Batch`] request returns [`SendActivityResponse::Batch`]
+// with one [`SendActivityResult`] per input object in the same order.
+type SendActivityResponse = variant {
+  // Outcome for a single activity delivery.
+  One : SendActivityResult;
+  // Per-activity outcomes for a batch delivery, index-aligned with the
+  // request.
+  Batch : vec SendActivityResult;
+};
+// Per-activity outcome of a `send_activity` call.
+// 
+// Carries the delivery result for a single [`SendActivityArgsObject`]. Batch
+// calls return one result per input object, index-aligned with the request.
+type SendActivityResult = variant { Ok; Err : SendActivityError };
 service : (FederationInstallArgs) -> {
   register_user : (RegisterUserArgs) -> (RegisterUserResponse);
   send_activity : (SendActivityArgs) -> (SendActivityResponse);

--- a/docs/src/federation.did
+++ b/docs/src/federation.did
@@ -10,6 +10,16 @@ type FederationInstallArgs = variant {
     directory_canister : principal;
   };
 };
+// Arguments for the `register_user` method of the Federation canister.
+type RegisterUserArgs = record {
+  user_handle : text;
+  user_id : principal;
+  user_canister_id : principal;
+};
+// Error type returned by the `register_user` method of the Federation canister.
+type RegisterUserError = variant { Internal : text };
+// Response type for the `register_user` method of the Federation canister.
+type RegisterUserResponse = variant { Ok; Err : RegisterUserError };
 // Arguments for the `send_activity` method of the Federation canister, supporting both single and batch activities.
 type SendActivityArgs = variant {
   // Send a single activity.
@@ -36,5 +46,6 @@ type SendActivityError = variant {
 // Response type for the `send_activity` method of the Federation canister.
 type SendActivityResponse = variant { Ok; Err : SendActivityError };
 service : (FederationInstallArgs) -> {
+  register_user : (RegisterUserArgs) -> (RegisterUserResponse);
   send_activity : (SendActivityArgs) -> (SendActivityResponse);
 }

--- a/docs/src/interface/types.md
+++ b/docs/src/interface/types.md
@@ -731,23 +731,31 @@ type GetFollowingError = variant {
 ### PublishStatus
 
 Request, response, and error types for the `publish_status` method. Creates a
-new status post in the caller's outbox and distributes it to followers via the
-Federation Canister.
+new status post in the caller's outbox and distributes it via the Federation
+Canister. For `Public`, `Unlisted`, and `FollowersOnly` visibilities, the
+recipients are the author's followers. For `Direct` visibility, the recipients
+are the explicitly listed `mentions` — followers are not addressed.
 
-| Field        | Description                                                       |
-| ------------ | ----------------------------------------------------------------- |
-| `content`    | The text content of the new post.                                 |
-| `visibility` | Audience control for this status (see [Visibility](#visibility)). |
+| Field        | Description                                                                             |
+| ------------ | --------------------------------------------------------------------------------------- |
+| `content`    | The text content of the new post.                                                       |
+| `visibility` | Audience control for this status (see [Visibility](#visibility)).                       |
+| `mentions`   | Actor URIs explicitly mentioned. Required (non-empty) when `visibility` is `Direct`.    |
 
 On success, returns the created `Status` with its assigned ID and timestamp.
 
 - **Unauthorized**: the caller is not the canister owner.
+- **ContentEmpty**: the content is empty or contains only whitespace.
 - **ContentTooLong**: the content exceeds the maximum allowed length.
+- **NoRecipients**: a `Direct` status was published with an empty `mentions`
+  list.
+- **Internal**: an internal error occurred while publishing the status.
 
 ```candid
 type PublishStatusArgs = record {
   content : text;
   visibility : Visibility;
+  mentions : vec text;
 };
 
 type PublishStatusResponse = variant {
@@ -757,7 +765,10 @@ type PublishStatusResponse = variant {
 
 type PublishStatusError = variant {
   Unauthorized;
+  ContentEmpty;
   ContentTooLong;
+  NoRecipients;
+  Internal : text;
 };
 ```
 
@@ -1025,33 +1036,52 @@ type FederationInstallArgs = variant {
 ### SendActivity
 
 Request, response, and error types for the `send_activity` method. Called by a
-User Canister to deliver an outbound ActivityPub activity to a remote server's
-inbox via HTTP.
+registered User Canister to deliver an outbound ActivityPub activity. Supports
+a single activity (`One`) or a batch (`Batch`) per call. Local targets are
+routed to the recipient User Canister via the Directory Canister; remote
+targets are skipped (remote HTTP delivery is Milestone 2).
 
-| Field           | Description                                                  |
-| --------------- | ------------------------------------------------------------ |
-| `activity_json` | JSON-encoded ActivityPub activity object to send.            |
-| `target_inbox`  | URL of the remote actor's inbox to deliver the activity to.  |
+| Field           | Description                                                 |
+| --------------- | ----------------------------------------------------------- |
+| `activity_json` | JSON-encoded ActivityPub activity object to send.           |
+| `target_inbox`  | URL of the actor's inbox to deliver the activity to.        |
 
-- **Unauthorized**: the caller is not a registered User Canister.
-- **DeliveryFailed**: the HTTP request to the target inbox failed.
-- **InvalidActivity**: the JSON could not be parsed as a valid ActivityPub
+`SendActivityError`:
+
+- **InvalidTargetInbox(text)**: `target_inbox` URL failed to parse or has an
+  unexpected path shape.
+- **UnknownLocalUser(text)**: local inbox references a handle that is not
+  registered in the Directory Canister.
+- **DeliveryFailed(text)**: inter-canister call to the target User Canister
+  failed (transport or decode).
+- **Rejected(text)**: target User Canister accepted the call but rejected the
   activity.
 
 ```candid
-type SendActivityArgs = record {
+type SendActivityArgsObject = record {
   activity_json : text;
   target_inbox : text;
 };
 
-type SendActivityResponse = variant {
+type SendActivityArgs = variant {
+  One : SendActivityArgsObject;
+  Batch : vec SendActivityArgsObject;
+};
+
+type SendActivityResult = variant {
   Ok;
   Err : SendActivityError;
 };
 
+type SendActivityResponse = variant {
+  One : SendActivityResult;
+  Batch : vec SendActivityResult;
+};
+
 type SendActivityError = variant {
-  Unauthorized;
-  DeliveryFailed;
-  InvalidActivity;
+  InvalidTargetInbox : text;
+  UnknownLocalUser : text;
+  DeliveryFailed : text;
+  Rejected : text;
 };
 ```

--- a/docs/src/user.did
+++ b/docs/src/user.did
@@ -108,6 +108,11 @@ type GetStatusesResponse = variant { Ok : vec Status; Err : GetStatusesError };
 type PublishStatusArgs = record {
   // The text content of the new post.
   content : text;
+  // Actor URIs explicitly mentioned by the author. Required (non-empty)
+  // for [`Visibility::Direct`]; optional for other visibilities, where
+  // the entries are carried as additional `cc` addressees so the
+  // mentioned actors are notified.
+  mentions : vec text;
   // Audience control for this status.
   visibility : Visibility;
 };
@@ -119,6 +124,9 @@ type PublishStatusError = variant {
   ContentEmpty;
   // The content exceeds the maximum allowed length.
   ContentTooLong;
+  // A [`Visibility::Direct`] status was published without any mentioned
+  // recipients.
+  NoRecipients;
   // The caller is not the canister owner.
   Unauthorized;
 };

--- a/integration-tests/src/user_client.rs
+++ b/integration-tests/src/user_client.rs
@@ -29,10 +29,12 @@ impl UserClient<'_> {
         caller: Principal,
         content: String,
         visibility: Visibility,
+        mentions: Vec<String>,
     ) -> PublishStatusResponse {
         let args = PublishStatusArgs {
             content,
             visibility,
+            mentions,
         };
 
         self.env

--- a/integration-tests/tests/publish_status.rs
+++ b/integration-tests/tests/publish_status.rs
@@ -19,6 +19,7 @@ async fn test_should_publish_status(env: PocketIcTestEnv<MasticCanisterSetup>) {
             rey_canisteryo(),
             "Hello, World!".to_string(),
             did::common::Visibility::Public,
+            vec![],
         )
         .await
     {

--- a/just/build.just
+++ b/just/build.just
@@ -28,7 +28,7 @@ pre_build:
 [private]
 build_canister canister_name wasm_name:
   echo "Building {{canister_name}} Canister"
-  cargo build --target wasm32-unknown-unknown --release --package "{{canister_name}}"
+  cargo build --target wasm32-unknown-unknown --release --target-dir target --package "{{canister_name}}"
   ic-wasm "target/wasm32-unknown-unknown/release/{{canister_name}}.wasm" -o "{{WASM_DIR}}/{{wasm_name}}.wasm" shrink
   candid-extractor "{{WASM_DIR}}/{{wasm_name}}.wasm" > "{{WASM_DIR}}/{{wasm_name}}.did"
   cp "{{WASM_DIR}}/{{wasm_name}}.did" ./docs/src/{{wasm_name}}.did

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.94.1"
+channel = "1.95.0"
 targets = ["wasm32-unknown-unknown"]


### PR DESCRIPTION
## Summary

- Federation Canister now routes activities from registered User Canisters to local recipients via the Directory Canister, and logs/skips remote targets (Milestone 2 work).
- Sender-side visibility selection: `Public`/`Unlisted`/`FollowersOnly` deliver to followers; `Direct` delivers only to `mentions` and rejects empty-mention submissions with `NoRecipients`.
- Fixes an authorization bug where `send_activity` checked the directory-canister principal instead of the caller's user-canister principal; adds a `USER_DATA_BY_CANISTER_ID` index so the check matches on the caller.

## Details

### Federation Canister

- New `adapters::user` module: `UserCanister` trait, `IcUserCanisterClient` (wasm), `MockUserCanisterClient` (test), typed `UserCanisterClientError`.
- `domain::activity::send_activity_inner`: parses `target_inbox` with the `url` crate, compares host+port with `public_url`, extracts `{handle}` from `/users/{handle}/inbox`, resolves the User Canister principal via `directory::get_user_by_handle`, and forwards the opaque `activity_json` via `receive_activity`.
- `SendActivityError` → `InvalidTargetInbox(String)` | `UnknownLocalUser(String)` | `DeliveryFailed(String)` | `Rejected(String)`.
- `api::send_activity` authorization now uses `is_user_canister` (canister-id index); matches the `inspect_message` guard.

### User Canister

- `PublishStatusArgs` gains `mentions: Vec<String>`.
- `PublishStatusError` gains `NoRecipients`.
- Recipient selection is now visibility-aware; mentions are carried in the activity's `to`/`cc` per Mastodon convention.

### Tooling & Docs

- Root `Cargo.toml` + `federation/Cargo.toml`: `url = 2`.
- `just/build.just`: `cargo build ... --target-dir target` so a global `target-dir` override in `~/.cargo/config.toml` does not make the `.did` copy go stale.
- `docs/src/interface/types.md` updated; auto-generated `docs/src/federation.did` and `docs/src/user.did` regenerated.

## Test plan

- [x] `just clippy -- -D warnings` — clean
- [x] `just build_all` — all three canister artifacts produced
- [x] `just test` — 33/33 federation unit tests, 24/24 user publish tests, full workspace green
- [x] `just integration_test` — 3/3 pass (sign-up + publish_status + whoami)
- [ ] New pocket-ic integration scenarios for Direct delivery, remote-skip, unknown-local-handle, invalid-inbox, batch-mixed outcomes, and `send_activity` authorization traps — tracked in #11

Closes #10