### PR TITLE
feat(directory): implement delete profile flow (UC4)

### DIFF
--- a/crates/canisters/directory/src/adapters.rs
+++ b/crates/canisters/directory/src/adapters.rs
@@ -2,3 +2,4 @@
 
 pub mod federation_canister;
 pub mod management_canister;
+pub mod user_canister;

--- a/crates/canisters/directory/src/adapters/management_canister.rs
+++ b/crates/canisters/directory/src/adapters/management_canister.rs
@@ -38,6 +38,22 @@ pub trait ManagementCanister: Send + Sync + Sized {
         arg: Vec<u8>,
     ) -> impl Future<Output = Result<(), ManagementCanisterError>>;
 
+    /// Stops a running canister.
+    ///
+    /// Idempotent: stopping an already-stopped canister must succeed.
+    fn stop_canister(
+        &self,
+        canister_id: Principal,
+    ) -> impl Future<Output = Result<(), ManagementCanisterError>>;
+
+    /// Deletes a stopped canister, reclaiming its cycles and canister ID.
+    ///
+    /// Idempotent: deleting a non-existent canister must succeed.
+    fn delete_canister(
+        &self,
+        canister_id: Principal,
+    ) -> impl Future<Output = Result<(), ManagementCanisterError>>;
+
     /// Returns the current canister version.
     fn canister_version(&self) -> u64;
 
@@ -140,6 +156,74 @@ impl ManagementCanister for IcManagementCanisterClient {
         );
 
         Ok(())
+    }
+
+    async fn stop_canister(&self, canister_id: Principal) -> Result<(), ManagementCanisterError> {
+        ic_utils::log!(
+            "IcManagementCanisterClient::stop_canister: stopping canister {canister_id}"
+        );
+        let args = ic_management_canister_types::StopCanisterArgs { canister_id };
+
+        match ic_cdk::call::Call::bounded_wait(Principal::management_canister(), "stop_canister")
+            .with_arg(args)
+            .await
+        {
+            Ok(_) => {
+                ic_utils::log!(
+                    "IcManagementCanisterClient::stop_canister: stopped canister {canister_id}"
+                );
+                Ok(())
+            }
+            Err(e) => {
+                let msg = format!("{e:?}");
+                if msg.contains("CanisterNotFound")
+                    || msg.contains("Canister has already been stopped")
+                {
+                    ic_utils::log!(
+                        "IcManagementCanisterClient::stop_canister: treating as success for {canister_id}: {msg}"
+                    );
+                    Ok(())
+                } else {
+                    ic_utils::log!(
+                        "IcManagementCanisterClient::stop_canister: call failed for {canister_id}: {msg}"
+                    );
+                    Err(ManagementCanisterError::CallFailed(msg))
+                }
+            }
+        }
+    }
+
+    async fn delete_canister(&self, canister_id: Principal) -> Result<(), ManagementCanisterError> {
+        ic_utils::log!(
+            "IcManagementCanisterClient::delete_canister: deleting canister {canister_id}"
+        );
+        let args = ic_management_canister_types::DeleteCanisterArgs { canister_id };
+
+        match ic_cdk::call::Call::bounded_wait(Principal::management_canister(), "delete_canister")
+            .with_arg(args)
+            .await
+        {
+            Ok(_) => {
+                ic_utils::log!(
+                    "IcManagementCanisterClient::delete_canister: deleted canister {canister_id}"
+                );
+                Ok(())
+            }
+            Err(e) => {
+                let msg = format!("{e:?}");
+                if msg.contains("CanisterNotFound") {
+                    ic_utils::log!(
+                        "IcManagementCanisterClient::delete_canister: canister {canister_id} not found; treating as success"
+                    );
+                    Ok(())
+                } else {
+                    ic_utils::log!(
+                        "IcManagementCanisterClient::delete_canister: call failed for {canister_id}: {msg}"
+                    );
+                    Err(ManagementCanisterError::CallFailed(msg))
+                }
+            }
+        }
     }
 
     fn canister_version(&self) -> u64 {

--- a/crates/canisters/directory/src/adapters/management_canister/mock.rs
+++ b/crates/canisters/directory/src/adapters/management_canister/mock.rs
@@ -33,6 +33,17 @@ impl ManagementCanister for MockManagementCanisterClient {
         Ok(())
     }
 
+    async fn stop_canister(&self, _canister_id: Principal) -> Result<(), ManagementCanisterError> {
+        Ok(())
+    }
+
+    async fn delete_canister(
+        &self,
+        _canister_id: Principal,
+    ) -> Result<(), ManagementCanisterError> {
+        Ok(())
+    }
+
     fn canister_version(&self) -> u64 {
         0
     }

--- a/crates/canisters/directory/src/adapters/user_canister.rs
+++ b/crates/canisters/directory/src/adapters/user_canister.rs
@@ -1,0 +1,82 @@
+//! User canister adapter trait and implementations.
+//!
+//! Abstracts user canister calls (currently `emit_delete_profile_activity`) behind
+//! a trait so that directory domain logic can be unit-tested without a running replica.
+
+#[cfg(not(target_family = "wasm"))]
+pub mod mock;
+
+use std::future::Future;
+
+use candid::Principal;
+
+/// Abstraction over the user canister API.
+pub trait UserCanister: Send + Sync + Sized {
+    /// Ask the target user canister to aggregate and dispatch `Delete(Person)` activities
+    /// to all its followers.
+    fn emit_delete_profile_activity(
+        &self,
+        user_canister_id: Principal,
+    ) -> impl Future<Output = Result<(), UserCanisterError>>;
+}
+
+/// Errors returned by [`UserCanister`] operations.
+#[derive(Debug, Clone, thiserror::Error)]
+pub enum UserCanisterError {
+    /// The inter-canister call failed.
+    #[error("inter-canister call failed: {0}")]
+    #[allow(dead_code, reason = "constructed only in wasm builds")]
+    #[cfg(any(target_family = "wasm", test))]
+    CallFailed(String),
+    /// The response could not be decoded.
+    #[error("decode failed: {0}")]
+    #[allow(dead_code, reason = "constructed only in wasm builds")]
+    #[cfg(target_family = "wasm")]
+    DecodeFailed(String),
+}
+
+/// Production implementation that delegates to `ic_cdk` calls.
+#[cfg(target_family = "wasm")]
+pub struct IcUserCanisterClient;
+
+#[cfg(target_family = "wasm")]
+impl UserCanister for IcUserCanisterClient {
+    async fn emit_delete_profile_activity(
+        &self,
+        user_canister_id: Principal,
+    ) -> Result<(), UserCanisterError> {
+        use did::user::EmitDeleteProfileActivityResponse;
+
+        ic_utils::log!(
+            "IcUserCanisterClient::emit_delete_profile_activity: calling canister {user_canister_id}"
+        );
+
+        let raw =
+            ic_cdk::call::Call::bounded_wait(user_canister_id, "emit_delete_profile_activity")
+                .await
+                .map_err(|e| {
+                    ic_utils::log!(
+                        "IcUserCanisterClient::emit_delete_profile_activity: call failed: {e:?}"
+                    );
+                    UserCanisterError::CallFailed(format!("{e:?}"))
+                })?;
+
+        let response =
+            candid::decode_one::<EmitDeleteProfileActivityResponse>(&raw).map_err(|e| {
+                ic_utils::log!(
+                    "IcUserCanisterClient::emit_delete_profile_activity: decode failed: {e}"
+                );
+                UserCanisterError::DecodeFailed(e.to_string())
+            })?;
+
+        match response {
+            EmitDeleteProfileActivityResponse::Ok => Ok(()),
+            EmitDeleteProfileActivityResponse::Err(e) => {
+                ic_utils::log!(
+                    "IcUserCanisterClient::emit_delete_profile_activity: user canister error: {e:?}"
+                );
+                Err(UserCanisterError::CallFailed(format!("{e:?}")))
+            }
+        }
+    }
+}

--- a/crates/canisters/directory/src/adapters/user_canister/mock.rs
+++ b/crates/canisters/directory/src/adapters/user_canister/mock.rs
@@ -1,0 +1,18 @@
+//! Mock implementation of [`UserCanister`] for unit tests.
+
+use candid::Principal;
+
+use super::{UserCanister, UserCanisterError};
+
+/// A test-only [`UserCanister`] that always succeeds.
+#[derive(Debug)]
+pub struct MockUserCanisterClient;
+
+impl UserCanister for MockUserCanisterClient {
+    async fn emit_delete_profile_activity(
+        &self,
+        _user_canister_id: Principal,
+    ) -> Result<(), UserCanisterError> {
+        Ok(())
+    }
+}

--- a/crates/canisters/directory/src/api.rs
+++ b/crates/canisters/directory/src/api.rs
@@ -2,8 +2,9 @@
 
 use candid::Principal;
 use did::directory::{
-    DirectoryInstallArgs, GetUserArgs, GetUserResponse, RetrySignUpResponse, SignUpRequest,
-    SignUpResponse, UserCanisterResponse, WhoAmIResponse,
+    DeleteProfileResponse, DirectoryInstallArgs, GetUserArgs, GetUserResponse,
+    RetryDeleteProfileResponse, RetrySignUpResponse, SignUpRequest, SignUpResponse,
+    UserCanisterResponse, WhoAmIResponse,
 };
 use ic_dbms_canister::prelude::DBMS_CONTEXT;
 
@@ -56,9 +57,25 @@ pub fn post_upgrade(args: DirectoryInstallArgs) {
     ic_utils::log!("Directory canister post-upgrade completed successfully");
 }
 
+/// Handles the `delete_profile` method call to delete the caller's profile and User Canister.
+pub fn delete_profile() -> DeleteProfileResponse {
+    let caller = ic_utils::caller();
+
+    crate::domain::users::delete_profile(caller)
+}
+
 /// Handles the `get_user` method call to retrieve user information by handle or principal.
 pub fn get_user(args: GetUserArgs) -> GetUserResponse {
     crate::domain::users::get_user(args)
+}
+
+/// Retry an interrupted profile deletion for the caller. Callable only when the
+/// caller's canister status is `DeletionPending`.
+pub fn retry_delete_profile() -> RetryDeleteProfileResponse {
+    let caller = ic_utils::caller();
+    ic_utils::log!("retry_delete_profile called by {caller}");
+
+    crate::domain::users::retry_delete_profile(caller)
 }
 
 /// Retry canister creation for the user that called this method.

--- a/crates/canisters/directory/src/domain.rs
+++ b/crates/canisters/directory/src/domain.rs
@@ -1,4 +1,5 @@
 //! Domain types for the Directory Canister
 
 pub mod moderators;
+pub mod tombstone;
 pub mod users;

--- a/crates/canisters/directory/src/domain/tombstone.rs
+++ b/crates/canisters/directory/src/domain/tombstone.rs
@@ -1,0 +1,5 @@
+//! Tombstone domain
+
+mod repository;
+
+pub use self::repository::TombstoneRepository;

--- a/crates/canisters/directory/src/domain/tombstone/repository.rs
+++ b/crates/canisters/directory/src/domain/tombstone/repository.rs
@@ -1,0 +1,87 @@
+//! Tombstone repository
+
+use candid::Principal;
+use ic_dbms_canister::prelude::DBMS_CONTEXT;
+use wasm_dbms::WasmDbmsDatabase;
+use wasm_dbms_api::prelude::{Database as _, Filter, Query};
+
+use crate::error::CanisterResult;
+use crate::schema::{Schema, Tombstone, TombstoneInsertRequest, TombstoneUpdateRequest};
+
+/// Time-to-live for tombstone records in seconds (e.g. 30 days)
+const TOMBSTONE_TTL_SECONDS: u64 = 60 * 60 * 24 * 30;
+
+/// Repository for managing tombstone records of deleted user profiles.
+pub struct TombstoneRepository;
+
+impl TombstoneRepository {
+    /// Inserts a [`Tombstone`] record for the given user principal and handle.
+    pub fn insert_or_update(user_principal: Principal, handle: String) -> CanisterResult<()> {
+        ic_utils::log!(
+            "TombstoneRepository::insert: inserting tombstone for user {user_principal} with handle {handle}"
+        );
+
+        if Self::is_tombstoned(&handle)? {
+            ic_utils::log!(
+                "TombstoneRepository::insert: existing tombstone found for handle {handle}, updating deleted_at timestamp"
+            );
+
+            let update_request = TombstoneUpdateRequest {
+                deleted_at: Some(ic_utils::now().into()),
+                where_clause: Some(Filter::eq("handle", handle.into())),
+                ..Default::default()
+            };
+
+            DBMS_CONTEXT.with(|ctx| {
+                let dbms = WasmDbmsDatabase::oneshot(ctx, Schema);
+                dbms.update::<Tombstone>(update_request)
+            })?;
+        } else {
+            ic_utils::log!(
+                "TombstoneRepository::insert: no existing tombstone found for handle {handle}, inserting new record"
+            );
+
+            let insert = TombstoneInsertRequest {
+                handle: handle.into(),
+                principal: ic_dbms_canister::prelude::Principal(user_principal),
+                deleted_at: ic_utils::now().into(),
+            };
+
+            DBMS_CONTEXT.with(|ctx| {
+                let dbms = WasmDbmsDatabase::oneshot(ctx, Schema);
+                dbms.insert::<Tombstone>(insert)
+            })?;
+        }
+
+        Ok(())
+    }
+
+    /// Checks if a given handle is currently tombstoned (i.e. has a tombstone record with a `deleted_at` timestamp within the TTL).
+    pub fn is_tombstoned(handle: &str) -> CanisterResult<bool> {
+        ic_utils::log!(
+            "TombstoneRepository::is_tombstoned: checking if handle {handle} is tombstoned"
+        );
+        let rows = DBMS_CONTEXT.with(|ctx| {
+            let dbms = WasmDbmsDatabase::oneshot(ctx, Schema);
+            dbms.select::<Tombstone>(
+                Query::builder()
+                    .field("deleted_at")
+                    .limit(1)
+                    .and_where(Filter::eq("handle", handle.into()))
+                    .build(),
+            )
+        })?;
+
+        // get `deleted_at` value from the first row if it exists, otherwise return false
+        let Some(row) = rows.first() else {
+            ic_utils::log!(
+                "TombstoneRepository::is_tombstoned: no tombstone record found for handle {handle}"
+            );
+            return Ok(false);
+        };
+
+        let deleted_at = row.deleted_at.expect("must be set").0;
+
+        Ok(ic_utils::now() - deleted_at < TOMBSTONE_TTL_SECONDS)
+    }
+}

--- a/crates/canisters/directory/src/domain/users.rs
+++ b/crates/canisters/directory/src/domain/users.rs
@@ -1,11 +1,13 @@
 //! Users domain logic.
 
+mod delete_profile;
 mod get_user;
 pub(crate) mod repository;
 mod sign_up;
 mod user_canister;
 mod whoami;
 
+pub use self::delete_profile::{delete_profile, retry_delete_profile};
 pub use self::get_user::get_user;
 pub use self::sign_up::{retry_sign_up, sign_up};
 pub use self::user_canister::user_canister;

--- a/crates/canisters/directory/src/domain/users/delete_profile.rs
+++ b/crates/canisters/directory/src/domain/users/delete_profile.rs
@@ -1,0 +1,268 @@
+//! Domain logic for deleting a user's profile and associated User Canister.
+
+mod state;
+
+use candid::Principal;
+use did::directory::{
+    DeleteProfileError, DeleteProfileResponse, RetryDeleteProfileError, RetryDeleteProfileResponse,
+    UserCanisterStatus,
+};
+
+use crate::domain::tombstone::TombstoneRepository;
+use crate::domain::users::repository::UserRepository;
+
+/// Handles the `delete_profile` method call to delete the caller's profile and User Canister.
+///
+/// Flow:
+/// 0. Reject anonymous principal.
+/// 1. Look up the user in the database.
+/// 2. Validate canister status: must be `Active` (not mid-creation or mid-deletion).
+/// 3. Insert a tombstone for the handle to prevent immediate reuse.
+/// 4. Mark the user `DeletionPending` in the directory.
+/// 5. Spawn the in-memory state machine that drives activity dispatch, canister
+///    stop/delete, and final row removal.
+pub fn delete_profile(caller: Principal) -> DeleteProfileResponse {
+    ic_utils::log!("delete_profile called by {caller}");
+
+    if caller == Principal::anonymous() {
+        ic_utils::log!("delete_profile: rejected anonymous principal");
+        return DeleteProfileResponse::Err(DeleteProfileError::AnonymousPrincipal);
+    }
+
+    let user = match UserRepository::get_user_by_principal(caller) {
+        Ok(Some(user)) => user,
+        Ok(None) => {
+            ic_utils::log!("delete_profile: user {caller} not registered");
+            return DeleteProfileResponse::Err(DeleteProfileError::NotRegistered);
+        }
+        Err(err) => {
+            ic_utils::log!("delete_profile: failed to look up user {caller}: {err}");
+            return DeleteProfileResponse::Err(DeleteProfileError::Internal(err.to_string()));
+        }
+    };
+
+    let canister_id = match (user.canister_status.0, user.canister_id.into_opt()) {
+        (UserCanisterStatus::Active, Some(cid)) => cid.0,
+        (UserCanisterStatus::DeletionPending, _) => {
+            ic_utils::log!("delete_profile: deletion already in progress for {caller}");
+            return DeleteProfileResponse::Err(DeleteProfileError::DeletionAlreadyInProgress);
+        }
+        (status, _) => {
+            ic_utils::log!(
+                "delete_profile: user {caller} canister not active (status: {status:?})"
+            );
+            return DeleteProfileResponse::Err(DeleteProfileError::CanisterNotActive);
+        }
+    };
+
+    let handle = user.handle.0.clone();
+
+    if let Err(err) = TombstoneRepository::insert_or_update(caller, handle.clone()) {
+        ic_utils::log!("delete_profile: failed to insert tombstone for {caller}: {err}");
+        return DeleteProfileResponse::Err(DeleteProfileError::Internal(err.to_string()));
+    }
+
+    if let Err(err) = UserRepository::mark_user_for_deletion(caller) {
+        ic_utils::log!("delete_profile: failed to mark user {caller} for deletion: {err}");
+        return DeleteProfileResponse::Err(DeleteProfileError::Internal(err.to_string()));
+    }
+
+    start_delete_profile_state_machine(caller, canister_id);
+
+    DeleteProfileResponse::Ok
+}
+
+/// Retry an interrupted `delete_profile` flow for the caller.
+///
+/// Allowed only when the caller is currently in `DeletionPending` state. Tombstone
+/// and repository state stay as-is; the state machine restarts from `EmitActivities`.
+/// All management-canister calls are idempotent, so re-running previously completed
+/// steps is safe.
+pub fn retry_delete_profile(caller: Principal) -> RetryDeleteProfileResponse {
+    ic_utils::log!("retry_delete_profile called by {caller}");
+
+    if caller == Principal::anonymous() {
+        ic_utils::log!("retry_delete_profile: rejected anonymous principal");
+        return RetryDeleteProfileResponse::Err(RetryDeleteProfileError::NotRegistered);
+    }
+
+    let user = match UserRepository::get_user_by_principal(caller) {
+        Ok(Some(user)) => user,
+        Ok(None) => {
+            ic_utils::log!("retry_delete_profile: user {caller} not registered");
+            return RetryDeleteProfileResponse::Err(RetryDeleteProfileError::NotRegistered);
+        }
+        Err(err) => {
+            ic_utils::log!("retry_delete_profile: failed to look up user {caller}: {err}");
+            return RetryDeleteProfileResponse::Err(RetryDeleteProfileError::Internal(
+                err.to_string(),
+            ));
+        }
+    };
+
+    if user.canister_status.0 != UserCanisterStatus::DeletionPending {
+        ic_utils::log!(
+            "retry_delete_profile: user {caller} not in deletion-pending state (status: {:?})",
+            user.canister_status.0
+        );
+        return RetryDeleteProfileResponse::Err(
+            RetryDeleteProfileError::CanisterNotInDeletionState,
+        );
+    }
+
+    let Some(canister_id) = user.canister_id.into_opt() else {
+        ic_utils::log!("retry_delete_profile: user {caller} has no canister_id set");
+        return RetryDeleteProfileResponse::Err(RetryDeleteProfileError::Internal(
+            "user has no canister_id".to_string(),
+        ));
+    };
+
+    start_delete_profile_state_machine(caller, canister_id.0);
+
+    RetryDeleteProfileResponse::Ok
+}
+
+fn start_delete_profile_state_machine(_user_id: Principal, _canister_id: Principal) {
+    #[cfg(target_family = "wasm")]
+    {
+        state::DeleteProfileStateMachine::start(
+            _user_id,
+            _canister_id,
+            crate::adapters::management_canister::IcManagementCanisterClient,
+            crate::adapters::user_canister::IcUserCanisterClient,
+        );
+    }
+    #[cfg(not(target_family = "wasm"))]
+    {
+        state::DeleteProfileStateMachine::start(
+            _user_id,
+            _canister_id,
+            crate::adapters::management_canister::mock::MockManagementCanisterClient {
+                canister_self: Principal::management_canister(),
+                created_canister_id: _canister_id,
+            },
+            crate::adapters::user_canister::mock::MockUserCanisterClient,
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_utils::{bob, rey_canisteryo, setup, setup_registered_user_with_canister};
+
+    #[test]
+    fn test_should_reject_anonymous() {
+        setup();
+
+        let response = delete_profile(Principal::anonymous());
+
+        assert_eq!(
+            response,
+            DeleteProfileResponse::Err(DeleteProfileError::AnonymousPrincipal)
+        );
+    }
+
+    #[test]
+    fn test_should_reject_unregistered() {
+        setup();
+
+        let response = delete_profile(bob());
+
+        assert_eq!(
+            response,
+            DeleteProfileResponse::Err(DeleteProfileError::NotRegistered)
+        );
+    }
+
+    #[test]
+    fn test_should_reject_when_canister_not_active() {
+        setup();
+        UserRepository::sign_up(bob(), "bob".to_string()).expect("should sign up");
+
+        let response = delete_profile(bob());
+
+        assert_eq!(
+            response,
+            DeleteProfileResponse::Err(DeleteProfileError::CanisterNotActive)
+        );
+    }
+
+    #[test]
+    fn test_should_mark_user_for_deletion_and_insert_tombstone() {
+        setup();
+        setup_registered_user_with_canister(bob(), "bob", rey_canisteryo());
+
+        let response = delete_profile(bob());
+        assert_eq!(response, DeleteProfileResponse::Ok);
+
+        let user = UserRepository::get_user_by_principal(bob())
+            .expect("should query user")
+            .expect("user should still exist pre-commit");
+        assert_eq!(user.canister_status.0, UserCanisterStatus::DeletionPending);
+
+        assert!(TombstoneRepository::is_tombstoned("bob").expect("should query tombstone"));
+    }
+
+    #[test]
+    fn test_should_reject_double_delete() {
+        setup();
+        setup_registered_user_with_canister(bob(), "bob", rey_canisteryo());
+
+        delete_profile(bob());
+        let response = delete_profile(bob());
+
+        assert_eq!(
+            response,
+            DeleteProfileResponse::Err(DeleteProfileError::DeletionAlreadyInProgress)
+        );
+    }
+
+    #[test]
+    fn test_retry_should_reject_anonymous() {
+        setup();
+
+        let response = retry_delete_profile(Principal::anonymous());
+
+        assert_eq!(
+            response,
+            RetryDeleteProfileResponse::Err(RetryDeleteProfileError::NotRegistered)
+        );
+    }
+
+    #[test]
+    fn test_retry_should_reject_unregistered() {
+        setup();
+
+        let response = retry_delete_profile(bob());
+
+        assert_eq!(
+            response,
+            RetryDeleteProfileResponse::Err(RetryDeleteProfileError::NotRegistered)
+        );
+    }
+
+    #[test]
+    fn test_retry_should_reject_when_not_in_deletion_state() {
+        setup();
+        setup_registered_user_with_canister(bob(), "bob", rey_canisteryo());
+
+        let response = retry_delete_profile(bob());
+
+        assert_eq!(
+            response,
+            RetryDeleteProfileResponse::Err(RetryDeleteProfileError::CanisterNotInDeletionState)
+        );
+    }
+
+    #[test]
+    fn test_retry_should_succeed_after_delete_marks_user() {
+        setup();
+        setup_registered_user_with_canister(bob(), "bob", rey_canisteryo());
+
+        delete_profile(bob());
+
+        let response = retry_delete_profile(bob());
+        assert_eq!(response, RetryDeleteProfileResponse::Ok);
+    }
+}

--- a/crates/canisters/directory/src/domain/users/delete_profile/state.rs
+++ b/crates/canisters/directory/src/domain/users/delete_profile/state.rs
@@ -1,0 +1,489 @@
+//! State machine for the `delete_profile` domain logic.
+//!
+//! Mirrors the sign_up state-machine pattern. Only `DeletionPending` is persisted
+//! in the directory database; fine-grained progress lives in this in-memory state.
+//! Each management-canister step is idempotent so that `retry_delete_profile`
+//! can safely restart from the beginning.
+
+use std::cell::RefCell;
+use std::collections::HashMap;
+use std::time::Duration;
+
+use candid::Principal;
+
+use crate::adapters::management_canister::ManagementCanister;
+use crate::adapters::user_canister::UserCanister;
+use crate::domain::users::repository::UserRepository;
+
+thread_local! {
+    /// Active delete_profile states, keyed by user principal.
+    static USER_DELETE_STATES: RefCell<HashMap<Principal, DeleteStateStep>> = RefCell::new(HashMap::new());
+}
+
+/// Minimum interval between two delete-profile operations to spread load.
+const OPERATION_INTERVAL: Duration = Duration::from_secs(1);
+/// Maximum number of retries for each step before giving up.
+const MAX_RETRIES: u8 = 5;
+
+/// A step in the delete_profile process, along with the number of retries attempted.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct DeleteStateStep {
+    state: DeleteState,
+    retries: u8,
+}
+
+/// In-memory state of the delete_profile process.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum DeleteState {
+    /// Ask the user canister to emit `Delete(Person)` activities to all followers.
+    EmitActivities { canister_id: Principal },
+    /// Stop the user canister via the management canister.
+    StopCanister { canister_id: Principal },
+    /// Delete the user canister via the management canister.
+    DeleteCanister { canister_id: Principal },
+    /// Remove the directory's user record.
+    Commit,
+}
+
+/// Result of a single state-machine step.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum StepResult {
+    /// Continue processing with updated state.
+    Continue(DeleteStateStep),
+    /// The delete_profile process is complete; clean up.
+    Finished,
+}
+
+/// State machine for the user delete_profile process.
+///
+/// Generic over `M` (management canister) and `U` (user canister) so that
+/// both dependencies can be replaced with mocks during unit tests.
+pub struct DeleteProfileStateMachine<M, U>
+where
+    M: ManagementCanister + 'static,
+    U: UserCanister + 'static,
+{
+    /// The user whose profile is being deleted.
+    user_id: Principal,
+    /// Adapter for management canister calls.
+    management: M,
+    /// Adapter for user canister calls.
+    user_canister: U,
+}
+
+impl<M, U> DeleteProfileStateMachine<M, U>
+where
+    M: ManagementCanister + 'static,
+    U: UserCanister + 'static,
+{
+    /// Start a new delete_profile process for a user.
+    pub fn start(user_id: Principal, canister_id: Principal, management: M, user_canister: U) {
+        ic_utils::log!("Starting delete_profile for user {user_id} (canister {canister_id})");
+        let already_exists = USER_DELETE_STATES.with_borrow(|states| states.contains_key(&user_id));
+        if already_exists {
+            return;
+        }
+
+        USER_DELETE_STATES.with_borrow_mut(|states| {
+            states.insert(
+                user_id,
+                DeleteStateStep {
+                    state: DeleteState::EmitActivities { canister_id },
+                    retries: 0,
+                },
+            )
+        });
+
+        Self {
+            user_id,
+            management,
+            user_canister,
+        }
+        .tick();
+    }
+
+    /// Tick the state machine.
+    fn tick(self) {
+        ic_utils::log!("Ticking delete_profile for user {}", self.user_id);
+        ic_utils::set_timer(OPERATION_INTERVAL, async move {
+            ic_utils::log!("Delete timer fired for user {}", self.user_id);
+            self.run().await;
+        });
+    }
+
+    /// Run a step of the delete_profile process.
+    async fn run(self) {
+        let Some(current) =
+            USER_DELETE_STATES.with_borrow(|states| states.get(&self.user_id).copied())
+        else {
+            return;
+        };
+
+        match self.step(current).await {
+            StepResult::Continue(next) => {
+                USER_DELETE_STATES.with_borrow_mut(|states| states.insert(self.user_id, next));
+                self.tick();
+            }
+            StepResult::Finished => self.finish(),
+        }
+    }
+
+    /// Execute a single state-transition step.
+    async fn step(&self, current: DeleteStateStep) -> StepResult {
+        let DeleteStateStep { state, retries } = current;
+        ic_utils::log!(
+            "delete_profile step for user {}: state={state:?}, retries={retries}",
+            self.user_id,
+        );
+        let current_discriminant = std::mem::discriminant(&state);
+
+        if retries >= MAX_RETRIES {
+            ic_utils::log!(
+                "delete_profile for user {} exhausted retries at state {state:?}; giving up",
+                self.user_id
+            );
+            return StepResult::Finished;
+        }
+
+        let new_state = match state {
+            DeleteState::EmitActivities { canister_id } => self.emit_activities(canister_id).await,
+            DeleteState::StopCanister { canister_id } => self.stop_canister(canister_id).await,
+            DeleteState::DeleteCanister { canister_id } => self.delete_canister(canister_id).await,
+            DeleteState::Commit => match self.commit() {
+                Ok(()) => return StepResult::Finished,
+                Err(_) => DeleteState::Commit,
+            },
+        };
+        let new_discriminant = std::mem::discriminant(&new_state);
+
+        let next = if current_discriminant == new_discriminant {
+            DeleteStateStep {
+                state: new_state,
+                retries: retries + 1,
+            }
+        } else {
+            DeleteStateStep {
+                state: new_state,
+                retries: 0,
+            }
+        };
+
+        StepResult::Continue(next)
+    }
+
+    async fn emit_activities(&self, canister_id: Principal) -> DeleteState {
+        if self
+            .user_canister
+            .emit_delete_profile_activity(canister_id)
+            .await
+            .is_err()
+        {
+            return DeleteState::EmitActivities { canister_id };
+        }
+
+        DeleteState::StopCanister { canister_id }
+    }
+
+    async fn stop_canister(&self, canister_id: Principal) -> DeleteState {
+        if self.management.stop_canister(canister_id).await.is_err() {
+            return DeleteState::StopCanister { canister_id };
+        }
+
+        DeleteState::DeleteCanister { canister_id }
+    }
+
+    async fn delete_canister(&self, canister_id: Principal) -> DeleteState {
+        if self.management.delete_canister(canister_id).await.is_err() {
+            return DeleteState::DeleteCanister { canister_id };
+        }
+
+        DeleteState::Commit
+    }
+
+    fn commit(&self) -> crate::error::CanisterResult<()> {
+        UserRepository::remove_user(self.user_id)
+    }
+
+    fn finish(&self) {
+        ic_utils::log!("delete_profile finished for user {}", self.user_id);
+        USER_DELETE_STATES.with_borrow_mut(|states| states.remove(&self.user_id));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::adapters::management_canister::ManagementCanisterError;
+    use crate::adapters::user_canister::UserCanisterError;
+    use crate::test_utils::{rey_canisteryo, setup};
+
+    struct TestManagementClient {
+        stop_result: Result<(), ManagementCanisterError>,
+        delete_result: Result<(), ManagementCanisterError>,
+    }
+
+    impl TestManagementClient {
+        fn ok() -> Self {
+            Self {
+                stop_result: Ok(()),
+                delete_result: Ok(()),
+            }
+        }
+
+        fn with_stop_err(mut self) -> Self {
+            self.stop_result = Err(ManagementCanisterError::CallFailed("test".to_string()));
+            self
+        }
+
+        fn with_delete_err(mut self) -> Self {
+            self.delete_result = Err(ManagementCanisterError::CallFailed("test".to_string()));
+            self
+        }
+    }
+
+    impl ManagementCanister for TestManagementClient {
+        async fn create_canister(
+            &self,
+            _settings: Option<ic_management_canister_types::CanisterSettings>,
+            _cycles: u128,
+        ) -> Result<Principal, ManagementCanisterError> {
+            unimplemented!()
+        }
+
+        async fn install_code(
+            &self,
+            _canister_id: Principal,
+            _wasm_module: &[u8],
+            _arg: Vec<u8>,
+        ) -> Result<(), ManagementCanisterError> {
+            unimplemented!()
+        }
+
+        async fn stop_canister(
+            &self,
+            _canister_id: Principal,
+        ) -> Result<(), ManagementCanisterError> {
+            self.stop_result.clone()
+        }
+
+        async fn delete_canister(
+            &self,
+            _canister_id: Principal,
+        ) -> Result<(), ManagementCanisterError> {
+            self.delete_result.clone()
+        }
+
+        fn canister_version(&self) -> u64 {
+            0
+        }
+
+        fn canister_self(&self) -> Principal {
+            Principal::management_canister()
+        }
+    }
+
+    struct TestUserCanisterClient {
+        emit_result: Result<(), UserCanisterError>,
+    }
+
+    impl TestUserCanisterClient {
+        fn ok() -> Self {
+            Self {
+                emit_result: Ok(()),
+            }
+        }
+
+        fn with_emit_err(mut self) -> Self {
+            self.emit_result = Err(UserCanisterError::CallFailed("test".to_string()));
+            self
+        }
+    }
+
+    impl UserCanister for TestUserCanisterClient {
+        async fn emit_delete_profile_activity(
+            &self,
+            _user_canister_id: Principal,
+        ) -> Result<(), UserCanisterError> {
+            self.emit_result.clone()
+        }
+    }
+
+    fn user_canister_id() -> Principal {
+        Principal::from_text("b77ix-eeaaa-aaaaa-qaada-cai").unwrap()
+    }
+
+    fn machine(
+        mgmt: TestManagementClient,
+        user: TestUserCanisterClient,
+    ) -> DeleteProfileStateMachine<TestManagementClient, TestUserCanisterClient> {
+        DeleteProfileStateMachine {
+            user_id: rey_canisteryo(),
+            management: mgmt,
+            user_canister: user,
+        }
+    }
+
+    #[tokio::test]
+    async fn test_emit_activities_advances_to_stop_canister() {
+        let sm = machine(TestManagementClient::ok(), TestUserCanisterClient::ok());
+
+        let result = sm.emit_activities(user_canister_id()).await;
+
+        assert_eq!(
+            result,
+            DeleteState::StopCanister {
+                canister_id: user_canister_id()
+            }
+        );
+    }
+
+    #[tokio::test]
+    async fn test_emit_activities_stays_on_failure() {
+        let sm = machine(
+            TestManagementClient::ok(),
+            TestUserCanisterClient::ok().with_emit_err(),
+        );
+
+        let result = sm.emit_activities(user_canister_id()).await;
+
+        assert_eq!(
+            result,
+            DeleteState::EmitActivities {
+                canister_id: user_canister_id()
+            }
+        );
+    }
+
+    #[tokio::test]
+    async fn test_stop_canister_advances_to_delete_canister() {
+        let sm = machine(TestManagementClient::ok(), TestUserCanisterClient::ok());
+
+        let result = sm.stop_canister(user_canister_id()).await;
+
+        assert_eq!(
+            result,
+            DeleteState::DeleteCanister {
+                canister_id: user_canister_id()
+            }
+        );
+    }
+
+    #[tokio::test]
+    async fn test_stop_canister_stays_on_failure() {
+        let sm = machine(
+            TestManagementClient::ok().with_stop_err(),
+            TestUserCanisterClient::ok(),
+        );
+
+        let result = sm.stop_canister(user_canister_id()).await;
+
+        assert_eq!(
+            result,
+            DeleteState::StopCanister {
+                canister_id: user_canister_id()
+            }
+        );
+    }
+
+    #[tokio::test]
+    async fn test_delete_canister_advances_to_commit() {
+        let sm = machine(TestManagementClient::ok(), TestUserCanisterClient::ok());
+
+        let result = sm.delete_canister(user_canister_id()).await;
+
+        assert_eq!(result, DeleteState::Commit);
+    }
+
+    #[tokio::test]
+    async fn test_delete_canister_stays_on_failure() {
+        let sm = machine(
+            TestManagementClient::ok().with_delete_err(),
+            TestUserCanisterClient::ok(),
+        );
+
+        let result = sm.delete_canister(user_canister_id()).await;
+
+        assert_eq!(
+            result,
+            DeleteState::DeleteCanister {
+                canister_id: user_canister_id()
+            }
+        );
+    }
+
+    #[tokio::test]
+    async fn test_commit_removes_user_row() {
+        setup();
+        UserRepository::sign_up(rey_canisteryo(), "alice".to_string())
+            .expect("should sign up user");
+
+        let sm = machine(TestManagementClient::ok(), TestUserCanisterClient::ok());
+
+        sm.commit().expect("commit should succeed");
+
+        let user =
+            UserRepository::get_user_by_principal(rey_canisteryo()).expect("should query user");
+        assert!(user.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_step_increments_retries_on_same_state() {
+        let sm = machine(
+            TestManagementClient::ok(),
+            TestUserCanisterClient::ok().with_emit_err(),
+        );
+        let current = DeleteStateStep {
+            state: DeleteState::EmitActivities {
+                canister_id: user_canister_id(),
+            },
+            retries: 1,
+        };
+
+        let result = sm.step(current).await;
+
+        assert_eq!(
+            result,
+            StepResult::Continue(DeleteStateStep {
+                state: DeleteState::EmitActivities {
+                    canister_id: user_canister_id()
+                },
+                retries: 2,
+            })
+        );
+    }
+
+    #[tokio::test]
+    async fn test_step_finishes_on_max_retries() {
+        let sm = machine(
+            TestManagementClient::ok(),
+            TestUserCanisterClient::ok().with_emit_err(),
+        );
+        let current = DeleteStateStep {
+            state: DeleteState::EmitActivities {
+                canister_id: user_canister_id(),
+            },
+            retries: MAX_RETRIES,
+        };
+
+        let result = sm.step(current).await;
+
+        assert_eq!(result, StepResult::Finished);
+    }
+
+    #[tokio::test]
+    async fn test_step_finishes_on_successful_commit() {
+        setup();
+        UserRepository::sign_up(rey_canisteryo(), "alice".to_string())
+            .expect("should sign up user");
+
+        let sm = machine(TestManagementClient::ok(), TestUserCanisterClient::ok());
+        let current = DeleteStateStep {
+            state: DeleteState::Commit,
+            retries: 0,
+        };
+
+        let result = sm.step(current).await;
+
+        assert_eq!(result, StepResult::Finished);
+    }
+}

--- a/crates/canisters/directory/src/domain/users/repository.rs
+++ b/crates/canisters/directory/src/domain/users/repository.rs
@@ -206,6 +206,61 @@ impl UserRepository {
         }
     }
 
+    /// Marks a user for deletion by setting their canister status to deletion pending.
+    /// The actual deletion of the user record and User Canister is handled asynchronously by the state machine.
+    pub fn mark_user_for_deletion(user_principal: Principal) -> CanisterResult<()> {
+        ic_utils::log!(
+            "UserRepository::mark_user_for_deletion: marking user {user_principal} for deletion"
+        );
+        let update = UserUpdateRequest {
+            canister_status: Some(UserCanisterStatus(
+                did::directory::UserCanisterStatus::DeletionPending,
+            )),
+            where_clause: Some(Filter::eq(
+                User::primary_key(),
+                ic_dbms_canister::prelude::Principal(user_principal).into(),
+            )),
+            ..Default::default()
+        };
+        let rows = DBMS_CONTEXT.with(|ctx| {
+            let dbms = WasmDbmsDatabase::oneshot(ctx, Schema);
+            dbms.update::<User>(update)
+        })?;
+
+        if rows == 0 {
+            return Err(CanisterError::SignUpFailed(format!(
+                "failed to mark user {user_principal} for deletion"
+            )));
+        }
+
+        Ok(())
+    }
+
+    /// Removes a user record from the database. Called by the delete_profile state machine
+    /// after the user canister has been stopped and deleted.
+    pub fn remove_user(user_principal: Principal) -> CanisterResult<()> {
+        ic_utils::log!("UserRepository::remove_user: removing user {user_principal}");
+
+        let deleted = DBMS_CONTEXT.with(|ctx| {
+            let dbms = WasmDbmsDatabase::oneshot(ctx, Schema);
+            dbms.delete::<User>(
+                DeleteBehavior::Restrict,
+                Some(Filter::eq(
+                    User::primary_key(),
+                    ic_dbms_canister::prelude::Principal(user_principal).into(),
+                )),
+            )
+        })?;
+
+        if deleted == 0 {
+            return Err(CanisterError::SignUpFailed(format!(
+                "no user record found for {user_principal}"
+            )));
+        }
+
+        Ok(())
+    }
+
     fn user_record_to_user(user: UserRecord) -> User {
         User {
             principal: user.principal.expect("principal cannot be empty"),

--- a/crates/canisters/directory/src/domain/users/sign_up.rs
+++ b/crates/canisters/directory/src/domain/users/sign_up.rs
@@ -6,6 +6,7 @@ use did::directory::{
     RetrySignUpError, RetrySignUpResponse, SignUpError, SignUpRequest, SignUpResponse,
 };
 
+use crate::domain::tombstone::TombstoneRepository;
 use crate::domain::users::repository::UserRepository;
 
 mod state;
@@ -23,11 +24,8 @@ mod state;
 /// 5. Spawn the state machine that will drive the user canister creation process, and return [`SignUpResponse::Ok`].
 ///
 /// Any internal error is returned as [`SignUpError::InternalError`] with a message describing the error.
-pub fn sign_up(user_id: Principal, request: SignUpRequest) -> SignUpResponse {
-    ic_utils::log!(
-        "sign_up: starting for user {user_id} with handle {:?}",
-        request.handle
-    );
+pub fn sign_up(user_id: Principal, SignUpRequest { handle }: SignUpRequest) -> SignUpResponse {
+    ic_utils::log!("sign_up: starting for user {user_id} with handle {handle}");
 
     // 0. Check if the caller's principal is anonymous, if it is, return [`SignUpError::AnonymousPrincipal`].
     if user_id == Principal::anonymous() {
@@ -51,44 +49,62 @@ pub fn sign_up(user_id: Principal, request: SignUpRequest) -> SignUpResponse {
     };
 
     // 2. Sanitize and validate the handle. See `handles.md` document for specs.
-    let handle = HandleSanitizer::sanitize_handle(&request.handle);
-    ic_utils::log!(
-        "sign_up: sanitized handle {:?} -> {handle:?}",
-        request.handle
-    );
-    if HandleValidator::check_handle(&handle).is_err() {
-        ic_utils::log!("sign_up: handle {handle:?} is invalid");
+    let sanitized_handle: String = HandleSanitizer::sanitize_handle(&handle);
+    ic_utils::log!("sign_up: sanitized handle {handle} -> {sanitized_handle}",);
+    if HandleValidator::check_handle(&sanitized_handle).is_err() {
+        ic_utils::log!("sign_up: handle {sanitized_handle} is invalid");
         return SignUpResponse::Err(SignUpError::InvalidHandle);
     }
 
-    // 3. Check if the handle is already taken by another user in the database, if it is, return [`SignUpError::HandleTaken`].
-    match UserRepository::get_user_by_handle(&handle) {
+    // 3. check whether is tombstoned
+    match TombstoneRepository::is_tombstoned(&sanitized_handle) {
+        Ok(true) => {
+            ic_utils::log!("sign_up: handle {sanitized_handle} is currently tombstoned");
+            return SignUpResponse::Err(SignUpError::HandleTombstoned);
+        }
+        Ok(false) => {
+            ic_utils::log!(
+                "sign_up: handle {sanitized_handle} is not tombstoned, proceeding with sign up"
+            );
+        }
         Err(err) => {
-            ic_utils::log!("sign_up: internal error checking handle {handle:?}: {err}");
+            ic_utils::log!(
+                "sign_up: internal error checking tombstone for handle {sanitized_handle}: {err}"
+            );
+            return SignUpResponse::Err(SignUpError::InternalError(format!(
+                "Failed to check tombstone for handle: {err}"
+            )));
+        }
+    }
+
+    // 4. Check if the handle is already taken by another user in the database, if it is, return [`SignUpError::HandleTaken`].
+    match UserRepository::get_user_by_handle(&sanitized_handle) {
+        Err(err) => {
+            ic_utils::log!("sign_up: internal error checking handle {sanitized_handle}: {err}");
             return SignUpResponse::Err(SignUpError::InternalError(format!(
                 "Failed to check existing user by handle: {err}"
             )));
         }
         Ok(Some(_)) => {
-            ic_utils::log!("sign_up: handle {handle:?} is already taken");
+            ic_utils::log!("sign_up: handle {sanitized_handle:?} is already taken");
             return SignUpResponse::Err(SignUpError::HandleTaken);
         }
         Ok(None) => (),
     };
 
-    // 4. Insert the new user in the database with the canister status set to [`did::directory::UserCanisterStatus::CreationPending`].
-    if let Err(err) = UserRepository::sign_up(user_id, handle.clone()) {
+    // 5. Insert the new user in the database with the canister status set to [`did::directory::UserCanisterStatus::CreationPending`].
+    if let Err(err) = UserRepository::sign_up(user_id, sanitized_handle.clone()) {
         ic_utils::log!("sign_up: failed to insert user {user_id} in the database: {err}");
         return SignUpResponse::Err(SignUpError::InternalError(format!(
             "Failed to insert new user in the database: {err}"
         )));
     }
 
-    // 5. Spawn the state machine that will drive the user canister creation process, and return [`SignUpResponse::Ok`].
+    // 6. Spawn the state machine that will drive the user canister creation process, and return [`SignUpResponse::Ok`].
     ic_utils::log!(
-        "sign_up: user {user_id} registered with handle {handle:?}, starting canister creation"
+        "sign_up: user {user_id} registered with handle {sanitized_handle:?}, starting canister creation"
     );
-    start_sign_up_state_machine(user_id, handle);
+    start_sign_up_state_machine(user_id, sanitized_handle);
 
     SignUpResponse::Ok
 }

--- a/crates/canisters/directory/src/domain/users/sign_up/state.rs
+++ b/crates/canisters/directory/src/domain/users/sign_up/state.rs
@@ -367,6 +367,20 @@ mod tests {
             self.install_result.clone()
         }
 
+        async fn stop_canister(
+            &self,
+            _canister_id: Principal,
+        ) -> Result<(), ManagementCanisterError> {
+            Ok(())
+        }
+
+        async fn delete_canister(
+            &self,
+            _canister_id: Principal,
+        ) -> Result<(), ManagementCanisterError> {
+            Ok(())
+        }
+
         fn canister_version(&self) -> u64 {
             0
         }

--- a/crates/canisters/directory/src/lib.rs
+++ b/crates/canisters/directory/src/lib.rs
@@ -11,8 +11,9 @@ mod test_utils;
 
 use candid::Principal;
 use did::directory::{
-    DirectoryInstallArgs, GetUserArgs, GetUserResponse, RetrySignUpResponse, SignUpRequest,
-    SignUpResponse, UserCanisterResponse, WhoAmIResponse,
+    DeleteProfileResponse, DirectoryInstallArgs, GetUserArgs, GetUserResponse,
+    RetryDeleteProfileResponse, RetrySignUpResponse, SignUpRequest, SignUpResponse,
+    UserCanisterResponse, WhoAmIResponse,
 };
 
 #[ic_cdk::init]
@@ -30,6 +31,11 @@ fn inspect_message() {
     inspect::inspect();
 }
 
+#[ic_cdk::update]
+fn delete_profile() -> DeleteProfileResponse {
+    api::delete_profile()
+}
+
 #[ic_cdk::query]
 fn get_user(args: GetUserArgs) -> GetUserResponse {
     api::get_user(args)
@@ -38,6 +44,11 @@ fn get_user(args: GetUserArgs) -> GetUserResponse {
 #[ic_cdk::update]
 fn retry_sign_up() -> RetrySignUpResponse {
     api::retry_sign_up()
+}
+
+#[ic_cdk::update]
+fn retry_delete_profile() -> RetryDeleteProfileResponse {
+    api::retry_delete_profile()
 }
 
 #[ic_cdk::update]

--- a/crates/canisters/directory/src/schema/user_canister_status.rs
+++ b/crates/canisters/directory/src/schema/user_canister_status.rs
@@ -38,6 +38,7 @@ impl fmt::Display for UserCanisterStatus {
             DidUserCanisterStatus::Active => "active",
             DidUserCanisterStatus::CreationPending => "creation_pending",
             DidUserCanisterStatus::CreationFailed => "creation_failed",
+            DidUserCanisterStatus::DeletionPending => "deletion_pending",
         };
         write!(f, "{}", activity_str)
     }
@@ -53,6 +54,7 @@ impl Encode for UserCanisterStatus {
             DidUserCanisterStatus::Active => 0,
             DidUserCanisterStatus::CreationPending => 1,
             DidUserCanisterStatus::CreationFailed => 2,
+            DidUserCanisterStatus::DeletionPending => 3,
         }])
     }
 
@@ -69,6 +71,7 @@ impl Encode for UserCanisterStatus {
             0 => DidUserCanisterStatus::Active,
             1 => DidUserCanisterStatus::CreationPending,
             2 => DidUserCanisterStatus::CreationFailed,
+            3 => DidUserCanisterStatus::DeletionPending,
             _ => {
                 return Err(MemoryError::DecodeError(DecodeError::InvalidDiscriminant(
                     byte,

--- a/crates/canisters/user/src/api.rs
+++ b/crates/canisters/user/src/api.rs
@@ -3,12 +3,12 @@
 pub mod inspect;
 
 use did::user::{
-    AcceptFollowArgs, AcceptFollowResponse, FollowUserArgs, FollowUserResponse,
-    GetFollowRequestsArgs, GetFollowRequestsResponse, GetFollowersArgs, GetFollowersResponse,
-    GetFollowingArgs, GetFollowingResponse, GetProfileResponse, GetStatusesArgs,
-    GetStatusesResponse, PublishStatusArgs, PublishStatusResponse, ReadFeedArgs, ReadFeedResponse,
-    ReceiveActivityArgs, ReceiveActivityResponse, RejectFollowArgs, RejectFollowResponse,
-    UpdateProfileArgs, UpdateProfileResponse, UserInstallArgs,
+    AcceptFollowArgs, AcceptFollowResponse, EmitDeleteProfileActivityResponse, FollowUserArgs,
+    FollowUserResponse, GetFollowRequestsArgs, GetFollowRequestsResponse, GetFollowersArgs,
+    GetFollowersResponse, GetFollowingArgs, GetFollowingResponse, GetProfileResponse,
+    GetStatusesArgs, GetStatusesResponse, PublishStatusArgs, PublishStatusResponse, ReadFeedArgs,
+    ReadFeedResponse, ReceiveActivityArgs, ReceiveActivityResponse, RejectFollowArgs,
+    RejectFollowResponse, UpdateProfileArgs, UpdateProfileResponse, UserInstallArgs,
 };
 use ic_dbms_canister::prelude::DBMS_CONTEXT;
 
@@ -170,6 +170,17 @@ pub async fn reject_follow(args: RejectFollowArgs) -> RejectFollowResponse {
     }
 
     crate::domain::follower::reject_follow(args).await
+}
+
+/// Emit a `Delete(Person)` activity to followers on profile deletion.
+///
+/// This function can only be called by the directory canister.
+pub async fn emit_delete_profile_activity() -> EmitDeleteProfileActivityResponse {
+    if !inspect::is_directory_canister(ic_utils::caller()) {
+        ic_utils::trap!("Only the directory canister can emit delete profile activity");
+    }
+
+    crate::domain::profile::emit_delete_profile_activity().await
 }
 
 /// Updates the user's profile.

--- a/crates/canisters/user/src/api/inspect.rs
+++ b/crates/canisters/user/src/api/inspect.rs
@@ -14,6 +14,13 @@ pub fn is_federation_canister(principal: Principal) -> bool {
             .expect("should read federation canister principal")
 }
 
+/// Inspect whether the provided [`Principal`] is the directory canister.
+pub fn is_directory_canister(principal: Principal) -> bool {
+    principal
+        == crate::settings::get_directory_canister()
+            .expect("should read directory canister principal")
+}
+
 #[cfg(test)]
 mod tests {
 

--- a/crates/canisters/user/src/domain/profile.rs
+++ b/crates/canisters/user/src/domain/profile.rs
@@ -1,11 +1,13 @@
 //! User profile domain.
 
 mod create_profile;
+mod emit_delete;
 mod get_profile;
 mod repository;
 mod update_profile;
 
 pub use self::create_profile::create_profile;
+pub use self::emit_delete::emit_delete_profile_activity;
 pub use self::get_profile::get_profile;
 pub use self::repository::ProfileRepository;
 pub use self::update_profile::update_profile;

--- a/crates/canisters/user/src/domain/profile/emit_delete.rs
+++ b/crates/canisters/user/src/domain/profile/emit_delete.rs
@@ -1,0 +1,207 @@
+//! Domain logic for emitting a `Delete(Person)` activity to followers on profile deletion.
+
+use activitypub::activity::{Activity, ActivityObject, ActivityType};
+use activitypub::context::{ACTIVITY_STREAMS_CONTEXT, Context};
+use activitypub::object::{BaseObject, OneOrMany};
+use did::federation::{SendActivityArgs, SendActivityArgsObject};
+use did::user::{EmitDeleteProfileActivityError, EmitDeleteProfileActivityResponse};
+
+use crate::adapters::federation;
+use crate::domain::block::BlockRepository;
+use crate::domain::follower::FollowerRepository;
+use crate::domain::profile::ProfileRepository;
+use crate::domain::urls;
+use crate::error::CanisterResult;
+
+/// The ActivityStreams public-audience constant.
+const AS_PUBLIC: &str = "https://www.w3.org/ns/activitystreams#Public";
+
+/// Emit a `Delete(Person)` activity for the owner to all (non-blocked) followers.
+///
+/// Called by the Directory Canister during the delete_profile flow before the
+/// User Canister is stopped and deleted.
+pub async fn emit_delete_profile_activity() -> EmitDeleteProfileActivityResponse {
+    ic_utils::log!("emit_delete_profile_activity: dispatching Delete(Person) to followers");
+
+    match dispatch().await {
+        Ok(()) => EmitDeleteProfileActivityResponse::Ok,
+        Err(err) => {
+            ic_utils::log!("emit_delete_profile_activity: failed: {err}");
+            EmitDeleteProfileActivityResponse::Err(EmitDeleteProfileActivityError::Internal(
+                err.to_string(),
+            ))
+        }
+    }
+}
+
+async fn dispatch() -> CanisterResult<()> {
+    let profile = ProfileRepository::get_profile()?;
+    let handle = profile.handle.0.clone();
+    let owner_uri = urls::actor_uri(&handle)?;
+
+    let recipients = followers_minus_blocked()?;
+    if recipients.is_empty() {
+        ic_utils::log!("emit_delete_profile_activity: no recipients; skipping dispatch");
+        return Ok(());
+    }
+
+    let followers_uri = urls::followers_url(&handle)?;
+
+    let activities: Vec<SendActivityArgsObject> = recipients
+        .iter()
+        .map(|recipient_uri| {
+            let activity = Activity {
+                base: BaseObject {
+                    context: Some(Context::Uri(ACTIVITY_STREAMS_CONTEXT.to_string())),
+                    kind: ActivityType::Delete,
+                    to: Some(OneOrMany::One(AS_PUBLIC.to_string())),
+                    cc: Some(OneOrMany::One(followers_uri.clone())),
+                    ..Default::default()
+                },
+                actor: Some(owner_uri.clone()),
+                object: Some(ActivityObject::Id(owner_uri.clone())),
+                target: None,
+                result: None,
+                origin: None,
+                instrument: None,
+            };
+
+            let activity_json =
+                serde_json::to_string(&activity).expect("Activity serialization must not fail");
+
+            SendActivityArgsObject {
+                activity_json,
+                target_inbox: urls::inbox_url_from_actor_uri(recipient_uri),
+            }
+        })
+        .collect();
+
+    ic_utils::log!(
+        "emit_delete_profile_activity: prepared {len} activities for federation",
+        len = activities.len()
+    );
+
+    federation::send_activity(SendActivityArgs::Batch(activities)).await
+}
+
+fn followers_minus_blocked() -> CanisterResult<Vec<String>> {
+    let followers = FollowerRepository::get_followers()?;
+    let blocked = BlockRepository::list_blocked_uris()?;
+    Ok(followers
+        .into_iter()
+        .map(|f| f.actor_uri.0)
+        .filter(|uri| !blocked.contains(uri))
+        .collect())
+}
+
+#[cfg(test)]
+mod tests {
+    use activitypub::activity::{ActivityObject, ActivityType};
+    use did::federation::SendActivityArgs;
+    use ic_dbms_canister::prelude::DBMS_CONTEXT;
+    use wasm_dbms::WasmDbmsDatabase;
+    use wasm_dbms_api::prelude::Database;
+
+    use super::*;
+    use crate::adapters::federation::mock::captured;
+    use crate::schema::{Block, BlockInsertRequest, Follower, FollowerInsertRequest, Schema};
+    use crate::test_utils::setup;
+
+    const ALICE_URI: &str = "https://remote.example/users/alice";
+    const BOB_URI: &str = "https://remote.example/users/bob";
+    const OWNER_URI: &str = "https://mastic.social/users/rey_canisteryo";
+
+    fn insert_follower(actor_uri: &str) {
+        DBMS_CONTEXT.with(|ctx| {
+            let db = WasmDbmsDatabase::oneshot(ctx, Schema);
+            db.insert::<Follower>(FollowerInsertRequest {
+                actor_uri: actor_uri.into(),
+                created_at: ic_utils::now().into(),
+            })
+            .expect("should insert follower");
+        });
+    }
+
+    fn insert_block(actor_uri: &str) {
+        DBMS_CONTEXT.with(|ctx| {
+            let db = WasmDbmsDatabase::oneshot(ctx, Schema);
+            db.insert::<Block>(BlockInsertRequest {
+                actor_uri: actor_uri.into(),
+                created_at: ic_utils::now().into(),
+            })
+            .expect("should insert block");
+        });
+    }
+
+    fn captured_flat_targets() -> Vec<String> {
+        captured()
+            .into_iter()
+            .flat_map(|args| match args {
+                SendActivityArgs::One(obj) => vec![obj.target_inbox],
+                SendActivityArgs::Batch(objs) => objs.into_iter().map(|o| o.target_inbox).collect(),
+            })
+            .collect()
+    }
+
+    #[tokio::test]
+    async fn test_should_skip_when_no_followers() {
+        setup();
+        let resp = emit_delete_profile_activity().await;
+        assert_eq!(resp, EmitDeleteProfileActivityResponse::Ok);
+        assert!(captured().is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_should_fan_out_to_all_followers() {
+        setup();
+        insert_follower(ALICE_URI);
+        insert_follower(BOB_URI);
+
+        let resp = emit_delete_profile_activity().await;
+        assert_eq!(resp, EmitDeleteProfileActivityResponse::Ok);
+
+        let targets = captured_flat_targets();
+        assert_eq!(targets.len(), 2);
+        assert!(targets.contains(&format!("{ALICE_URI}/inbox")));
+        assert!(targets.contains(&format!("{BOB_URI}/inbox")));
+    }
+
+    #[tokio::test]
+    async fn test_should_exclude_blocked_followers() {
+        setup();
+        insert_follower(ALICE_URI);
+        insert_follower(BOB_URI);
+        insert_block(BOB_URI);
+
+        let resp = emit_delete_profile_activity().await;
+        assert_eq!(resp, EmitDeleteProfileActivityResponse::Ok);
+
+        let targets = captured_flat_targets();
+        assert_eq!(targets, vec![format!("{ALICE_URI}/inbox")]);
+    }
+
+    #[tokio::test]
+    async fn test_should_build_delete_person_activity() {
+        setup();
+        insert_follower(ALICE_URI);
+
+        emit_delete_profile_activity().await;
+
+        let args = captured();
+        assert_eq!(args.len(), 1);
+        let batch = match &args[0] {
+            SendActivityArgs::Batch(v) => v.clone(),
+            SendActivityArgs::One(_) => panic!("expected Batch"),
+        };
+        assert_eq!(batch.len(), 1);
+        let activity: activitypub::activity::Activity =
+            serde_json::from_str(&batch[0].activity_json).expect("deserialize");
+
+        assert_eq!(activity.base.kind, ActivityType::Delete);
+        assert_eq!(activity.actor.as_deref(), Some(OWNER_URI));
+        let ActivityObject::Id(id) = activity.object.expect("object present") else {
+            panic!("expected Id variant");
+        };
+        assert_eq!(id, OWNER_URI);
+    }
+}

--- a/crates/canisters/user/src/inspect.rs
+++ b/crates/canisters/user/src/inspect.rs
@@ -28,6 +28,15 @@ pub fn inspect() {
                 return;
             }
         }
+        "emit_delete_profile_activity" => {
+            let caller = ic_utils::caller();
+            if !crate::api::inspect::is_directory_canister(caller) {
+                ic_cdk::api::msg_reject(
+                    "Unauthorized caller. Only the directory canister can call this method.",
+                );
+                return;
+            }
+        }
         _ => {}
     }
 

--- a/crates/canisters/user/src/lib.rs
+++ b/crates/canisters/user/src/lib.rs
@@ -9,12 +9,12 @@ mod settings;
 mod test_utils;
 
 use did::user::{
-    AcceptFollowArgs, AcceptFollowResponse, FollowUserArgs, FollowUserResponse,
-    GetFollowRequestsArgs, GetFollowRequestsResponse, GetFollowersArgs, GetFollowersResponse,
-    GetFollowingArgs, GetFollowingResponse, GetProfileResponse, GetStatusesArgs,
-    GetStatusesResponse, PublishStatusArgs, PublishStatusResponse, ReadFeedArgs, ReadFeedResponse,
-    ReceiveActivityArgs, ReceiveActivityResponse, RejectFollowArgs, RejectFollowResponse,
-    UpdateProfileArgs, UpdateProfileResponse, UserInstallArgs,
+    AcceptFollowArgs, AcceptFollowResponse, EmitDeleteProfileActivityResponse, FollowUserArgs,
+    FollowUserResponse, GetFollowRequestsArgs, GetFollowRequestsResponse, GetFollowersArgs,
+    GetFollowersResponse, GetFollowingArgs, GetFollowingResponse, GetProfileResponse,
+    GetStatusesArgs, GetStatusesResponse, PublishStatusArgs, PublishStatusResponse, ReadFeedArgs,
+    ReadFeedResponse, ReceiveActivityArgs, ReceiveActivityResponse, RejectFollowArgs,
+    RejectFollowResponse, UpdateProfileArgs, UpdateProfileResponse, UserInstallArgs,
 };
 
 #[ic_cdk::init]
@@ -40,6 +40,11 @@ async fn accept_follow(args: AcceptFollowArgs) -> AcceptFollowResponse {
 #[ic_cdk::update]
 async fn follow_user(args: FollowUserArgs) -> FollowUserResponse {
     api::follow_user(args).await
+}
+
+#[ic_cdk::update]
+async fn emit_delete_profile_activity() -> EmitDeleteProfileActivityResponse {
+    api::emit_delete_profile_activity().await
 }
 
 #[ic_cdk::query]

--- a/crates/canisters/user/src/settings.rs
+++ b/crates/canisters/user/src/settings.rs
@@ -73,10 +73,6 @@ pub fn set_owner_principal(principal: Principal) -> CanisterResult<()> {
 }
 
 /// Gets the principal of the directory canister.
-#[cfg_attr(
-    not(any(target_family = "wasm", test)),
-    expect(dead_code, reason = "called only from wasm adapter")
-)]
 pub fn get_directory_canister() -> CanisterResult<Principal> {
     DBMS_CONTEXT
         .with(|ctx| {

--- a/crates/libs/did/src/directory.rs
+++ b/crates/libs/did/src/directory.rs
@@ -44,6 +44,8 @@ pub enum SignUpError {
     InvalidHandle,
     /// Anonymous users are not allowed to sign up
     AnonymousPrincipal,
+    /// Handle is tombstoned (i.e. was recently used by a deleted account)
+    HandleTombstoned,
     /// Internal error
     InternalError(String),
 }
@@ -86,6 +88,8 @@ pub enum UserCanisterStatus {
     CreationPending,
     /// Creation failed
     CreationFailed,
+    /// Deletion pending
+    DeletionPending,
 }
 
 /// `who_am_i` method data to be returned in case the caller is registered in the directory.
@@ -278,15 +282,41 @@ pub enum SearchProfilesResponse {
 }
 
 /// Error types for the `delete_profile` method on the Directory Canister.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, CandidType, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, CandidType, Serialize, Deserialize)]
 pub enum DeleteProfileError {
     /// The caller has no account to delete.
     NotRegistered,
+    /// Deletion is already in progress for the caller.
+    DeletionAlreadyInProgress,
+    /// The caller's canister is not active (e.g. pending creation or failed).
+    CanisterNotActive,
+    /// Anonymous callers cannot delete.
+    AnonymousPrincipal,
+    /// Internal error occurred while deleting the profile.
+    Internal(String),
 }
 
 /// Response type for the `delete_profile` method on the Directory Canister.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, CandidType, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, CandidType, Serialize, Deserialize)]
 pub enum DeleteProfileResponse {
     Ok,
     Err(DeleteProfileError),
+}
+
+/// Error types for the `retry_delete_profile` method on the Directory Canister.
+#[derive(Debug, Clone, PartialEq, Eq, CandidType, Serialize, Deserialize)]
+pub enum RetryDeleteProfileError {
+    /// The caller has no account to delete.
+    NotRegistered,
+    /// The caller's account is not in a deletion-pending state, so retrying is not allowed.
+    CanisterNotInDeletionState,
+    /// Internal error occurred while retrying the profile deletion.
+    Internal(String),
+}
+
+/// Response type for the `retry_delete_profile` method on the Directory Canister.
+#[derive(Debug, Clone, PartialEq, Eq, CandidType, Serialize, Deserialize)]
+pub enum RetryDeleteProfileResponse {
+    Ok,
+    Err(RetryDeleteProfileError),
 }

--- a/crates/libs/did/src/user.rs
+++ b/crates/libs/did/src/user.rs
@@ -68,6 +68,25 @@ pub enum UpdateProfileResponse {
     Err(UpdateProfileError),
 }
 
+/// Error types for the `emit_delete_profile_activity` method.
+///
+/// Called by the Directory Canister during delete_profile flow to aggregate and
+/// dispatch `Delete(Person)` activities to followers before canister destruction.
+#[derive(Debug, Clone, PartialEq, Eq, CandidType, Serialize, Deserialize)]
+pub enum EmitDeleteProfileActivityError {
+    /// The caller is not the directory canister.
+    Unauthorized,
+    /// Internal error occurred while emitting the delete activity.
+    Internal(String),
+}
+
+/// Response type for the `emit_delete_profile_activity` method.
+#[derive(Debug, Clone, PartialEq, Eq, CandidType, Serialize, Deserialize)]
+pub enum EmitDeleteProfileActivityResponse {
+    Ok,
+    Err(EmitDeleteProfileActivityError),
+}
+
 /// Request arguments for the `follow_user` method.
 #[derive(Debug, Clone, PartialEq, Eq, CandidType, Serialize, Deserialize)]
 pub struct FollowUserArgs {

--- a/docs/src/directory.did
+++ b/docs/src/directory.did
@@ -1,3 +1,18 @@
+// Error types for the `delete_profile` method on the Directory Canister.
+type DeleteProfileError = variant {
+  // Internal error occurred while deleting the profile.
+  Internal : text;
+  // The caller has no account to delete.
+  NotRegistered;
+  // Deletion is already in progress for the caller.
+  DeletionAlreadyInProgress;
+  // The caller's canister is not active (e.g. pending creation or failed).
+  CanisterNotActive;
+  // Anonymous callers cannot delete.
+  AnonymousPrincipal;
+};
+// Response type for the `delete_profile` method on the Directory Canister.
+type DeleteProfileResponse = variant { Ok; Err : DeleteProfileError };
 // Install arguments for the Directory canister.
 type DirectoryInstallArgs = variant {
   // Upgrade argument, provided on `upgrade`
@@ -40,6 +55,17 @@ type GetUserError = variant {
 };
 // Response type for the `get_user` method.
 type GetUserResponse = variant { Ok : GetUser; Err : GetUserError };
+// Error types for the `retry_delete_profile` method on the Directory Canister.
+type RetryDeleteProfileError = variant {
+  // Internal error occurred while retrying the profile deletion.
+  Internal : text;
+  // The caller has no account to delete.
+  NotRegistered;
+  // The caller's account is not in a deletion-pending state, so retrying is not allowed.
+  CanisterNotInDeletionState;
+};
+// Response type for the `retry_delete_profile` method on the Directory Canister.
+type RetryDeleteProfileResponse = variant { Ok; Err : RetryDeleteProfileError };
 // Response error types for the `retry_sign_up` method.
 // Retries the canister creation for a user that failed to create their canister during the sign up process.
 type RetrySignUpError = variant {
@@ -64,6 +90,8 @@ type SignUpError = variant {
   AnonymousPrincipal;
   // The chosen handle is already taken by another user
   HandleTaken;
+  // Handle is tombstoned (i.e. was recently used by a deleted account)
+  HandleTombstoned;
   // Internal error
   InternalError : text;
 };
@@ -91,6 +119,8 @@ type UserCanisterResponse = variant { Ok : principal; Err : UserCanisterError };
 // The status of a user's canister, used in the `who_am_i` method to indicate whether
 // the user's canister is active, pending creation, or failed to create.
 type UserCanisterStatus = variant {
+  // Deletion pending
+  DeletionPending;
   // Creation failed
   CreationFailed;
   // Active and created
@@ -118,7 +148,9 @@ type WhoAmIError = variant {
 // information or an error if they are not registered.
 type WhoAmIResponse = variant { Ok : WhoAmI; Err : WhoAmIError };
 service : (DirectoryInstallArgs) -> {
+  delete_profile : () -> (DeleteProfileResponse);
   get_user : (GetUserArgs) -> (GetUserResponse) query;
+  retry_delete_profile : () -> (RetryDeleteProfileResponse);
   retry_sign_up : () -> (RetrySignUpResponse);
   sign_up : (SignUpRequest) -> (SignUpResponse);
   user_canister : (opt principal) -> (UserCanisterResponse) query;

--- a/docs/src/project.md
+++ b/docs/src/project.md
@@ -200,6 +200,10 @@ get\_user : (*GetUserArgs*) -> (*GetUserResponse*) query;
 
 remove\_moderator : (*RemoveModeratorArgs*) -> (*RemoveModeratorResponse*);
 
+retry\_delete\_profile : () -> (*RetryDeleteProfileResponse*);
+
+retry\_sign\_up : () -> (*RetrySignUpResponse*);
+
 search\_profiles : (*SearchProfilesArgs*) -> (*SearchProfilesResponse*) query;
 
 sign\_up : (*text*) -> (*SignUpResponse*);
@@ -234,9 +238,9 @@ block\_user : (*BlockUserArgs*) -> (*BlockUserResponse*);
 
 boost\_status : (*BoostStatusArgs*) -> (*BoostStatusResponse*);
 
-delete\_profile : () -> (*DeleteProfileResponse*);
-
 delete\_status : (*DeleteStatusArgs*) -> (*DeleteStatusResponse*);
+
+emit\_delete\_profile\_activity : () -> (*EmitDeleteProfileActivityResponse*);
 
 follow\_user : (*FollowUserArgs*) -> (*FollowUserResponse*);
 

--- a/docs/src/user.did
+++ b/docs/src/user.did
@@ -14,6 +14,21 @@ type AcceptFollowError = variant {
 };
 // Response type for the `accept_follow` method.
 type AcceptFollowResponse = variant { Ok; Err : AcceptFollowError };
+// Error types for the `emit_delete_profile_activity` method.
+// 
+// Called by the Directory Canister during delete_profile flow to aggregate and
+// dispatch `Delete(Person)` activities to followers before canister destruction.
+type EmitDeleteProfileActivityError = variant {
+  // Internal error occurred while emitting the delete activity.
+  Internal : text;
+  // The caller is not the directory canister.
+  Unauthorized;
+};
+// Response type for the `emit_delete_profile_activity` method.
+type EmitDeleteProfileActivityResponse = variant {
+  Ok;
+  Err : EmitDeleteProfileActivityError;
+};
 // A single entry in a user's feed. Wraps a [`Status`] and optionally indicates
 // that it was boosted (reblogged) by another user.
 type FeedItem = record {
@@ -256,6 +271,7 @@ type Visibility = variant {
 };
 service : (UserInstallArgs) -> {
   accept_follow : (AcceptFollowArgs) -> (AcceptFollowResponse);
+  emit_delete_profile_activity : () -> (EmitDeleteProfileActivityResponse);
   follow_user : (FollowUserArgs) -> (FollowUserResponse);
   get_follow_requests : (GetFollowRequestsArgs) -> (
       GetFollowRequestsResponse,

--- a/integration-tests/src/directory_client.rs
+++ b/integration-tests/src/directory_client.rs
@@ -1,5 +1,6 @@
 use candid::{Encode, Principal};
 use did::directory::{
+    DeleteProfileResponse, GetUserArgs, GetUserResponse, RetryDeleteProfileResponse,
     RetrySignUpResponse, SignUpRequest, SignUpResponse, UserCanisterResponse, WhoAmIResponse,
 };
 use pocket_ic_harness::PocketIcTestEnv;
@@ -29,6 +30,32 @@ impl DirectoryClient<'_> {
             )
             .await
             .expect("Failed to call sign_up")
+    }
+
+    pub async fn delete_profile(&self, user: Principal) -> DeleteProfileResponse {
+        self.env
+            .update(self.canister_id(), user, "delete_profile", vec![])
+            .await
+            .expect("Failed to call delete_profile")
+    }
+
+    pub async fn retry_delete_profile(&self, user: Principal) -> RetryDeleteProfileResponse {
+        self.env
+            .update(self.canister_id(), user, "retry_delete_profile", vec![])
+            .await
+            .expect("Failed to call retry_delete_profile")
+    }
+
+    pub async fn get_user(&self, args: GetUserArgs) -> GetUserResponse {
+        self.env
+            .query(
+                self.canister_id(),
+                Principal::anonymous(),
+                "get_user",
+                Encode!(&args).expect("Failed to encode get_user args"),
+            )
+            .await
+            .expect("Failed to call get_user")
     }
 
     pub async fn retry_sign_up(&self, user: Principal) -> RetrySignUpResponse {

--- a/integration-tests/tests/delete_profile.rs
+++ b/integration-tests/tests/delete_profile.rs
@@ -1,0 +1,103 @@
+use std::time::{Duration, Instant};
+
+use did::directory::{
+    DeleteProfileError, DeleteProfileResponse, GetUserArgs, GetUserError, GetUserResponse,
+    RetryDeleteProfileError, RetryDeleteProfileResponse, SignUpError, SignUpResponse,
+    UserCanisterError, UserCanisterResponse, WhoAmIError, WhoAmIResponse,
+};
+use integration_tests::helpers::sign_up_user;
+use integration_tests::{DirectoryClient, MasticCanisterSetup};
+use pocket_ic_harness::{PocketIcTestEnv, alice, bob};
+
+async fn wait_for_deleted(
+    env: &PocketIcTestEnv<MasticCanisterSetup>,
+    client: &DirectoryClient<'_>,
+    user: candid::Principal,
+) {
+    let t = Instant::now();
+    loop {
+        if t.elapsed() > Duration::from_secs(60) {
+            panic!("timeout waiting for user deletion to complete");
+        }
+        if let WhoAmIResponse::Err(WhoAmIError::NotRegistered) = client.whoami(user).await {
+            return;
+        }
+        tokio::time::sleep(Duration::from_secs(1)).await;
+        env.pic.advance_time(Duration::from_secs(1)).await;
+        env.pic.tick().await;
+    }
+}
+
+#[pocket_ic_harness::test]
+async fn test_should_delete_profile(env: PocketIcTestEnv<MasticCanisterSetup>) {
+    let client = DirectoryClient::new(&env);
+
+    sign_up_user(&env, bob(), "bob".to_string()).await;
+
+    let response = client.delete_profile(bob()).await;
+    assert_eq!(response, DeleteProfileResponse::Ok);
+
+    wait_for_deleted(&env, &client, bob()).await;
+
+    let response = client.user_canister(bob(), None).await;
+    assert_eq!(
+        response,
+        UserCanisterResponse::Err(UserCanisterError::NotRegistered)
+    );
+
+    let response = client
+        .get_user(GetUserArgs::Handle("bob".to_string()))
+        .await;
+    assert_eq!(response, GetUserResponse::Err(GetUserError::NotFound));
+}
+
+#[pocket_ic_harness::test]
+async fn test_should_reject_unregistered_delete(env: PocketIcTestEnv<MasticCanisterSetup>) {
+    let client = DirectoryClient::new(&env);
+
+    let response = client.delete_profile(bob()).await;
+    assert_eq!(
+        response,
+        DeleteProfileResponse::Err(DeleteProfileError::NotRegistered)
+    );
+}
+
+#[pocket_ic_harness::test]
+async fn test_should_tombstone_handle_after_delete(env: PocketIcTestEnv<MasticCanisterSetup>) {
+    let client = DirectoryClient::new(&env);
+
+    sign_up_user(&env, bob(), "bob".to_string()).await;
+
+    client.delete_profile(bob()).await;
+    wait_for_deleted(&env, &client, bob()).await;
+
+    // another user cannot reclaim the handle during the tombstone grace period
+    let response = client.sign_up(alice(), "bob".to_string()).await;
+    assert_eq!(response, SignUpResponse::Err(SignUpError::HandleTombstoned));
+}
+
+#[pocket_ic_harness::test]
+async fn test_retry_delete_profile_rejects_when_not_in_deletion_state(
+    env: PocketIcTestEnv<MasticCanisterSetup>,
+) {
+    let client = DirectoryClient::new(&env);
+
+    sign_up_user(&env, bob(), "bob".to_string()).await;
+
+    let response = client.retry_delete_profile(bob()).await;
+    assert_eq!(
+        response,
+        RetryDeleteProfileResponse::Err(RetryDeleteProfileError::CanisterNotInDeletionState)
+    );
+}
+
+#[pocket_ic_harness::test]
+async fn test_retry_delete_profile_rejects_unregistered(env: PocketIcTestEnv<MasticCanisterSetup>) {
+    let client = DirectoryClient::new(&env);
+
+    let response = client.retry_delete_profile(bob()).await;
+    assert_eq!(
+        response,
+        RetryDeleteProfileResponse::Err(RetryDeleteProfileError::NotRegistered)
+    );
+}


### PR DESCRIPTION
## Summary

- Implements account deletion across Directory + User canisters (UC4, WI-1.3).
- In-memory state machine mirrors sign_up: `EmitActivities -> StopCanister -> DeleteCanister -> Commit`. Only `DeletionPending` persisted in schema; fine-grained steps stay in-memory.
- `retry_delete_profile` restarts the SM from the beginning. Management-canister calls are idempotent, so re-running previously completed steps is safe.
- Fixes `UserCanisterStatus` decode (missing case for `DeletionPending` discriminant).

## Scope revision vs. refinement

Refinement specified 4 persisted deletion states. Over-specified: sign_up pattern persists only `CreationPending` / `CreationFailed`. Trimmed to `DeletionPending` only; fine-grained progress lives in the SM. See issue comment for rationale.

## Test plan

- [x] `just check_code` — zero warnings
- [x] `cargo test -p directory -p user --lib` — all unit tests green
- [x] `just build_all` — WASM artefacts built
- [x] `cargo test -p integration-tests --test delete_profile` — 5 integration tests pass (full delete flow, unregistered reject, tombstone handle block, retry rejection paths)

Closes #14