### PR TITLE
feat(user): implement unfollow_user flow (UC6)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -241,6 +241,9 @@ name = "bitflags"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+dependencies = [
+ "serde_core",
+]
 
 [[package]]
 name = "bitvec"
@@ -692,6 +695,7 @@ version = "0.1.0"
 dependencies = [
  "candid",
  "did",
+ "ic-cdk",
  "ic-dbms-canister",
  "ic-utils",
  "serde",
@@ -1456,9 +1460,9 @@ dependencies = [
 
 [[package]]
 name = "ic-dbms-api"
-version = "0.8.2"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "069acb68d6a6dc4af55a52dd355f2c0002409fb4e45d6c05732660455882ba55"
+checksum = "77b55685d723f02d52a0df76073178e4954fb3a98136beddabd6d6bb8144d964"
 dependencies = [
  "candid",
  "ic-cdk",
@@ -1469,9 +1473,9 @@ dependencies = [
 
 [[package]]
 name = "ic-dbms-canister"
-version = "0.8.2"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e57c0026862e70674f7187e79acf6079b24f97103dbd73c961acb19728e838a5"
+checksum = "56c02167cbc3e484a3ec9165749a83c0336b317ef715a7c01dcb86726a24d097"
 dependencies = [
  "candid",
  "ic-cdk",
@@ -1486,9 +1490,9 @@ dependencies = [
 
 [[package]]
 name = "ic-dbms-macros"
-version = "0.8.2"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79399ced674f72bf80857290b1e505bc643fd053807f48fd62a0a1630e4c0958"
+checksum = "7cdb0b49ee70ad3bbb19b70c047475a18d1c571420e2eed9847100555f29e506"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3888,20 +3892,23 @@ dependencies = [
 
 [[package]]
 name = "wasm-dbms"
-version = "0.8.2"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64ab5f7084540742e643a4c2b5e7034de18c066613c323d9fd15b24d3eeaf248"
+checksum = "b2d4ac68f899b1e0dd749028e935a137e0d41eede085ea2bb716bd0c58ba59cf"
 dependencies = [
+ "rust_decimal",
  "wasm-dbms-api",
  "wasm-dbms-memory",
+ "xxhash-rust",
 ]
 
 [[package]]
 name = "wasm-dbms-api"
-version = "0.8.2"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22e766800086d0c54ea2c122a4a7d3ea540773eb57f7d09e999e4ee6f01a5ed9"
+checksum = "d9393d86c645c060833bc25a9748771f7ce84ecb136b0315d4a8356a1e7ad2a0"
 dependencies = [
+ "bitflags",
  "candid",
  "lazy-regex",
  "percent-encoding",
@@ -3912,13 +3919,14 @@ dependencies = [
  "url",
  "uuid",
  "wasm-dbms-macros",
+ "xxhash-rust",
 ]
 
 [[package]]
 name = "wasm-dbms-macros"
-version = "0.8.2"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc45c843e816068795f34c4218fd135f529a2cf0143b2498cbd7b6d7bac56a45"
+checksum = "cdc0d5f11aa8a36de27a3dbde0133de53c57902cc5cb420f12e6a0fefaf4b4a9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3927,11 +3935,12 @@ dependencies = [
 
 [[package]]
 name = "wasm-dbms-memory"
-version = "0.8.2"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8262660d686ec48e32cc2083cd677e07156a32c61085d78dfe378a68025784e5"
+checksum = "9c9517388f4b7a0507824063c4e93309f23d43cf13ff1c46f949b68b8a1f698b"
 dependencies = [
  "wasm-dbms-api",
+ "xxhash-rust",
 ]
 
 [[package]]
@@ -4430,6 +4439,12 @@ checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
 dependencies = [
  "tap",
 ]
+
+[[package]]
+name = "xxhash-rust"
+version = "0.8.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdd20c5420375476fbd4394763288da7eb0cc0b8c11deed431a91562af7335d3"
 
 [[package]]
 name = "yoke"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ edition = "2024"
 authors = ["Christian Visintin <christian.visintin@veeso.dev>"]
 license = "MIT"
 repository = "https://github.com/veeso/mastic"
-rust-version = "1.91.1"
+rust-version = "1.92.0"
 
 [workspace.dependencies]
 activitypub = { path = "crates/libs/activitypub" }
@@ -28,7 +28,7 @@ did = { path = "crates/libs/did" }
 ic-cdk = "0.20"
 ic-cdk-macros = "0.20"
 ic-cdk-timers = "1"
-ic-dbms-canister = "0.8"
+ic-dbms-canister = "0.9"
 ic-management-canister-types = "0.7"
 ic-stable-structures = "0.7"
 ic-utils = { path = "crates/libs/ic-utils" }
@@ -40,6 +40,6 @@ serde_json = "1"
 thiserror = "2"
 tokio = { version = "1", features = ["full"] }
 url = "2"
-wasm-dbms = "0.8"
-wasm-dbms-api = "0.8"
-wasm-dbms-memory = "0.8"
+wasm-dbms = "0.9"
+wasm-dbms-api = "0.9"
+wasm-dbms-memory = "0.9"

--- a/crates/canisters/directory/src/api.rs
+++ b/crates/canisters/directory/src/api.rs
@@ -8,6 +8,8 @@ use did::directory::{
 };
 use ic_dbms_canister::prelude::DBMS_CONTEXT;
 
+use crate::schema::Schema;
+
 /// Initializes the canister.
 pub fn init(args: DirectoryInstallArgs) {
     ic_utils::log!("Initializing directory canister");
@@ -53,6 +55,8 @@ pub fn post_upgrade(args: DirectoryInstallArgs) {
     let DirectoryInstallArgs::Upgrade { .. } = args else {
         ic_utils::trap!("Invalid post-upgrade arguments");
     };
+
+    db_utils::migration::run_post_upgrade_migration(&DBMS_CONTEXT, Schema);
 
     ic_utils::log!("Directory canister post-upgrade completed successfully");
 }

--- a/crates/canisters/directory/src/schema.rs
+++ b/crates/canisters/directory/src/schema.rs
@@ -105,7 +105,7 @@ pub struct Report {
     pub resolved_by: Nullable<Principal>,
 }
 
-#[derive(DatabaseSchema)]
+#[derive(DatabaseSchema, Clone)]
 #[tables(
     Settings = "settings",
     Moderator = "moderators",

--- a/crates/canisters/user/src/api.rs
+++ b/crates/canisters/user/src/api.rs
@@ -12,6 +12,8 @@ use did::user::{
 };
 use ic_dbms_canister::prelude::DBMS_CONTEXT;
 
+use crate::schema::Schema;
+
 /// Initializes the canister with the given arguments.
 pub fn init(args: UserInstallArgs) {
     ic_utils::log!("Initializing user canister");
@@ -75,6 +77,8 @@ pub fn post_upgrade(args: UserInstallArgs) {
     let UserInstallArgs::Upgrade { .. } = args else {
         ic_utils::trap!("Invalid post-upgrade arguments");
     };
+
+    db_utils::migration::run_post_upgrade_migration(&DBMS_CONTEXT, Schema);
 
     ic_utils::log!("User canister post-upgrade completed successfully");
 }

--- a/crates/canisters/user/src/api.rs
+++ b/crates/canisters/user/src/api.rs
@@ -8,7 +8,8 @@ use did::user::{
     GetFollowersResponse, GetFollowingArgs, GetFollowingResponse, GetProfileResponse,
     GetStatusesArgs, GetStatusesResponse, PublishStatusArgs, PublishStatusResponse, ReadFeedArgs,
     ReadFeedResponse, ReceiveActivityArgs, ReceiveActivityResponse, RejectFollowArgs,
-    RejectFollowResponse, UpdateProfileArgs, UpdateProfileResponse, UserInstallArgs,
+    RejectFollowResponse, UnfollowUserArgs, UnfollowUserResponse, UpdateProfileArgs,
+    UpdateProfileResponse, UserInstallArgs,
 };
 use ic_dbms_canister::prelude::DBMS_CONTEXT;
 
@@ -185,6 +186,15 @@ pub async fn emit_delete_profile_activity() -> EmitDeleteProfileActivityResponse
     }
 
     crate::domain::profile::emit_delete_profile_activity().await
+}
+
+/// Unfollows a user.
+pub async fn unfollow_user(args: UnfollowUserArgs) -> UnfollowUserResponse {
+    if !inspect::is_owner(ic_utils::caller()) {
+        ic_utils::trap!("Only the owner can unfollow other users");
+    }
+
+    crate::domain::following::unfollow_user(args).await
 }
 
 /// Updates the user's profile.

--- a/crates/canisters/user/src/domain/activity/handle_incoming.rs
+++ b/crates/canisters/user/src/domain/activity/handle_incoming.rs
@@ -6,6 +6,7 @@ use did::user::{ReceiveActivityArgs, ReceiveActivityError, ReceiveActivityRespon
 use wasm_dbms_api::prelude::{Database, Nullable};
 
 use crate::domain::follow_request::FollowRequestRepository;
+use crate::domain::follower::FollowerRepository;
 use crate::domain::following::FollowingRepository;
 use crate::domain::snowflake::Snowflake;
 use crate::error::CanisterError;
@@ -31,6 +32,7 @@ pub fn handle_incoming(
         ActivityType::Follow => handle_follow(&activity),
         ActivityType::Accept => handle_accept(&activity),
         ActivityType::Reject => handle_reject(&activity),
+        ActivityType::Undo => handle_undo(&activity),
         other => {
             // Unknown / not-yet-implemented activity types are silently accepted.
             // ActivityPub receivers should not reject deliveries they can't act
@@ -179,13 +181,54 @@ fn handle_reject(activity: &Activity) -> Result<(), ReceiveActivityError> {
 
     ic_utils::log!("handle_incoming: rejecting following for {remote_actor_uri}, removing entry");
 
-    FollowingRepository::delete_by_actor_uri(remote_actor_uri).map_err(|e| {
-        ic_utils::log!("handle_incoming: failed to delete following entry: {e}");
-        match e {
-            CanisterError::Database(_) => ReceiveActivityError::ProcessingFailed,
-            _ => ReceiveActivityError::Internal(e.to_string()),
-        }
-    })
+    FollowingRepository::delete_by_actor_uri(remote_actor_uri)
+        .map_err(|e| {
+            ic_utils::log!("handle_incoming: failed to delete following entry: {e}");
+            match e {
+                CanisterError::Database(_) => ReceiveActivityError::ProcessingFailed,
+                _ => ReceiveActivityError::Internal(e.to_string()),
+            }
+        })
+        .map(|_| ())
+}
+
+/// Handle an incoming `Undo(Follow)` activity.
+///
+/// Removes the sender from the `followers` table (accepted inbound follow)
+/// and from the `follow_requests` table (pending inbound follow). Idempotent:
+/// missing entries do not produce an error. `Undo` of any inner activity
+/// other than `Follow` is silently ignored (out of scope here).
+fn handle_undo(activity: &Activity) -> Result<(), ReceiveActivityError> {
+    let sender_uri = activity
+        .actor
+        .as_deref()
+        .ok_or(ReceiveActivityError::ProcessingFailed)?;
+
+    let Some(ActivityObject::Activity(inner)) = &activity.object else {
+        ic_utils::log!("handle_incoming: Undo missing inner activity");
+        return Err(ReceiveActivityError::ProcessingFailed);
+    };
+
+    if inner.base.kind != ActivityType::Follow {
+        ic_utils::log!(
+            "handle_incoming: ignoring Undo of unsupported inner type: {:?}",
+            inner.base.kind
+        );
+        return Ok(());
+    }
+
+    ic_utils::log!("handle_incoming: Undo(Follow) from {sender_uri}");
+
+    FollowerRepository::delete_by_actor_uri(sender_uri).map_err(|e| {
+        ic_utils::log!("handle_incoming: failed to delete follower: {e}");
+        ReceiveActivityError::Internal(e.to_string())
+    })?;
+    FollowRequestRepository::delete_by_actor_uri(sender_uri).map_err(|e| {
+        ic_utils::log!("handle_incoming: failed to delete follow request: {e}");
+        ReceiveActivityError::Internal(e.to_string())
+    })?;
+
+    Ok(())
 }
 
 #[cfg(test)]
@@ -197,6 +240,7 @@ mod tests {
 
     use super::handle_incoming;
     use crate::domain::follow_request::FollowRequestRepository;
+    use crate::domain::follower::FollowerRepository;
     use crate::domain::following::FollowingRepository;
     use crate::schema::FollowStatus;
     use crate::test_utils::setup;
@@ -453,5 +497,158 @@ mod tests {
             response,
             ReceiveActivityResponse::Err(ReceiveActivityError::ProcessingFailed)
         );
+    }
+
+    fn make_undo_follow_json(unfollower_actor_uri: &str, target_actor_uri: &str) -> String {
+        let activity = Activity {
+            base: BaseObject {
+                kind: ActivityType::Undo,
+                ..Default::default()
+            },
+            actor: Some(unfollower_actor_uri.to_string()),
+            object: Some(ActivityObject::Activity(Box::new(Activity {
+                base: BaseObject {
+                    kind: ActivityType::Follow,
+                    ..Default::default()
+                },
+                actor: Some(unfollower_actor_uri.to_string()),
+                object: Some(ActivityObject::Id(target_actor_uri.to_string())),
+                target: None,
+                result: None,
+                origin: None,
+                instrument: None,
+            }))),
+            target: None,
+            result: None,
+            origin: None,
+            instrument: None,
+        };
+        serde_json::to_string(&activity).unwrap()
+    }
+
+    #[test]
+    fn test_should_remove_follower_on_undo_follow() {
+        setup();
+
+        FollowerRepository::insert("https://mastic.social/users/alice").expect("should insert");
+
+        let json = make_undo_follow_json(
+            "https://mastic.social/users/alice",
+            "https://mastic.social/users/rey_canisteryo",
+        );
+
+        let response = handle_incoming(ReceiveActivityArgs {
+            activity_json: json,
+        });
+        assert_eq!(response, ReceiveActivityResponse::Ok);
+
+        let followers = FollowerRepository::get_followers().expect("should query");
+        assert!(followers.is_empty(), "follower entry should be deleted");
+    }
+
+    #[test]
+    fn test_should_remove_pending_follow_request_on_undo_follow() {
+        setup();
+
+        FollowRequestRepository::insert("https://mastic.social/users/alice")
+            .expect("should insert");
+
+        let json = make_undo_follow_json(
+            "https://mastic.social/users/alice",
+            "https://mastic.social/users/rey_canisteryo",
+        );
+
+        let response = handle_incoming(ReceiveActivityArgs {
+            activity_json: json,
+        });
+        assert_eq!(response, ReceiveActivityResponse::Ok);
+
+        let request =
+            FollowRequestRepository::find_by_actor_uri("https://mastic.social/users/alice")
+                .expect("should query");
+        assert!(request.is_none(), "follow request should be deleted");
+    }
+
+    #[test]
+    fn test_should_succeed_undo_follow_when_no_entry_exists() {
+        setup();
+
+        let json = make_undo_follow_json(
+            "https://mastic.social/users/alice",
+            "https://mastic.social/users/rey_canisteryo",
+        );
+
+        let response = handle_incoming(ReceiveActivityArgs {
+            activity_json: json,
+        });
+        assert_eq!(response, ReceiveActivityResponse::Ok);
+    }
+
+    #[test]
+    fn test_should_fail_undo_when_missing_inner_activity() {
+        setup();
+
+        let activity = Activity {
+            base: BaseObject {
+                kind: ActivityType::Undo,
+                ..Default::default()
+            },
+            actor: Some("https://mastic.social/users/alice".to_string()),
+            object: Some(ActivityObject::Id(
+                "https://mastic.social/users/rey_canisteryo".to_string(),
+            )),
+            target: None,
+            result: None,
+            origin: None,
+            instrument: None,
+        };
+        let json = serde_json::to_string(&activity).unwrap();
+
+        let response = handle_incoming(ReceiveActivityArgs {
+            activity_json: json,
+        });
+
+        assert_eq!(
+            response,
+            ReceiveActivityResponse::Err(ReceiveActivityError::ProcessingFailed)
+        );
+    }
+
+    #[test]
+    fn test_should_ignore_undo_of_unsupported_inner_type() {
+        setup();
+
+        let activity = Activity {
+            base: BaseObject {
+                kind: ActivityType::Undo,
+                ..Default::default()
+            },
+            actor: Some("https://mastic.social/users/alice".to_string()),
+            object: Some(ActivityObject::Activity(Box::new(Activity {
+                base: BaseObject {
+                    kind: ActivityType::Like,
+                    ..Default::default()
+                },
+                actor: Some("https://mastic.social/users/alice".to_string()),
+                object: Some(ActivityObject::Id(
+                    "https://mastic.social/statuses/1".to_string(),
+                )),
+                target: None,
+                result: None,
+                origin: None,
+                instrument: None,
+            }))),
+            target: None,
+            result: None,
+            origin: None,
+            instrument: None,
+        };
+        let json = serde_json::to_string(&activity).unwrap();
+
+        let response = handle_incoming(ReceiveActivityArgs {
+            activity_json: json,
+        });
+
+        assert_eq!(response, ReceiveActivityResponse::Ok);
     }
 }

--- a/crates/canisters/user/src/domain/follower/repository.rs
+++ b/crates/canisters/user/src/domain/follower/repository.rs
@@ -56,6 +56,23 @@ impl FollowerRepository {
         })
     }
 
+    /// Delete a follower entry by actor URI.
+    ///
+    /// Returns `true` if an entry was deleted, `false` if no entry was found
+    /// with the given actor URI.
+    pub fn delete_by_actor_uri(actor_uri: &str) -> CanisterResult<bool> {
+        DBMS_CONTEXT.with(|ctx| {
+            let db = WasmDbmsDatabase::oneshot(ctx, Schema);
+
+            db.delete::<Follower>(
+                DeleteBehavior::Restrict,
+                Some(Filter::eq("actor_uri", Value::from(actor_uri.to_string()))),
+            )
+            .map(|entries| entries > 0)
+            .map_err(CanisterError::from)
+        })
+    }
+
     /// Get the list of [`Follower`]s of the user.
     pub fn get_paginated(offset: usize, limit: usize) -> CanisterResult<Vec<Follower>> {
         DBMS_CONTEXT.with(|ctx| {

--- a/crates/canisters/user/src/domain/following.rs
+++ b/crates/canisters/user/src/domain/following.rs
@@ -3,7 +3,9 @@
 mod follow_user;
 mod get_following;
 mod repository;
+mod unfollow_user;
 
 pub use self::follow_user::follow_user;
 pub use self::get_following::get_following;
 pub use self::repository::FollowingRepository;
+pub use self::unfollow_user::unfollow_user;

--- a/crates/canisters/user/src/domain/following/repository.rs
+++ b/crates/canisters/user/src/domain/following/repository.rs
@@ -64,7 +64,9 @@ impl FollowingRepository {
     }
 
     /// Delete a following entry by actor URI.
-    pub fn delete_by_actor_uri(actor_uri: &str) -> CanisterResult<()> {
+    ///
+    /// Returns `true` if an entry was deleted, `false` if no entry was found with the given actor URI.
+    pub fn delete_by_actor_uri(actor_uri: &str) -> CanisterResult<bool> {
         DBMS_CONTEXT.with(|ctx| {
             let db = WasmDbmsDatabase::oneshot(ctx, Schema);
 
@@ -72,7 +74,7 @@ impl FollowingRepository {
                 DeleteBehavior::Restrict,
                 Some(Filter::eq("actor_uri", Value::from(actor_uri.to_string()))),
             )
-            .map(|_| ())
+            .map(|entries| entries > 0)
             .map_err(CanisterError::from)
         })
     }

--- a/crates/canisters/user/src/domain/following/unfollow_user.rs
+++ b/crates/canisters/user/src/domain/following/unfollow_user.rs
@@ -1,0 +1,182 @@
+//! Domain logic for the `unfollow_user` flow.
+//!
+//! The flow consists of:
+//! 1. Look up the target in the `following` table.
+//! 2. If absent, return success (idempotent).
+//! 3. Delete the row regardless of its status (`Pending` cancels an outbound
+//!    follow request, `Accepted` ends an established follow).
+//! 4. Build an `Undo(Follow)` activity and dispatch it to the target via the
+//!    Federation Canister.
+
+use activitypub::activity::{Activity, ActivityObject, ActivityType};
+use activitypub::context::ACTIVITY_STREAMS_CONTEXT;
+use activitypub::object::{BaseObject, OneOrMany};
+use did::federation::{SendActivityArgs, SendActivityArgsObject};
+use did::user::{UnfollowUserArgs, UnfollowUserError, UnfollowUserResponse};
+
+use crate::domain::following::FollowingRepository;
+use crate::domain::profile::ProfileRepository;
+use crate::error::CanisterResult;
+
+/// Execute the unfollow-user flow.
+pub async fn unfollow_user(
+    UnfollowUserArgs { actor_uri }: UnfollowUserArgs,
+) -> UnfollowUserResponse {
+    ic_utils::log!("unfollow_user: attempting to unfollow {actor_uri}");
+
+    match unfollow_user_inner(&actor_uri).await {
+        Ok(()) => UnfollowUserResponse::Ok,
+        Err(err) => {
+            let err = err.to_string();
+            ic_utils::log!("unfollow_user: error: {err}");
+            UnfollowUserResponse::Err(UnfollowUserError::Internal(err))
+        }
+    }
+}
+
+async fn unfollow_user_inner(target_actor_uri: &str) -> CanisterResult<()> {
+    // Idempotent: delete returns false when no row matched — nothing to do.
+    // Removes the row regardless of status (Pending or Accepted).
+    if !FollowingRepository::delete_by_actor_uri(target_actor_uri)? {
+        ic_utils::log!("unfollow_user: not following {target_actor_uri}, no-op");
+        return Ok(());
+    }
+    ic_utils::log!("unfollow_user: removed following entry for {target_actor_uri}");
+
+    // Build own actor URI for the Undo(Follow) payload.
+    let own_profile = ProfileRepository::get_profile()?;
+    let own_actor_uri = crate::domain::urls::actor_uri(&own_profile.handle.0)?;
+
+    let activity = make_undo_follow_activity(&own_actor_uri, target_actor_uri);
+    let target_inbox = crate::domain::urls::inbox_url_from_actor_uri(target_actor_uri);
+
+    let args = SendActivityArgs::One(SendActivityArgsObject {
+        activity_json: serde_json::to_string(&activity)
+            .expect("Activity serialization must not fail"),
+        target_inbox,
+    });
+
+    crate::adapters::federation::send_activity(args).await?;
+
+    Ok(())
+}
+
+/// Build an `Undo(Follow)` [`Activity`] cancelling a previous follow.
+fn make_undo_follow_activity(own_actor_uri: &str, target_actor_uri: &str) -> Activity {
+    let inner_follow = Activity {
+        base: BaseObject {
+            kind: ActivityType::Follow,
+            ..Default::default()
+        },
+        actor: Some(own_actor_uri.to_string()),
+        object: Some(ActivityObject::Id(target_actor_uri.to_string())),
+        target: None,
+        result: None,
+        origin: None,
+        instrument: None,
+    };
+
+    Activity {
+        base: BaseObject {
+            context: Some(activitypub::context::Context::Uri(
+                ACTIVITY_STREAMS_CONTEXT.to_string(),
+            )),
+            kind: ActivityType::Undo,
+            to: Some(OneOrMany::One(target_actor_uri.to_string())),
+            ..Default::default()
+        },
+        actor: Some(own_actor_uri.to_string()),
+        object: Some(ActivityObject::Activity(Box::new(inner_follow))),
+        target: None,
+        result: None,
+        origin: None,
+        instrument: None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    use did::user::{UnfollowUserArgs, UnfollowUserResponse};
+
+    use super::*;
+    use crate::schema::FollowStatus;
+    use crate::test_utils::setup;
+
+    const TARGET_URI: &str = "https://mastic.social/users/alice";
+    const OWN_URI: &str = "https://mastic.social/users/rey_canisteryo";
+
+    #[tokio::test]
+    async fn test_should_unfollow_accepted_target() {
+        setup();
+
+        FollowingRepository::insert_pending(TARGET_URI).expect("should insert");
+        FollowingRepository::update_status(TARGET_URI, FollowStatus::Accepted)
+            .expect("should accept");
+
+        let response = unfollow_user(UnfollowUserArgs {
+            actor_uri: TARGET_URI.to_string(),
+        })
+        .await;
+
+        assert_eq!(response, UnfollowUserResponse::Ok);
+        assert!(
+            FollowingRepository::find_by_actor_uri(TARGET_URI)
+                .expect("should query")
+                .is_none()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_should_unfollow_pending_target() {
+        setup();
+
+        FollowingRepository::insert_pending(TARGET_URI).expect("should insert");
+
+        let response = unfollow_user(UnfollowUserArgs {
+            actor_uri: TARGET_URI.to_string(),
+        })
+        .await;
+
+        assert_eq!(response, UnfollowUserResponse::Ok);
+        assert!(
+            FollowingRepository::find_by_actor_uri(TARGET_URI)
+                .expect("should query")
+                .is_none()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_should_be_idempotent_when_not_following() {
+        setup();
+
+        let response = unfollow_user(UnfollowUserArgs {
+            actor_uri: TARGET_URI.to_string(),
+        })
+        .await;
+
+        assert_eq!(response, UnfollowUserResponse::Ok);
+    }
+
+    #[test]
+    fn test_make_undo_follow_activity_should_wrap_inner_follow() {
+        let activity = make_undo_follow_activity(OWN_URI, TARGET_URI);
+
+        assert_eq!(activity.base.kind, ActivityType::Undo);
+        assert_eq!(activity.actor.as_deref(), Some(OWN_URI));
+        assert_eq!(
+            activity.base.to,
+            Some(OneOrMany::One(TARGET_URI.to_string()))
+        );
+
+        let ActivityObject::Activity(inner) = activity.object.expect("should have object") else {
+            panic!("expected Activity variant");
+        };
+        assert_eq!(inner.base.kind, ActivityType::Follow);
+        assert_eq!(inner.actor.as_deref(), Some(OWN_URI));
+        let ActivityObject::Id(inner_obj) = inner.object.expect("should have inner object") else {
+            panic!("expected Id variant");
+        };
+        assert_eq!(inner_obj, TARGET_URI);
+    }
+}

--- a/crates/canisters/user/src/inspect.rs
+++ b/crates/canisters/user/src/inspect.rs
@@ -10,6 +10,7 @@ pub fn inspect() {
         | "publish_status"
         | "read_feed"
         | "reject_follow"
+        | "unfollow_user"
         | "update_profile" => {
             let caller = ic_utils::caller();
             if !crate::api::inspect::is_owner(caller) {

--- a/crates/canisters/user/src/lib.rs
+++ b/crates/canisters/user/src/lib.rs
@@ -14,7 +14,8 @@ use did::user::{
     GetFollowersResponse, GetFollowingArgs, GetFollowingResponse, GetProfileResponse,
     GetStatusesArgs, GetStatusesResponse, PublishStatusArgs, PublishStatusResponse, ReadFeedArgs,
     ReadFeedResponse, ReceiveActivityArgs, ReceiveActivityResponse, RejectFollowArgs,
-    RejectFollowResponse, UpdateProfileArgs, UpdateProfileResponse, UserInstallArgs,
+    RejectFollowResponse, UnfollowUserArgs, UnfollowUserResponse, UpdateProfileArgs,
+    UpdateProfileResponse, UserInstallArgs,
 };
 
 #[ic_cdk::init]
@@ -90,6 +91,11 @@ fn receive_activity(args: ReceiveActivityArgs) -> ReceiveActivityResponse {
 #[ic_cdk::update]
 async fn reject_follow(args: RejectFollowArgs) -> RejectFollowResponse {
     api::reject_follow(args).await
+}
+
+#[ic_cdk::update]
+async fn unfollow_user(args: UnfollowUserArgs) -> UnfollowUserResponse {
+    api::unfollow_user(args).await
 }
 
 #[ic_cdk::update]

--- a/crates/canisters/user/src/schema.rs
+++ b/crates/canisters/user/src/schema.rs
@@ -398,7 +398,7 @@ pub struct ProfileMetadata {
     pub value: Text,
 }
 
-#[derive(DatabaseSchema)]
+#[derive(DatabaseSchema, Clone)]
 #[tables(
     Settings = "settings",
     Profile = "profiles",

--- a/crates/libs/db-utils/Cargo.toml
+++ b/crates/libs/db-utils/Cargo.toml
@@ -9,6 +9,7 @@ publish = false
 [dependencies]
 candid = { workspace = true }
 did = { workspace = true }
+ic-cdk = { workspace = true }
 ic-dbms-canister = { workspace = true }
 ic-utils = { workspace = true }
 serde = { workspace = true }

--- a/crates/libs/db-utils/src/lib.rs
+++ b/crates/libs/db-utils/src/lib.rs
@@ -5,6 +5,7 @@ pub mod field_update;
 pub mod handle;
 pub mod hashtag;
 pub mod media;
+pub mod migration;
 pub mod settings;
 pub mod transaction;
 pub mod url;

--- a/crates/libs/db-utils/src/migration.rs
+++ b/crates/libs/db-utils/src/migration.rs
@@ -1,0 +1,75 @@
+//! Migration utilities for the database.
+
+use std::thread::LocalKey;
+
+use ic_dbms_canister::prelude::{
+    DatabaseSchema, DbmsContext, IcAccessControlList, IcMemoryProvider,
+};
+use wasm_dbms::WasmDbmsDatabase;
+use wasm_dbms_api::prelude::{Database, MigrationPolicy};
+
+/// Run a post-upgrade migration to update the database schema after a canister upgrade.
+///
+/// This function doesn't fail with an error, but can trap if it fails to check whether there is a migration to run.
+///
+/// Since Internet Computer wouldn't allow the user to run the migration inside a single call, we need to run the migration in
+/// a separate task, so this means we don't have control over whether the migration failed or not, but we can at least log the error if it fails.
+pub fn run_post_upgrade_migration<S>(
+    ctx: &'static LocalKey<DbmsContext<IcMemoryProvider, IcAccessControlList>>,
+    schema: S,
+) where
+    S: DatabaseSchema<IcMemoryProvider, IcAccessControlList> + Clone + 'static,
+{
+    let has_drift = match ctx.with(|c| {
+        let db = WasmDbmsDatabase::oneshot(c, schema.clone());
+        db.has_drift()
+    }) {
+        Ok(v) => v,
+        Err(err) => {
+            ic_utils::trap!("Failed to check database drift: {err}");
+        }
+    };
+
+    if !has_drift {
+        ic_utils::log!("No database drift detected, skipping migration");
+        return;
+    }
+
+    ic_utils::log!("Database drift detected, running migration");
+    ic_cdk::futures::spawn_migratory(run_migration(ctx, schema));
+}
+
+/// Run a migration to update the database schema after a canister upgrade.
+///
+/// This function is intended to be used in a post-upgrade hook,
+/// and it will run the migration in a separate task, so it won't block the upgrade process.
+/// However, it can trap if it fails to check whether there is a migration to run.
+async fn run_migration<S>(
+    ctx: &'static LocalKey<DbmsContext<IcMemoryProvider, IcAccessControlList>>,
+    schema: S,
+) where
+    S: DatabaseSchema<IcMemoryProvider, IcAccessControlList> + Clone + 'static,
+{
+    ctx.with(|c| {
+        let mut db = WasmDbmsDatabase::oneshot(c, schema);
+
+        let pending_migrations = match db.pending_migrations() {
+            Ok(migrations) => migrations,
+            Err(err) => {
+                ic_utils::log!("Failed to check pending migrations: {err}");
+                return;
+            }
+        };
+        for migration in pending_migrations {
+            ic_utils::log!("Pending migration: {migration:?}");
+        }
+
+        if let Err(err) = db.migrate(MigrationPolicy {
+            allow_destructive: true,
+        }) {
+            ic_utils::log!("Failed to run database migrations: {err}");
+        } else {
+            ic_utils::log!("Database migrations completed successfully");
+        }
+    });
+}

--- a/crates/libs/did/src/user.rs
+++ b/crates/libs/did/src/user.rs
@@ -174,10 +174,6 @@ pub struct UnfollowUserArgs {
 /// Error types for the `unfollow_user` method.
 #[derive(Debug, Clone, PartialEq, Eq, CandidType, Serialize, Deserialize)]
 pub enum UnfollowUserError {
-    /// The caller is not the canister owner.
-    Unauthorized,
-    /// The caller does not currently follow the target user.
-    NotFollowing,
     /// Internal error occurred while processing the unfollow request.
     Internal(String),
 }

--- a/crates/libs/did/src/user/tests.rs
+++ b/crates/libs/did/src/user/tests.rs
@@ -190,16 +190,10 @@ fn test_should_roundtrip_unfollow_user_response_ok() {
 
 #[test]
 fn test_should_roundtrip_unfollow_user_response_err() {
-    for error in [
-        UnfollowUserError::Unauthorized,
-        UnfollowUserError::NotFollowing,
-        UnfollowUserError::Internal("db error".to_string()),
-    ] {
-        let resp = UnfollowUserResponse::Err(error);
-        let bytes = Encode!(&resp).unwrap();
-        let decoded = Decode!(&bytes, UnfollowUserResponse).unwrap();
-        assert_eq!(resp, decoded);
-    }
+    let resp = UnfollowUserResponse::Err(UnfollowUserError::Internal("db error".to_string()));
+    let bytes = Encode!(&resp).unwrap();
+    let decoded = Decode!(&bytes, UnfollowUserResponse).unwrap();
+    assert_eq!(resp, decoded);
 }
 
 #[test]

--- a/docs/src/user.did
+++ b/docs/src/user.did
@@ -209,6 +209,13 @@ type Status = record {
   // The visibility setting of the status, controlling its audience.
   visibility : Visibility;
 };
+// Error types for the `unfollow_user` method.
+type UnfollowUserError = variant {
+  // Internal error occurred while processing the unfollow request.
+  Internal : text;
+};
+// Response type for the `unfollow_user` method.
+type UnfollowUserResponse = variant { Ok; Err : UnfollowUserError };
 // Request arguments for the `update_profile` method.
 // All fields are optional; only provided fields are updated.
 type UpdateProfileArgs = record {
@@ -217,13 +224,6 @@ type UpdateProfileArgs = record {
   // New display name, or `Leave` to leave unchanged.
   display_name : FieldUpdate;
 };
-// Error types for the `update_profile` method.
-type UpdateProfileError = variant {
-  // The caller is not the canister owner.
-  Internal : text;
-};
-// Response type for the `update_profile` method.
-type UpdateProfileResponse = variant { Ok; Err : UpdateProfileError };
 // Install arguments for the User Canister.
 type UserInstallArgs = variant {
   // Upgrade argument, provided on `upgrade`.
@@ -284,5 +284,6 @@ service : (UserInstallArgs) -> {
   read_feed : (ReadFeedArgs) -> (ReadFeedResponse) query;
   receive_activity : (ReceiveActivityArgs) -> (ReceiveActivityResponse);
   reject_follow : (AcceptFollowArgs) -> (AcceptFollowResponse);
-  update_profile : (UpdateProfileArgs) -> (UpdateProfileResponse);
+  unfollow_user : (AcceptFollowArgs) -> (UnfollowUserResponse);
+  update_profile : (UpdateProfileArgs) -> (UnfollowUserResponse);
 }

--- a/integration-tests/src/user_client.rs
+++ b/integration-tests/src/user_client.rs
@@ -5,7 +5,8 @@ use did::user::{
     GetFollowRequestsArgs, GetFollowRequestsResponse, GetFollowersArgs, GetFollowersResponse,
     GetFollowingArgs, GetFollowingResponse, GetProfileResponse, GetStatusesArgs,
     GetStatusesResponse, PublishStatusArgs, PublishStatusResponse, ReadFeedArgs, ReadFeedResponse,
-    RejectFollowArgs, RejectFollowResponse, UpdateProfileArgs, UpdateProfileResponse,
+    RejectFollowArgs, RejectFollowResponse, UnfollowUserArgs, UnfollowUserResponse,
+    UpdateProfileArgs, UpdateProfileResponse,
 };
 use pocket_ic_harness::PocketIcTestEnv;
 
@@ -159,6 +160,24 @@ impl UserClient<'_> {
             )
             .await
             .expect("Failed to call reject_follow")
+    }
+
+    pub async fn unfollow_user(
+        &self,
+        caller: Principal,
+        actor_uri: String,
+    ) -> UnfollowUserResponse {
+        let args = UnfollowUserArgs { actor_uri };
+
+        self.env
+            .update(
+                self.canister_id,
+                caller,
+                "unfollow_user",
+                Encode!(&args).expect("Failed to encode unfollow_user arguments"),
+            )
+            .await
+            .expect("Failed to call unfollow_user")
     }
 
     pub async fn read_feed(&self, caller: Principal, offset: u64, limit: u64) -> ReadFeedResponse {

--- a/integration-tests/tests/unfollow.rs
+++ b/integration-tests/tests/unfollow.rs
@@ -1,0 +1,148 @@
+use did::user::{
+    AcceptFollowResponse, FollowUserResponse, GetFollowRequestsResponse, GetFollowersResponse,
+    GetFollowingResponse, UnfollowUserResponse,
+};
+use integration_tests::{MasticCanisterSetup, PUBLIC_URL, UserClient};
+use pocket_ic_harness::{PocketIcTestEnv, alice, bob};
+
+fn actor_uri(handle: &str) -> String {
+    format!("{PUBLIC_URL}/users/{handle}")
+}
+
+#[pocket_ic_harness::test]
+async fn test_should_unfollow_after_accept(env: PocketIcTestEnv<MasticCanisterSetup>) {
+    let alice_canister_id =
+        integration_tests::helpers::sign_up_user(&env, alice(), "alice".to_string()).await;
+    let bob_canister_id =
+        integration_tests::helpers::sign_up_user(&env, bob(), "bob".to_string()).await;
+
+    let alice_client = UserClient::new(&env, alice_canister_id);
+    let bob_client = UserClient::new(&env, bob_canister_id);
+
+    let alice_uri = actor_uri("alice");
+    let bob_uri = actor_uri("bob");
+
+    // alice follows bob
+    assert_eq!(
+        alice_client.follow_user(alice(), "bob".to_string()).await,
+        FollowUserResponse::Ok
+    );
+
+    // bob accepts alice's follow request
+    assert_eq!(
+        bob_client.accept_follow(bob(), alice_uri.clone()).await,
+        AcceptFollowResponse::Ok
+    );
+
+    // sanity: alice follows bob, bob has alice as follower
+    let GetFollowingResponse::Ok(following) = alice_client.get_following(alice(), 0, 10).await
+    else {
+        panic!("Failed to get following list for alice");
+    };
+    assert_eq!(following, vec![bob_uri.clone()]);
+
+    let GetFollowersResponse::Ok(followers) = bob_client.get_followers(bob(), 0, 10).await else {
+        panic!("Failed to get followers list for bob");
+    };
+    assert_eq!(followers, vec![alice_uri.clone()]);
+
+    // alice unfollows bob
+    assert_eq!(
+        alice_client.unfollow_user(alice(), bob_uri.clone()).await,
+        UnfollowUserResponse::Ok
+    );
+
+    // alice's following list is empty
+    let GetFollowingResponse::Ok(following) = alice_client.get_following(alice(), 0, 10).await
+    else {
+        panic!("Failed to get following list for alice");
+    };
+    assert!(following.is_empty());
+
+    // bob's followers list is empty (Undo(Follow) delivered)
+    let GetFollowersResponse::Ok(followers) = bob_client.get_followers(bob(), 0, 10).await else {
+        panic!("Failed to get followers list for bob");
+    };
+    assert!(followers.is_empty());
+}
+
+#[pocket_ic_harness::test]
+async fn test_should_cancel_pending_follow_on_unfollow(env: PocketIcTestEnv<MasticCanisterSetup>) {
+    let alice_canister_id =
+        integration_tests::helpers::sign_up_user(&env, alice(), "alice".to_string()).await;
+    let bob_canister_id =
+        integration_tests::helpers::sign_up_user(&env, bob(), "bob".to_string()).await;
+
+    let alice_client = UserClient::new(&env, alice_canister_id);
+    let bob_client = UserClient::new(&env, bob_canister_id);
+
+    let alice_uri = actor_uri("alice");
+    let bob_uri = actor_uri("bob");
+
+    // alice follows bob, but bob has not accepted yet
+    assert_eq!(
+        alice_client.follow_user(alice(), "bob".to_string()).await,
+        FollowUserResponse::Ok
+    );
+
+    // bob has alice in follow_requests
+    let GetFollowRequestsResponse::Ok(bob_follow_requests) =
+        bob_client.get_follow_requests(bob(), 0, 10).await
+    else {
+        panic!("Failed to get follow requests for bob");
+    };
+    assert_eq!(bob_follow_requests, vec![alice_uri.clone()]);
+
+    // alice unfollows bob before acceptance — cancels outbound follow
+    assert_eq!(
+        alice_client.unfollow_user(alice(), bob_uri.clone()).await,
+        UnfollowUserResponse::Ok
+    );
+
+    // alice's pending following row is gone
+    let GetFollowingResponse::Ok(following) = alice_client.get_following(alice(), 0, 10).await
+    else {
+        panic!("Failed to get following list for alice");
+    };
+    assert!(following.is_empty());
+
+    // bob's pending follow_request from alice is gone (Undo(Follow) delivered)
+    let GetFollowRequestsResponse::Ok(bob_follow_requests) =
+        bob_client.get_follow_requests(bob(), 0, 10).await
+    else {
+        panic!("Failed to get follow requests for bob");
+    };
+    assert!(bob_follow_requests.is_empty());
+
+    // bob never had alice as a follower
+    let GetFollowersResponse::Ok(followers) = bob_client.get_followers(bob(), 0, 10).await else {
+        panic!("Failed to get followers list for bob");
+    };
+    assert!(followers.is_empty());
+}
+
+#[pocket_ic_harness::test]
+async fn test_should_succeed_unfollow_when_not_following(
+    env: PocketIcTestEnv<MasticCanisterSetup>,
+) {
+    let alice_canister_id =
+        integration_tests::helpers::sign_up_user(&env, alice(), "alice".to_string()).await;
+    let _bob_canister_id =
+        integration_tests::helpers::sign_up_user(&env, bob(), "bob".to_string()).await;
+
+    let alice_client = UserClient::new(&env, alice_canister_id);
+
+    let bob_uri = actor_uri("bob");
+
+    // alice never followed bob — unfollow is a silent no-op
+    assert_eq!(
+        alice_client.unfollow_user(alice(), bob_uri).await,
+        UnfollowUserResponse::Ok
+    );
+
+    let GetFollowingResponse::Ok(following) = alice_client.get_following(alice(), 0, 10).await
+    else {
+        panic!("Failed to get following list for alice");
+    };
+    assert!(following.is_empty());
+}


### PR DESCRIPTION
## Summary

- Implements `unfollow_user` (owner-only) on the User Canister: removes the target from `following` and dispatches `Undo(Follow)` to the target inbox via the Federation Canister. Idempotent on miss. Removes the row regardless of `Pending` (outbound cancel) or `Accepted` status.
- Adds inbound `Undo(Follow)` handling in `receive_activity`: removes sender from `followers` and from `follow_requests` (idempotent; non-`Follow` inner is silently ignored).
- Updates issue spec to clarify that `follow_requests` is inbound-only — outbound pending lives in `following.Pending`.

Closes #15.

## Test plan

- [x] `just check_code`
- [x] `just test` (unit tests, including 5 new in `handle_incoming` and 4 new in `unfollow_user`)
- [x] `just build_all`
- [x] `just integration_test` — 3 new scenarios under `tests/unfollow.rs`:
  - follow → accept → unfollow → both lists cleared
  - follow → unfollow before accept → pending cancelled both sides
  - unfollow when not following → silent success