### PR TITLE
test(integration): milestone 0 flow tests for follow, publish, get_statuses, read_feed

### DIFF
--- a/integration-tests/src/helpers.rs
+++ b/integration-tests/src/helpers.rs
@@ -1,12 +1,63 @@
 //! Helpers functions for integration tests.
 
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use candid::Principal;
 use did::directory::{SignUpResponse, UserCanisterStatus, WhoAmI, WhoAmIResponse};
 use pocket_ic_harness::PocketIcTestEnv;
 
 use crate::{DirectoryClient, MasticCanisterSetup};
+
+/// Advance pocket-ic time by `secs` seconds and tick once.
+///
+/// Used to make consecutive canister calls produce distinct `ic_cdk::api::time()` values
+/// so tests that rely on chronological ordering can distinguish entries.
+pub async fn advance_time_secs(env: &PocketIcTestEnv<MasticCanisterSetup>, secs: u64) {
+    env.pic.advance_time(Duration::from_secs(secs)).await;
+    env.pic.tick().await;
+}
+
+/// Build the actor URI for a local user handle.
+pub fn actor_uri(handle: &str) -> String {
+    format!("{url}/users/{handle}", url = crate::PUBLIC_URL)
+}
+
+/// Sign up `follower_principal` as `follower_handle` and have them follow
+/// `target_handle`'s canister (`target_canister`), and accept the follow
+/// request as the target (`target_principal`).
+///
+/// Returns the follower's user canister ID.
+#[allow(clippy::too_many_arguments)]
+pub async fn follow_and_accept(
+    env: &PocketIcTestEnv<MasticCanisterSetup>,
+    follower_principal: Principal,
+    follower_handle: &str,
+    target_principal: Principal,
+    target_canister: Principal,
+    target_handle: &str,
+) -> Principal {
+    use did::user::{AcceptFollowResponse, FollowUserResponse};
+
+    use crate::UserClient;
+
+    let follower_canister =
+        sign_up_user(env, follower_principal, follower_handle.to_string()).await;
+    let follower_client = UserClient::new(env, follower_canister);
+    let target_client = UserClient::new(env, target_canister);
+
+    let resp = follower_client
+        .follow_user(follower_principal, target_handle.to_string())
+        .await;
+    assert_eq!(resp, FollowUserResponse::Ok, "follow_user failed");
+
+    let follower_actor_uri = actor_uri(follower_handle);
+    let resp = target_client
+        .accept_follow(target_principal, follower_actor_uri)
+        .await;
+    assert_eq!(resp, AcceptFollowResponse::Ok, "accept_follow failed");
+
+    follower_canister
+}
 
 /// Signs up a user with the given principal in the User canister and return the user canister ID.
 pub async fn sign_up_user(

--- a/integration-tests/src/lib.rs
+++ b/integration-tests/src/lib.rs
@@ -13,11 +13,23 @@ use pocket_ic_harness::{Canister, CanisterSetup, PocketIcTestEnv, alice};
 pub use self::directory_client::DirectoryClient;
 pub use self::user_client::UserClient;
 
-const PUBLIC_URL: &str = "https://mastic.social";
+pub const PUBLIC_URL: &str = "https://mastic.social";
 
 pub fn rey_canisteryo() -> Principal {
     Principal::from_text("duo63-t5gbk-nptmp-gq7dy-saoed-ni2jl-5uuzr-ikrjk-o6vhp-2c3p5-pqe")
         .expect("Failed to parse Rey canister ID")
+}
+
+pub fn charlie() -> Principal {
+    Principal::self_authenticating([3u8; 32])
+}
+
+pub fn carol() -> Principal {
+    Principal::self_authenticating([4u8; 32])
+}
+
+pub fn dave() -> Principal {
+    Principal::self_authenticating([5u8; 32])
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]

--- a/integration-tests/src/user_client.rs
+++ b/integration-tests/src/user_client.rs
@@ -1,6 +1,12 @@
 use candid::{Encode, Principal};
 use did::common::Visibility;
-use did::user::{GetProfileResponse, PublishStatusArgs, PublishStatusResponse};
+use did::user::{
+    AcceptFollowArgs, AcceptFollowResponse, FollowUserArgs, FollowUserResponse,
+    GetFollowRequestsArgs, GetFollowRequestsResponse, GetFollowersArgs, GetFollowersResponse,
+    GetFollowingArgs, GetFollowingResponse, GetProfileResponse, GetStatusesArgs,
+    GetStatusesResponse, PublishStatusArgs, PublishStatusResponse, ReadFeedArgs, ReadFeedResponse,
+    RejectFollowArgs, RejectFollowResponse,
+};
 use pocket_ic_harness::PocketIcTestEnv;
 
 use crate::MasticCanisterSetup;
@@ -17,9 +23,9 @@ impl<'a> UserClient<'a> {
 }
 
 impl UserClient<'_> {
-    pub async fn get_profile(&self, user: Principal) -> GetProfileResponse {
+    pub async fn get_profile(&self, caller: Principal) -> GetProfileResponse {
         self.env
-            .query(self.canister_id, user, "get_profile", vec![])
+            .query(self.canister_id, caller, "get_profile", vec![])
             .await
             .expect("Failed to call get_profile")
     }
@@ -46,5 +52,145 @@ impl UserClient<'_> {
             )
             .await
             .expect("Failed to call publish_status")
+    }
+
+    pub async fn follow_user(&self, caller: Principal, handle: String) -> FollowUserResponse {
+        let args = FollowUserArgs { handle };
+
+        self.env
+            .update(
+                self.canister_id,
+                caller,
+                "follow_user",
+                Encode!(&args).expect("Failed to encode follow_user arguments"),
+            )
+            .await
+            .expect("Failed to call follow_user")
+    }
+
+    pub async fn get_following(
+        &self,
+        caller: Principal,
+        offset: u64,
+        limit: u64,
+    ) -> GetFollowingResponse {
+        let args = GetFollowingArgs { offset, limit };
+
+        self.env
+            .query(
+                self.canister_id,
+                caller,
+                "get_following",
+                Encode!(&args).expect("Failed to encode get_following arguments"),
+            )
+            .await
+            .expect("Failed to call get_following")
+    }
+
+    pub async fn get_followers(
+        &self,
+        caller: Principal,
+        offset: u64,
+        limit: u64,
+    ) -> GetFollowersResponse {
+        let args = GetFollowersArgs { offset, limit };
+
+        self.env
+            .query(
+                self.canister_id,
+                caller,
+                "get_followers",
+                Encode!(&args).expect("Failed to encode get_followers arguments"),
+            )
+            .await
+            .expect("Failed to call get_followers")
+    }
+
+    pub async fn get_follow_requests(
+        &self,
+        caller: Principal,
+        offset: u64,
+        limit: u64,
+    ) -> GetFollowRequestsResponse {
+        let args = GetFollowRequestsArgs { offset, limit };
+
+        self.env
+            .query(
+                self.canister_id,
+                caller,
+                "get_follow_requests",
+                Encode!(&args).expect("Failed to encode get_follow_requests arguments"),
+            )
+            .await
+            .expect("Failed to call get_follow_requests")
+    }
+
+    pub async fn accept_follow(
+        &self,
+        caller: Principal,
+        actor_uri: String,
+    ) -> AcceptFollowResponse {
+        let args = AcceptFollowArgs { actor_uri };
+
+        self.env
+            .update(
+                self.canister_id,
+                caller,
+                "accept_follow",
+                Encode!(&args).expect("Failed to encode accept_follow arguments"),
+            )
+            .await
+            .expect("Failed to call accept_follow")
+    }
+
+    pub async fn reject_follow(
+        &self,
+        caller: Principal,
+        actor_uri: String,
+    ) -> RejectFollowResponse {
+        let args = RejectFollowArgs { actor_uri };
+
+        self.env
+            .update(
+                self.canister_id,
+                caller,
+                "reject_follow",
+                Encode!(&args).expect("Failed to encode reject_follow arguments"),
+            )
+            .await
+            .expect("Failed to call reject_follow")
+    }
+
+    pub async fn read_feed(&self, caller: Principal, offset: u64, limit: u64) -> ReadFeedResponse {
+        let args = ReadFeedArgs { offset, limit };
+
+        self.env
+            .query(
+                self.canister_id,
+                caller,
+                "read_feed",
+                Encode!(&args).expect("Failed to encode read_feed arguments"),
+            )
+            .await
+            .expect("Failed to call read_feed")
+    }
+
+    pub async fn get_statuses(
+        &self,
+        caller: Principal,
+        offset: u64,
+        limit: u64,
+    ) -> GetStatusesResponse {
+        let args = GetStatusesArgs { offset, limit };
+
+        self.env
+            .query(
+                self.canister_id,
+                caller,
+                "get_statuses",
+                Encode!(&args).expect("Failed to encode get_statuses arguments"),
+            )
+            .await
+            .expect("Failed to call get_statuses")
     }
 }

--- a/integration-tests/tests/follow.rs
+++ b/integration-tests/tests/follow.rs
@@ -1,0 +1,340 @@
+use did::user::{
+    AcceptFollowResponse, FollowUserResponse, GetFollowRequestsResponse, GetFollowersResponse,
+    GetFollowingResponse, RejectFollowResponse,
+};
+use integration_tests::{MasticCanisterSetup, PUBLIC_URL, UserClient};
+use pocket_ic_harness::{PocketIcTestEnv, alice, bob};
+
+fn actor_uri(handle: &str) -> String {
+    format!("{PUBLIC_URL}/users/{handle}")
+}
+
+#[pocket_ic_harness::test]
+async fn test_should_follow_and_accept_follower(env: PocketIcTestEnv<MasticCanisterSetup>) {
+    let alice_canister_id =
+        integration_tests::helpers::sign_up_user(&env, alice(), "alice".to_string()).await;
+    let bob_canister_id =
+        integration_tests::helpers::sign_up_user(&env, bob(), "bob".to_string()).await;
+
+    let alice_client = UserClient::new(&env, alice_canister_id);
+    let bob_client = UserClient::new(&env, bob_canister_id);
+
+    let alice_uri = actor_uri("alice");
+    let bob_uri = actor_uri("bob");
+
+    // alice calls follow user "bob"
+    assert_eq!(
+        alice_client.follow_user(alice(), "bob".to_string()).await,
+        FollowUserResponse::Ok
+    );
+
+    // bob checks his follow requests, and must have one from alice
+    let GetFollowRequestsResponse::Ok(bob_follow_requests) =
+        bob_client.get_follow_requests(bob(), 0, 10).await
+    else {
+        panic!("Failed to get follow requests for bob");
+    };
+    assert_eq!(bob_follow_requests.len(), 1);
+    let alice_actor_uri = bob_follow_requests[0].clone();
+    assert_eq!(alice_actor_uri, alice_uri);
+
+    // bob accepts alice's follow request
+    assert_eq!(
+        bob_client
+            .accept_follow(bob(), alice_actor_uri.clone())
+            .await,
+        AcceptFollowResponse::Ok
+    );
+
+    // get alice's following list, and it should include bob
+    let GetFollowingResponse::Ok(following) = alice_client.get_following(alice(), 0, 10).await
+    else {
+        panic!("Failed to get following list for alice");
+    };
+    assert_eq!(following.len(), 1);
+    assert_eq!(following[0], bob_uri);
+
+    // bob's followers list should include alice
+    let GetFollowersResponse::Ok(followers) = bob_client.get_followers(alice(), 0, 10).await else {
+        panic!("Failed to get followers list for bob");
+    };
+    assert_eq!(followers.len(), 1);
+    assert_eq!(followers[0], alice_uri);
+
+    // verify the follow request is no longer in bob's follow requests
+    let GetFollowRequestsResponse::Ok(bob_follow_requests) =
+        bob_client.get_follow_requests(bob(), 0, 10).await
+    else {
+        panic!("Failed to get follow requests for bob");
+    };
+    assert_eq!(bob_follow_requests.len(), 0);
+}
+
+#[pocket_ic_harness::test]
+async fn test_should_follow_and_reject_follower(env: PocketIcTestEnv<MasticCanisterSetup>) {
+    let alice_canister_id =
+        integration_tests::helpers::sign_up_user(&env, alice(), "alice".to_string()).await;
+    let bob_canister_id =
+        integration_tests::helpers::sign_up_user(&env, bob(), "bob".to_string()).await;
+
+    let alice_client = UserClient::new(&env, alice_canister_id);
+    let bob_client = UserClient::new(&env, bob_canister_id);
+
+    let alice_uri = actor_uri("alice");
+
+    // alice calls follow user "bob"
+    assert_eq!(
+        alice_client.follow_user(alice(), "bob".to_string()).await,
+        FollowUserResponse::Ok
+    );
+
+    // bob checks his follow requests, and must have one from alice
+    let GetFollowRequestsResponse::Ok(bob_follow_requests) =
+        bob_client.get_follow_requests(bob(), 0, 10).await
+    else {
+        panic!("Failed to get follow requests for bob");
+    };
+    assert_eq!(bob_follow_requests.len(), 1);
+    let alice_actor_uri = bob_follow_requests[0].clone();
+    assert_eq!(alice_actor_uri, alice_uri);
+
+    // bob rejects alice's follow request
+    assert_eq!(
+        bob_client
+            .reject_follow(bob(), alice_actor_uri.clone())
+            .await,
+        RejectFollowResponse::Ok
+    );
+
+    // get alice's following list, and it be empty
+    let GetFollowingResponse::Ok(following) = alice_client.get_following(alice(), 0, 10).await
+    else {
+        panic!("Failed to get following list for alice");
+    };
+    assert_eq!(following.len(), 0);
+
+    // bob's followers list should be empty
+    let GetFollowersResponse::Ok(followers) = bob_client.get_followers(bob(), 0, 10).await else {
+        panic!("Failed to get followers list for bob");
+    };
+    assert_eq!(followers.len(), 0);
+
+    // verify the follow request is no longer in bob's follow requests
+    let GetFollowRequestsResponse::Ok(bob_follow_requests) =
+        bob_client.get_follow_requests(bob(), 0, 10).await
+    else {
+        panic!("Failed to get follow requests for bob");
+    };
+    assert_eq!(bob_follow_requests.len(), 0);
+}
+
+#[pocket_ic_harness::test]
+async fn test_should_be_able_to_refollow_after_rejection(
+    env: PocketIcTestEnv<MasticCanisterSetup>,
+) {
+    let alice_canister_id =
+        integration_tests::helpers::sign_up_user(&env, alice(), "alice".to_string()).await;
+    let bob_canister_id =
+        integration_tests::helpers::sign_up_user(&env, bob(), "bob".to_string()).await;
+
+    let alice_client = UserClient::new(&env, alice_canister_id);
+    let bob_client = UserClient::new(&env, bob_canister_id);
+
+    let alice_uri = actor_uri("alice");
+    let bob_uri = actor_uri("bob");
+
+    // alice calls follow user "bob"
+    assert_eq!(
+        alice_client.follow_user(alice(), "bob".to_string()).await,
+        FollowUserResponse::Ok
+    );
+
+    // bob checks his follow requests, and must have one from alice
+    let GetFollowRequestsResponse::Ok(bob_follow_requests) =
+        bob_client.get_follow_requests(bob(), 0, 10).await
+    else {
+        panic!("Failed to get follow requests for bob");
+    };
+    assert_eq!(bob_follow_requests.len(), 1);
+    let alice_actor_uri = bob_follow_requests[0].clone();
+    assert_eq!(alice_actor_uri, alice_uri);
+
+    // bob rejects alice's follow request
+    assert_eq!(
+        bob_client
+            .reject_follow(bob(), alice_actor_uri.clone())
+            .await,
+        RejectFollowResponse::Ok
+    );
+
+    // get alice's following list, and it be empty
+    let GetFollowingResponse::Ok(following) = alice_client.get_following(alice(), 0, 10).await
+    else {
+        panic!("Failed to get following list for alice");
+    };
+    assert_eq!(following.len(), 0);
+
+    // bob's followers list should be empty
+    let GetFollowersResponse::Ok(followers) = bob_client.get_followers(bob(), 0, 10).await else {
+        panic!("Failed to get followers list for bob");
+    };
+    assert_eq!(followers.len(), 0);
+
+    // verify the follow request is no longer in bob's follow requests
+    let GetFollowRequestsResponse::Ok(bob_follow_requests) =
+        bob_client.get_follow_requests(bob(), 0, 10).await
+    else {
+        panic!("Failed to get follow requests for bob");
+    };
+    assert_eq!(bob_follow_requests.len(), 0);
+
+    // refollow again
+    assert_eq!(
+        alice_client.follow_user(alice(), "bob".to_string()).await,
+        FollowUserResponse::Ok
+    );
+
+    // bob should see the follow request again
+    let GetFollowRequestsResponse::Ok(bob_follow_requests) =
+        bob_client.get_follow_requests(bob(), 0, 10).await
+    else {
+        panic!("Failed to get follow requests for bob");
+    };
+    assert_eq!(bob_follow_requests.len(), 1);
+    let alice_actor_uri = bob_follow_requests[0].clone();
+    assert_eq!(alice_actor_uri, alice_uri);
+
+    // this time bob accepts the follow request
+    assert_eq!(
+        bob_client
+            .accept_follow(bob(), alice_actor_uri.clone())
+            .await,
+        AcceptFollowResponse::Ok
+    );
+
+    // get alice's following list, and it should include bob
+    let GetFollowingResponse::Ok(following) = alice_client.get_following(alice(), 0, 10).await
+    else {
+        panic!("Failed to get following list for alice");
+    };
+    assert_eq!(following.len(), 1);
+    assert_eq!(following[0], bob_uri);
+
+    // bob's followers list should include alice
+    let GetFollowersResponse::Ok(followers) = bob_client.get_followers(bob(), 0, 10).await else {
+        panic!("Failed to get followers list for bob");
+    };
+    assert_eq!(followers.len(), 1);
+    assert_eq!(followers[0], alice_uri);
+
+    // verify the follow request is no longer in bob's follow requests
+    let GetFollowRequestsResponse::Ok(bob_follow_requests) =
+        bob_client.get_follow_requests(bob(), 0, 10).await
+    else {
+        panic!("Failed to get follow requests for bob");
+    };
+    assert_eq!(bob_follow_requests.len(), 0);
+}
+
+#[pocket_ic_harness::test]
+async fn test_should_reject_self_follow(env: PocketIcTestEnv<MasticCanisterSetup>) {
+    let alice_canister_id =
+        integration_tests::helpers::sign_up_user(&env, alice(), "alice".to_string()).await;
+
+    let alice_client = UserClient::new(&env, alice_canister_id);
+
+    // alice calls follow user "alice" (self-follow)
+    assert_eq!(
+        alice_client.follow_user(alice(), "alice".to_string()).await,
+        FollowUserResponse::Err(did::user::FollowUserError::CannotFollowSelf)
+    );
+
+    // alice's following list should be empty
+    let GetFollowingResponse::Ok(following) = alice_client.get_following(alice(), 0, 10).await
+    else {
+        panic!("Failed to get following list for alice");
+    };
+    assert_eq!(following.len(), 0);
+
+    // alice's followers list should be empty
+    let GetFollowersResponse::Ok(followers) = alice_client.get_followers(alice(), 0, 10).await
+    else {
+        panic!("Failed to get followers list for alice");
+    };
+    assert_eq!(followers.len(), 0);
+
+    // alice's follow requests should be empty
+    let GetFollowRequestsResponse::Ok(follow_requests) =
+        alice_client.get_follow_requests(alice(), 0, 10).await
+    else {
+        panic!("Failed to get follow requests for alice");
+    };
+    assert_eq!(follow_requests.len(), 0);
+}
+
+#[pocket_ic_harness::test]
+async fn test_should_not_allow_duplicate_follow(env: PocketIcTestEnv<MasticCanisterSetup>) {
+    let alice_canister_id =
+        integration_tests::helpers::sign_up_user(&env, alice(), "alice".to_string()).await;
+    let bob_canister_id =
+        integration_tests::helpers::sign_up_user(&env, bob(), "bob".to_string()).await;
+
+    let alice_client = UserClient::new(&env, alice_canister_id);
+    let bob_client = UserClient::new(&env, bob_canister_id);
+
+    let alice_uri = actor_uri("alice");
+    let bob_uri = actor_uri("bob");
+
+    // alice calls follow user "bob"
+    assert_eq!(
+        alice_client.follow_user(alice(), "bob".to_string()).await,
+        FollowUserResponse::Ok
+    );
+
+    // bob checks his follow requests, and must have one from alice
+    let GetFollowRequestsResponse::Ok(bob_follow_requests) =
+        bob_client.get_follow_requests(bob(), 0, 10).await
+    else {
+        panic!("Failed to get follow requests for bob");
+    };
+    assert_eq!(bob_follow_requests.len(), 1);
+    let alice_actor_uri = bob_follow_requests[0].clone();
+    assert_eq!(alice_actor_uri, alice_uri);
+
+    // bob accepts alice's follow request
+    assert_eq!(
+        bob_client
+            .accept_follow(bob(), alice_actor_uri.clone())
+            .await,
+        AcceptFollowResponse::Ok
+    );
+
+    // get alice's following list, and it should include bob
+    let GetFollowingResponse::Ok(following) = alice_client.get_following(alice(), 0, 10).await
+    else {
+        panic!("Failed to get following list for alice");
+    };
+    assert_eq!(following.len(), 1);
+    assert_eq!(following[0], bob_uri);
+
+    // bob's followers list should include alice
+    let GetFollowersResponse::Ok(followers) = bob_client.get_followers(alice(), 0, 10).await else {
+        panic!("Failed to get followers list for bob");
+    };
+    assert_eq!(followers.len(), 1);
+    assert_eq!(followers[0], alice_uri);
+
+    // verify the follow request is no longer in bob's follow requests
+    let GetFollowRequestsResponse::Ok(bob_follow_requests) =
+        bob_client.get_follow_requests(bob(), 0, 10).await
+    else {
+        panic!("Failed to get follow requests for bob");
+    };
+    assert_eq!(bob_follow_requests.len(), 0);
+
+    // alice tries to follow bob again, and should get an error
+    assert_eq!(
+        alice_client.follow_user(alice(), "bob".to_string()).await,
+        FollowUserResponse::Err(did::user::FollowUserError::AlreadyFollowing)
+    );
+}

--- a/integration-tests/tests/get_profile.rs
+++ b/integration-tests/tests/get_profile.rs
@@ -1,0 +1,32 @@
+use did::user::GetProfileResponse;
+use integration_tests::{MasticCanisterSetup, UserClient, rey_canisteryo};
+use pocket_ic_harness::{PocketIcTestEnv, bob};
+
+#[pocket_ic_harness::test]
+async fn test_should_get_profile(env: PocketIcTestEnv<MasticCanisterSetup>) {
+    let user_canister_id = integration_tests::helpers::sign_up_user(
+        &env,
+        rey_canisteryo(),
+        "rey_canisteryo".to_string(),
+    )
+    .await;
+
+    let user_client = UserClient::new(&env, user_canister_id);
+    // call get profile
+    let GetProfileResponse::Ok(profile) = user_client.get_profile(rey_canisteryo()).await else {
+        panic!("Failed to get profile");
+    };
+
+    assert_eq!(profile.avatar, None);
+    assert_eq!(profile.display_name, None);
+    assert_eq!(profile.handle, "rey_canisteryo".to_string());
+
+    // call get profile with another user
+    let GetProfileResponse::Ok(profile) = user_client.get_profile(bob()).await else {
+        panic!("Failed to get profile");
+    };
+
+    assert_eq!(profile.avatar, None);
+    assert_eq!(profile.display_name, None);
+    assert_eq!(profile.handle, "rey_canisteryo".to_string());
+}

--- a/integration-tests/tests/get_statuses.rs
+++ b/integration-tests/tests/get_statuses.rs
@@ -1,0 +1,131 @@
+use did::common::Visibility;
+use did::user::{GetStatusesResponse, PublishStatusResponse};
+use integration_tests::helpers::{follow_and_accept, sign_up_user};
+use integration_tests::{MasticCanisterSetup, UserClient, carol, charlie};
+use pocket_ic_harness::{PocketIcTestEnv, alice, bob};
+
+async fn publish(
+    client: &UserClient<'_>,
+    caller: candid::Principal,
+    content: &str,
+    visibility: Visibility,
+    mentions: Vec<String>,
+) {
+    let resp = client
+        .publish_status(caller, content.to_string(), visibility, mentions)
+        .await;
+    assert!(matches!(resp, PublishStatusResponse::Ok(_)), "{resp:?}");
+}
+
+#[pocket_ic_harness::test]
+async fn test_public_outbox_visible_to_any_caller(env: PocketIcTestEnv<MasticCanisterSetup>) {
+    let alice_canister = sign_up_user(&env, alice(), "alice".to_string()).await;
+    let alice_client = UserClient::new(&env, alice_canister);
+
+    publish(
+        &alice_client,
+        alice(),
+        "public post",
+        Visibility::Public,
+        vec![],
+    )
+    .await;
+    publish(
+        &alice_client,
+        alice(),
+        "unlisted post",
+        Visibility::Unlisted,
+        vec![],
+    )
+    .await;
+
+    let charlie_canister = sign_up_user(&env, charlie(), "charlie".to_string()).await;
+
+    // charlie (not a follower) queries alice's statuses
+    let GetStatusesResponse::Ok(statuses) = alice_client.get_statuses(charlie(), 0, 10).await
+    else {
+        panic!("get_statuses failed");
+    };
+    assert_eq!(statuses.len(), 2);
+    let contents: Vec<&str> = statuses.iter().map(|s| s.content.as_str()).collect();
+    assert!(contents.contains(&"public post"));
+    assert!(contents.contains(&"unlisted post"));
+
+    // ensure charlie canister variable used (avoid unused warning)
+    let _ = charlie_canister;
+}
+
+#[pocket_ic_harness::test]
+async fn test_followers_only_filtered_by_relationship(env: PocketIcTestEnv<MasticCanisterSetup>) {
+    let alice_canister = sign_up_user(&env, alice(), "alice".to_string()).await;
+    // bob is a follower of alice
+    let _bob_canister =
+        follow_and_accept(&env, bob(), "bob", alice(), alice_canister, "alice").await;
+    // carol is signed up but does not follow alice
+    let _carol_canister = sign_up_user(&env, carol(), "carol".to_string()).await;
+
+    let alice_client = UserClient::new(&env, alice_canister);
+    publish(
+        &alice_client,
+        alice(),
+        "followers only".to_string().as_str(),
+        Visibility::FollowersOnly,
+        vec![],
+    )
+    .await;
+    publish(&alice_client, alice(), "public", Visibility::Public, vec![]).await;
+
+    // bob (follower) sees both
+    let GetStatusesResponse::Ok(bob_view) = alice_client.get_statuses(bob(), 0, 10).await else {
+        panic!("bob get_statuses failed");
+    };
+    assert_eq!(bob_view.len(), 2);
+    let bob_contents: Vec<&str> = bob_view.iter().map(|s| s.content.as_str()).collect();
+    assert!(bob_contents.contains(&"followers only"));
+    assert!(bob_contents.contains(&"public"));
+
+    // carol (non-follower) sees only the public one
+    let GetStatusesResponse::Ok(carol_view) = alice_client.get_statuses(carol(), 0, 10).await
+    else {
+        panic!("carol get_statuses failed");
+    };
+    assert_eq!(carol_view.len(), 1);
+    assert_eq!(carol_view[0].content, "public");
+    assert_eq!(carol_view[0].visibility, Visibility::Public);
+}
+
+#[pocket_ic_harness::test]
+async fn test_direct_excluded_from_get_statuses(env: PocketIcTestEnv<MasticCanisterSetup>) {
+    let alice_canister = sign_up_user(&env, alice(), "alice".to_string()).await;
+    let _bob_canister =
+        follow_and_accept(&env, bob(), "bob", alice(), alice_canister, "alice").await;
+    let _carol_canister = sign_up_user(&env, carol(), "carol".to_string()).await;
+
+    let alice_client = UserClient::new(&env, alice_canister);
+
+    // alice sends a Direct mentioning bob
+    publish(
+        &alice_client,
+        alice(),
+        "secret to bob",
+        Visibility::Direct,
+        vec![integration_tests::helpers::actor_uri("bob")],
+    )
+    .await;
+
+    // bob (follower + mentioned) does NOT see it via get_statuses — Direct excluded
+    let GetStatusesResponse::Ok(bob_view) = alice_client.get_statuses(bob(), 0, 10).await else {
+        panic!("bob get_statuses failed");
+    };
+    assert!(
+        bob_view.iter().all(|s| s.visibility != Visibility::Direct),
+        "bob must not see Direct via get_statuses"
+    );
+
+    // carol (non-follower) also sees nothing (no public/unlisted posts exist)
+    let GetStatusesResponse::Ok(carol_view) = alice_client.get_statuses(carol(), 0, 10).await
+    else {
+        panic!("carol get_statuses failed");
+    };
+    assert!(carol_view.is_empty());
+}

--- a/integration-tests/tests/publish_status.rs
+++ b/integration-tests/tests/publish_status.rs
@@ -1,28 +1,209 @@
-use did::user::PublishStatusResponse;
-use integration_tests::{MasticCanisterSetup, UserClient, rey_canisteryo};
-use pocket_ic_harness::PocketIcTestEnv;
+use did::common::Visibility;
+use did::user::{PublishStatusError, PublishStatusResponse, ReadFeedResponse};
+use integration_tests::helpers::{actor_uri, follow_and_accept, sign_up_user};
+use integration_tests::{MasticCanisterSetup, UserClient, carol, charlie, dave, rey_canisteryo};
+use pocket_ic_harness::{PocketIcTestEnv, alice, bob};
 
 #[pocket_ic_harness::test]
 async fn test_should_publish_status(env: PocketIcTestEnv<MasticCanisterSetup>) {
-    let user_canister_id = integration_tests::helpers::sign_up_user(
-        &env,
-        rey_canisteryo(),
-        "rey_canisteryo".to_string(),
-    )
-    .await;
-
-    // TODO: should have follower to check the feed
+    let user_canister_id = sign_up_user(&env, rey_canisteryo(), "rey_canisteryo".to_string()).await;
 
     let user_client = UserClient::new(&env, user_canister_id);
     if let PublishStatusResponse::Err(err) = user_client
         .publish_status(
             rey_canisteryo(),
             "Hello, World!".to_string(),
-            did::common::Visibility::Public,
+            Visibility::Public,
             vec![],
         )
         .await
     {
-        panic!("Failed to publish status: {:?}", err);
+        panic!("Failed to publish status: {err:?}");
+    }
+}
+
+#[pocket_ic_harness::test]
+async fn test_should_deliver_public_status_to_follower(env: PocketIcTestEnv<MasticCanisterSetup>) {
+    let bob_canister = sign_up_user(&env, bob(), "bob".to_string()).await;
+    let alice_canister =
+        follow_and_accept(&env, alice(), "alice", bob(), bob_canister, "bob").await;
+
+    let bob_client = UserClient::new(&env, bob_canister);
+    let alice_client = UserClient::new(&env, alice_canister);
+
+    let resp = bob_client
+        .publish_status(bob(), "hello world".to_string(), Visibility::Public, vec![])
+        .await;
+    assert!(matches!(resp, PublishStatusResponse::Ok(_)), "{resp:?}");
+
+    let ReadFeedResponse::Ok(feed) = alice_client.read_feed(alice(), 0, 10).await else {
+        panic!("alice read_feed failed");
+    };
+    assert_eq!(feed.len(), 1);
+    assert_eq!(feed[0].status.content, "hello world");
+    assert_eq!(feed[0].status.author, actor_uri("bob"));
+    assert_eq!(feed[0].status.visibility, Visibility::Public);
+}
+
+#[pocket_ic_harness::test]
+async fn test_followers_only_not_delivered_to_strangers(env: PocketIcTestEnv<MasticCanisterSetup>) {
+    // TODO: also assert follower alice sees the status once publish addressing
+    // for FollowersOnly includes the owner's `/followers` collection URL.
+    // Currently publish emits `to=None, cc=None` for FollowersOnly without
+    // mentions, which the receiver's `infer_visibility` misclassifies as
+    // Direct and then filters out because the receiver isn't addressed.
+    let bob_canister = sign_up_user(&env, bob(), "bob".to_string()).await;
+    let _alice_canister =
+        follow_and_accept(&env, alice(), "alice", bob(), bob_canister, "bob").await;
+    let charlie_canister = sign_up_user(&env, charlie(), "charlie".to_string()).await;
+
+    let bob_client = UserClient::new(&env, bob_canister);
+    let charlie_client = UserClient::new(&env, charlie_canister);
+
+    let resp = bob_client
+        .publish_status(
+            bob(),
+            "for my followers".to_string(),
+            Visibility::FollowersOnly,
+            vec![],
+        )
+        .await;
+    assert!(matches!(resp, PublishStatusResponse::Ok(_)), "{resp:?}");
+
+    let ReadFeedResponse::Ok(charlie_feed) = charlie_client.read_feed(charlie(), 0, 10).await
+    else {
+        panic!("charlie read_feed failed");
+    };
+    assert!(
+        charlie_feed.is_empty(),
+        "non-follower must not receive FollowersOnly status"
+    );
+}
+
+#[pocket_ic_harness::test]
+async fn test_direct_delivers_only_to_mentioned(env: PocketIcTestEnv<MasticCanisterSetup>) {
+    // alice has two followers (bob, carol). alice sends Direct mentioning dave only.
+    let alice_canister = sign_up_user(&env, alice(), "alice".to_string()).await;
+    let bob_canister =
+        follow_and_accept(&env, bob(), "bob", alice(), alice_canister, "alice").await;
+    let carol_canister =
+        follow_and_accept(&env, carol(), "carol", alice(), alice_canister, "alice").await;
+    let dave_canister = sign_up_user(&env, dave(), "dave".to_string()).await;
+
+    let alice_client = UserClient::new(&env, alice_canister);
+    let bob_client = UserClient::new(&env, bob_canister);
+    let carol_client = UserClient::new(&env, carol_canister);
+    let dave_client = UserClient::new(&env, dave_canister);
+
+    let resp = alice_client
+        .publish_status(
+            alice(),
+            "psst".to_string(),
+            Visibility::Direct,
+            vec![actor_uri("dave")],
+        )
+        .await;
+    assert!(matches!(resp, PublishStatusResponse::Ok(_)), "{resp:?}");
+
+    let ReadFeedResponse::Ok(dave_feed) = dave_client.read_feed(dave(), 0, 10).await else {
+        panic!("dave read_feed failed");
+    };
+    assert_eq!(dave_feed.len(), 1);
+    assert_eq!(dave_feed[0].status.content, "psst");
+    assert_eq!(dave_feed[0].status.visibility, Visibility::Direct);
+
+    let ReadFeedResponse::Ok(bob_feed) = bob_client.read_feed(bob(), 0, 10).await else {
+        panic!("bob read_feed failed");
+    };
+    assert!(bob_feed.is_empty(), "bob should not receive direct");
+
+    let ReadFeedResponse::Ok(carol_feed) = carol_client.read_feed(carol(), 0, 10).await else {
+        panic!("carol read_feed failed");
+    };
+    assert!(carol_feed.is_empty(), "carol should not receive direct");
+}
+
+#[pocket_ic_harness::test]
+async fn test_direct_without_mentions_rejected(env: PocketIcTestEnv<MasticCanisterSetup>) {
+    let alice_canister = sign_up_user(&env, alice(), "alice".to_string()).await;
+    let alice_client = UserClient::new(&env, alice_canister);
+
+    let resp = alice_client
+        .publish_status(alice(), "secret".to_string(), Visibility::Direct, vec![])
+        .await;
+    assert_eq!(
+        resp,
+        PublishStatusResponse::Err(PublishStatusError::NoRecipients)
+    );
+}
+
+#[pocket_ic_harness::test]
+async fn test_direct_with_multiple_mentions_no_duplicate(
+    env: PocketIcTestEnv<MasticCanisterSetup>,
+) {
+    // carol is a follower of alice; alice sends Direct to [bob, carol].
+    // Direct only targets mentions, so each gets exactly one activity —
+    // no duplicate for carol even though she's also a follower.
+    let alice_canister = sign_up_user(&env, alice(), "alice".to_string()).await;
+    let carol_canister =
+        follow_and_accept(&env, carol(), "carol", alice(), alice_canister, "alice").await;
+    let bob_canister = sign_up_user(&env, bob(), "bob".to_string()).await;
+
+    let alice_client = UserClient::new(&env, alice_canister);
+    let bob_client = UserClient::new(&env, bob_canister);
+    let carol_client = UserClient::new(&env, carol_canister);
+
+    let resp = alice_client
+        .publish_status(
+            alice(),
+            "hi both".to_string(),
+            Visibility::Direct,
+            vec![actor_uri("bob"), actor_uri("carol")],
+        )
+        .await;
+    assert!(matches!(resp, PublishStatusResponse::Ok(_)), "{resp:?}");
+
+    let ReadFeedResponse::Ok(bob_feed) = bob_client.read_feed(bob(), 0, 10).await else {
+        panic!("bob read_feed failed");
+    };
+    assert_eq!(bob_feed.len(), 1);
+    assert_eq!(bob_feed[0].status.content, "hi both");
+
+    let ReadFeedResponse::Ok(carol_feed) = carol_client.read_feed(carol(), 0, 10).await else {
+        panic!("carol read_feed failed");
+    };
+    assert_eq!(carol_feed.len(), 1, "carol should get exactly one activity");
+    assert_eq!(carol_feed[0].status.content, "hi both");
+}
+
+#[pocket_ic_harness::test]
+async fn test_public_fanout_to_all_followers(env: PocketIcTestEnv<MasticCanisterSetup>) {
+    // alice has 3 followers (bob, carol, charlie). One Public status → all feeds include it.
+    let alice_canister = sign_up_user(&env, alice(), "alice".to_string()).await;
+    let bob_canister =
+        follow_and_accept(&env, bob(), "bob", alice(), alice_canister, "alice").await;
+    let carol_canister =
+        follow_and_accept(&env, carol(), "carol", alice(), alice_canister, "alice").await;
+    let charlie_canister =
+        follow_and_accept(&env, charlie(), "charlie", alice(), alice_canister, "alice").await;
+
+    let alice_client = UserClient::new(&env, alice_canister);
+    let resp = alice_client
+        .publish_status(alice(), "hi all".to_string(), Visibility::Public, vec![])
+        .await;
+    assert!(matches!(resp, PublishStatusResponse::Ok(_)), "{resp:?}");
+
+    for (caller, canister, label) in [
+        (bob(), bob_canister, "bob"),
+        (carol(), carol_canister, "carol"),
+        (charlie(), charlie_canister, "charlie"),
+    ] {
+        let client = UserClient::new(&env, canister);
+        let ReadFeedResponse::Ok(feed) = client.read_feed(caller, 0, 10).await else {
+            panic!("{label} read_feed failed");
+        };
+        assert_eq!(feed.len(), 1, "{label} feed should include alice's post");
+        assert_eq!(feed[0].status.content, "hi all");
+        assert_eq!(feed[0].status.author, actor_uri("alice"));
     }
 }

--- a/integration-tests/tests/read_feed.rs
+++ b/integration-tests/tests/read_feed.rs
@@ -1,0 +1,184 @@
+use did::common::Visibility;
+use did::user::{PublishStatusResponse, ReadFeedResponse};
+use integration_tests::helpers::{actor_uri, advance_time_secs, follow_and_accept, sign_up_user};
+use integration_tests::{MasticCanisterSetup, UserClient, carol};
+use pocket_ic_harness::{PocketIcTestEnv, alice, bob};
+
+async fn publish(
+    client: &UserClient<'_>,
+    caller: candid::Principal,
+    content: &str,
+    visibility: Visibility,
+    mentions: Vec<String>,
+) {
+    let resp = client
+        .publish_status(caller, content.to_string(), visibility, mentions)
+        .await;
+    assert!(matches!(resp, PublishStatusResponse::Ok(_)), "{resp:?}");
+}
+
+#[pocket_ic_harness::test]
+async fn test_own_statuses_appear_in_feed(env: PocketIcTestEnv<MasticCanisterSetup>) {
+    let alice_canister = sign_up_user(&env, alice(), "alice".to_string()).await;
+    let alice_client = UserClient::new(&env, alice_canister);
+
+    publish(&alice_client, alice(), "first", Visibility::Public, vec![]).await;
+    publish(&alice_client, alice(), "second", Visibility::Public, vec![]).await;
+
+    let ReadFeedResponse::Ok(feed) = alice_client.read_feed(alice(), 0, 10).await else {
+        panic!("read_feed failed");
+    };
+    assert_eq!(feed.len(), 2);
+    let contents: Vec<&str> = feed.iter().map(|i| i.status.content.as_str()).collect();
+    assert!(contents.contains(&"first"));
+    assert!(contents.contains(&"second"));
+}
+
+#[pocket_ic_harness::test]
+async fn test_followed_users_statuses_appear_in_feed(env: PocketIcTestEnv<MasticCanisterSetup>) {
+    let bob_canister = sign_up_user(&env, bob(), "bob".to_string()).await;
+    let alice_canister =
+        follow_and_accept(&env, alice(), "alice", bob(), bob_canister, "bob").await;
+
+    let bob_client = UserClient::new(&env, bob_canister);
+    publish(&bob_client, bob(), "bob's post", Visibility::Public, vec![]).await;
+
+    let alice_client = UserClient::new(&env, alice_canister);
+    let ReadFeedResponse::Ok(feed) = alice_client.read_feed(alice(), 0, 10).await else {
+        panic!("read_feed failed");
+    };
+    assert_eq!(feed.len(), 1);
+    assert_eq!(feed[0].status.content, "bob's post");
+    assert_eq!(feed[0].status.author, actor_uri("bob"));
+}
+
+#[pocket_ic_harness::test]
+async fn test_feed_sorted_newest_first(env: PocketIcTestEnv<MasticCanisterSetup>) {
+    let bob_canister = sign_up_user(&env, bob(), "bob".to_string()).await;
+    let alice_canister =
+        follow_and_accept(&env, alice(), "alice", bob(), bob_canister, "bob").await;
+
+    let alice_client = UserClient::new(&env, alice_canister);
+    let bob_client = UserClient::new(&env, bob_canister);
+
+    publish(
+        &alice_client,
+        alice(),
+        "alice-1",
+        Visibility::Public,
+        vec![],
+    )
+    .await;
+    advance_time_secs(&env, 2).await;
+    publish(&bob_client, bob(), "bob-1", Visibility::Public, vec![]).await;
+    advance_time_secs(&env, 2).await;
+    publish(
+        &alice_client,
+        alice(),
+        "alice-2",
+        Visibility::Public,
+        vec![],
+    )
+    .await;
+
+    let ReadFeedResponse::Ok(feed) = alice_client.read_feed(alice(), 0, 10).await else {
+        panic!("read_feed failed");
+    };
+    assert_eq!(feed.len(), 3);
+
+    // newest-first
+    for pair in feed.windows(2) {
+        assert!(
+            pair[0].status.created_at >= pair[1].status.created_at,
+            "feed must be sorted newest-first"
+        );
+    }
+    assert_eq!(feed[0].status.content, "alice-2");
+    assert_eq!(feed[2].status.content, "alice-1");
+}
+
+#[pocket_ic_harness::test]
+async fn test_feed_pagination(env: PocketIcTestEnv<MasticCanisterSetup>) {
+    let alice_canister = sign_up_user(&env, alice(), "alice".to_string()).await;
+    let alice_client = UserClient::new(&env, alice_canister);
+
+    for i in 0..5 {
+        publish(
+            &alice_client,
+            alice(),
+            &format!("post-{i}"),
+            Visibility::Public,
+            vec![],
+        )
+        .await;
+        advance_time_secs(&env, 1).await;
+    }
+
+    let ReadFeedResponse::Ok(page1) = alice_client.read_feed(alice(), 0, 2).await else {
+        panic!("page1 read_feed failed");
+    };
+    assert_eq!(page1.len(), 2);
+
+    let ReadFeedResponse::Ok(page2) = alice_client.read_feed(alice(), 2, 2).await else {
+        panic!("page2 read_feed failed");
+    };
+    assert_eq!(page2.len(), 2);
+
+    let ReadFeedResponse::Ok(page3) = alice_client.read_feed(alice(), 4, 2).await else {
+        panic!("page3 read_feed failed");
+    };
+    assert_eq!(page3.len(), 1);
+
+    // No overlap between pages
+    let mut all_ids: Vec<u64> = page1
+        .iter()
+        .chain(page2.iter())
+        .chain(page3.iter())
+        .map(|i| i.status.id)
+        .collect();
+    all_ids.sort();
+    all_ids.dedup();
+    assert_eq!(all_ids.len(), 5, "pages must contain distinct statuses");
+}
+
+#[pocket_ic_harness::test]
+async fn test_empty_feed(env: PocketIcTestEnv<MasticCanisterSetup>) {
+    let alice_canister = sign_up_user(&env, alice(), "alice".to_string()).await;
+    let alice_client = UserClient::new(&env, alice_canister);
+
+    let ReadFeedResponse::Ok(feed) = alice_client.read_feed(alice(), 0, 10).await else {
+        panic!("read_feed failed");
+    };
+    assert!(feed.is_empty());
+}
+
+#[pocket_ic_harness::test]
+async fn test_direct_message_visible_to_recipient_only(env: PocketIcTestEnv<MasticCanisterSetup>) {
+    let alice_canister = sign_up_user(&env, alice(), "alice".to_string()).await;
+    let bob_canister = sign_up_user(&env, bob(), "bob".to_string()).await;
+    let carol_canister = sign_up_user(&env, carol(), "carol".to_string()).await;
+
+    let alice_client = UserClient::new(&env, alice_canister);
+    publish(
+        &alice_client,
+        alice(),
+        "dm for bob",
+        Visibility::Direct,
+        vec![actor_uri("bob")],
+    )
+    .await;
+
+    let bob_client = UserClient::new(&env, bob_canister);
+    let ReadFeedResponse::Ok(bob_feed) = bob_client.read_feed(bob(), 0, 10).await else {
+        panic!("bob read_feed failed");
+    };
+    assert_eq!(bob_feed.len(), 1);
+    assert_eq!(bob_feed[0].status.content, "dm for bob");
+    assert_eq!(bob_feed[0].status.visibility, Visibility::Direct);
+
+    let carol_client = UserClient::new(&env, carol_canister);
+    let ReadFeedResponse::Ok(carol_feed) = carol_client.read_feed(carol(), 0, 10).await else {
+        panic!("carol read_feed failed");
+    };
+    assert!(carol_feed.is_empty(), "carol should not see the DM");
+}


### PR DESCRIPTION
## Summary

- Adds pocket-ic integration tests for Milestone 0 flows: follow (5), publish_status (7), get_statuses (3), read_feed (6) — 21 tests total, all passing.
- Introduces `charlie`/`carol`/`dave` test principals via `Principal::self_authenticating` and helpers (`actor_uri`, `advance_time_secs`, `follow_and_accept`) in `integration-tests/src/helpers.rs` to cut boilerplate across tests.
- Full federation routing is exercised (User → Federation → Directory → User) for follow, accept/reject, and Create(Note) delivery.

## Known production bug flagged

`publish.rs` `visibility_addressing` for `FollowersOnly` with no mentions emits `to=None, cc=None`. The receiver's `infer_visibility` then misclassifies the activity as `Direct` and `hydrate_inbox` drops it because the receiver isn't in `to`/`cc`. Fix (separate PR): include the owner's `/followers` collection URL in `to` for `FollowersOnly`. The `test_followers_only_not_delivered_to_strangers` test has a TODO to re-enable the follower-delivery assertion once this is fixed; it currently only verifies the non-follower exclusion half of the spec.

## Test plan

- [x] `cargo test --test follow` — 5/5 pass
- [x] `cargo test --test publish_status` — 7/7 pass
- [x] `cargo test --test get_statuses` — 3/3 pass
- [x] `cargo test --test read_feed` — 6/6 pass
- [x] `cargo clippy --all-features --all-targets -- -D warnings` — clean
- [x] `just fmt_nightly` — applied

Closes #11