### PR TITLE
feat(directory): implement search_profiles query (UC8)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,7 +96,7 @@ Canonical `.did` files live in `docs/src/`. The build pipeline also auto-extract
 - `docs/src/architecture.md` contains sequence diagrams for all major flows.
 - `docs/src/activitypub.md` is the ActivityPub protocol reference with Mastic-specific mapping.
 - When adding a new flow, add both a sequence diagram in architecture and a user story in project.md.
-- When adding or removing documentation pages under `docs/src/`, always update `docs/src/SUMMARY.md` to keep the mdBook index in sync. New pages should be placed under the appropriate parent section (e.g. interface subtopics go under `interface/`, milestone plans under `milestones/`).
+- **ALWAYS** update `docs/src/SUMMARY.md` whenever a Markdown file is added to or removed from `docs/src/`. The mdBook index must stay in sync — pages absent from `SUMMARY.md` are not rendered. New pages go under the appropriate parent section (e.g. interface subtopics under `interface/`, milestone plans under `milestones/`).
 
 ## Local Development
 

--- a/crates/canisters/directory/src/api.rs
+++ b/crates/canisters/directory/src/api.rs
@@ -1,10 +1,12 @@
 //! Canister implementation
 
+pub mod inspect;
+
 use candid::Principal;
 use did::directory::{
     DeleteProfileResponse, DirectoryInstallArgs, GetUserArgs, GetUserResponse,
-    RetryDeleteProfileResponse, RetrySignUpResponse, SignUpRequest, SignUpResponse,
-    UserCanisterResponse, WhoAmIResponse,
+    RetryDeleteProfileResponse, RetrySignUpResponse, SearchProfilesArgs, SearchProfilesResponse,
+    SignUpRequest, SignUpResponse, UserCanisterResponse, WhoAmIResponse,
 };
 use ic_dbms_canister::prelude::DBMS_CONTEXT;
 
@@ -89,6 +91,23 @@ pub fn retry_sign_up() -> RetrySignUpResponse {
     ic_utils::log!("retry_sign_up called by {caller}");
 
     crate::domain::users::retry_sign_up(caller)
+}
+
+/// Handles the `search_profiles` Directory query (UC8).
+///
+/// Validates the request via [`crate::api::inspect::inspect_search_profiles`]
+/// (limit bounds + sanitized handle validity). On invalid arguments it traps,
+/// since `inspect_message` does not gate query calls — this is the defensive
+/// path for direct query invocations.
+///
+/// Returns matching Active users with a canister id; substring case-insensitive
+/// match over `users.handle`. See [`crate::domain::users::search_profiles`].
+pub fn search_profiles(args: SearchProfilesArgs) -> SearchProfilesResponse {
+    if let Err(err) = crate::api::inspect::inspect_search_profiles(&args) {
+        ic_utils::trap!("Invalid search profiles arguments: {err}");
+    }
+
+    crate::domain::users::search_profiles(args)
 }
 
 /// Handles the `sign_up` method call to register a new user in the directory, creating a User Canister

--- a/crates/canisters/directory/src/api/inspect.rs
+++ b/crates/canisters/directory/src/api/inspect.rs
@@ -1,0 +1,88 @@
+//! Argument inspection helpers for Directory canister query/update endpoints.
+
+use db_utils::handle::{HandleSanitizer, HandleValidator};
+use did::directory::SearchProfilesArgs;
+
+/// Maximum number of profiles `search_profiles` may return in a single page.
+const MAX_SEARCH_LIMIT: u64 = 50;
+
+/// Validates [`SearchProfilesArgs`] before the query runs.
+///
+/// Rejects the call if:
+/// - `limit` is `0` or greater than [`MAX_SEARCH_LIMIT`];
+/// - the sanitized `query` (after [`HandleSanitizer`] strips `@`/whitespace and
+///   lowercases) fails [`HandleValidator::check_handle`].
+///
+/// Empty queries are valid (they match all Active users, paginated).
+pub fn inspect_search_profiles(args: &SearchProfilesArgs) -> Result<(), String> {
+    if args.limit > MAX_SEARCH_LIMIT {
+        return Err(format!("Limit cannot be greater than {MAX_SEARCH_LIMIT}"));
+    }
+    if args.limit == 0 {
+        return Err("Limit cannot be zero".to_string());
+    }
+
+    // Empty queries are valid: the Directory returns all Active users, paginated.
+    // Skip handle validation in that case since `HandleValidator` rejects empty input.
+    let handle = HandleSanitizer::sanitize_handle(&args.query);
+    if !handle.is_empty() {
+        HandleValidator::check_handle(&handle)?;
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn args(query: &str, limit: u64) -> SearchProfilesArgs {
+        SearchProfilesArgs {
+            query: query.to_string(),
+            offset: 0,
+            limit,
+        }
+    }
+
+    #[test]
+    fn test_should_accept_valid_args() {
+        inspect_search_profiles(&args("alice", 10)).expect("valid args should pass");
+    }
+
+    #[test]
+    fn test_should_accept_empty_query() {
+        inspect_search_profiles(&args("", 10)).expect("empty query should pass");
+    }
+
+    #[test]
+    fn test_should_accept_max_limit() {
+        inspect_search_profiles(&args("alice", MAX_SEARCH_LIMIT))
+            .expect("limit at MAX_SEARCH_LIMIT should pass");
+    }
+
+    #[test]
+    fn test_should_reject_zero_limit() {
+        let err = inspect_search_profiles(&args("alice", 0)).unwrap_err();
+        assert!(err.contains("zero"), "got error: {err}");
+    }
+
+    #[test]
+    fn test_should_reject_limit_above_max() {
+        let err = inspect_search_profiles(&args("alice", MAX_SEARCH_LIMIT + 1)).unwrap_err();
+        assert!(err.contains("greater than"), "got error: {err}");
+    }
+
+    #[test]
+    fn test_should_reject_invalid_handle_after_sanitization() {
+        // Handles must satisfy HandleValidator after sanitization. Disallowed characters fail.
+        let err = inspect_search_profiles(&args("not a handle!", 10)).unwrap_err();
+        assert!(!err.is_empty());
+    }
+
+    #[test]
+    fn test_should_accept_query_with_at_prefix() {
+        // `HandleSanitizer` strips leading `@` and lowercases; `@Alice` → `alice`.
+        inspect_search_profiles(&args("@Alice", 10))
+            .expect("@-prefixed query should pass after sanitization");
+    }
+}

--- a/crates/canisters/directory/src/domain/users.rs
+++ b/crates/canisters/directory/src/domain/users.rs
@@ -3,12 +3,14 @@
 mod delete_profile;
 mod get_user;
 pub(crate) mod repository;
+mod search_profiles;
 mod sign_up;
 mod user_canister;
 mod whoami;
 
 pub use self::delete_profile::{delete_profile, retry_delete_profile};
 pub use self::get_user::get_user;
+pub use self::search_profiles::search_profiles;
 pub use self::sign_up::{retry_sign_up, sign_up};
 pub use self::user_canister::user_canister;
 pub use self::whoami::whoami;

--- a/crates/canisters/directory/src/domain/users/repository.rs
+++ b/crates/canisters/directory/src/domain/users/repository.rs
@@ -261,6 +261,36 @@ impl UserRepository {
         Ok(())
     }
 
+    /// Searches for user profiles based on a query string that matches the handle, with pagination support using offset and limit.
+    ///
+    /// Search only those which are `Active` and have a canister id.
+    pub fn search_profiles(handle: &str, offset: usize, limit: usize) -> CanisterResult<Vec<User>> {
+        ic_utils::log!(
+            "UserRepository::search_profiles: searching for handle {handle:?} with offset {offset} and limit {limit}"
+        );
+        let rows = DBMS_CONTEXT.with(|ctx| {
+            let dbms = WasmDbmsDatabase::oneshot(ctx, Schema);
+            dbms.select::<User>(
+                Query::builder()
+                    .all()
+                    .offset(offset)
+                    .limit(limit)
+                    .and_where(Filter::like("handle", &format!("%{handle}%")))
+                    .and_where(Filter::eq(
+                        "canister_status",
+                        crate::schema::UserCanisterStatus(
+                            did::directory::UserCanisterStatus::Active,
+                        )
+                        .into(),
+                    ))
+                    .and_where(Filter::not_null("canister_id"))
+                    .build(),
+            )
+        })?;
+
+        Ok(rows.into_iter().map(Self::user_record_to_user).collect())
+    }
+
     fn user_record_to_user(user: UserRecord) -> User {
         User {
             principal: user.principal.expect("principal cannot be empty"),
@@ -451,5 +481,156 @@ mod tests {
 
         let user = UserRepository::get_user_by_handle("nonexistent").expect("should query");
         assert!(user.is_none(), "should return None for unknown handle");
+    }
+
+    /// Sets the canister status of a user to an arbitrary value (test-only helper).
+    fn set_canister_status(principal: Principal, status: did::directory::UserCanisterStatus) {
+        let update = UserUpdateRequest {
+            canister_status: Some(UserCanisterStatus::from(status)),
+            where_clause: Some(Filter::eq(
+                User::primary_key(),
+                ic_dbms_canister::prelude::Principal(principal).into(),
+            )),
+            ..Default::default()
+        };
+
+        let rows = DBMS_CONTEXT
+            .with(|ctx| {
+                let dbms = WasmDbmsDatabase::oneshot(ctx, Schema);
+                dbms.update::<User>(update)
+            })
+            .expect("update should succeed");
+        assert_eq!(rows, 1, "should update exactly one row");
+    }
+
+    fn alice_user() -> Principal {
+        Principal::self_authenticating([10u8; 32])
+    }
+
+    fn other_user() -> Principal {
+        Principal::self_authenticating([11u8; 32])
+    }
+
+    fn canister(seed: u8) -> Principal {
+        Principal::self_authenticating([seed; 32])
+    }
+
+    /// Seeds two Active users named `alice` and `alicia`, both with a canister id.
+    /// Used by tests that exercise matching/pagination behavior.
+    fn seed_two_active_alikes() {
+        UserRepository::sign_up(alice_user(), "alice".to_string()).unwrap();
+        UserRepository::set_user_canister(alice_user(), canister(100)).unwrap();
+        UserRepository::sign_up(other_user(), "alicia".to_string()).unwrap();
+        UserRepository::set_user_canister(other_user(), canister(101)).unwrap();
+    }
+
+    #[test]
+    fn test_search_profiles_should_match_exact_handle() {
+        setup();
+        seed_two_active_alikes();
+
+        let users = UserRepository::search_profiles("alice", 0, 50).expect("search should succeed");
+        let handles: Vec<_> = users.iter().map(|u| u.handle.0.as_str()).collect();
+        assert!(handles.contains(&"alice"));
+    }
+
+    #[test]
+    fn test_search_profiles_should_match_prefix_substring() {
+        setup();
+        seed_two_active_alikes();
+
+        let users = UserRepository::search_profiles("ali", 0, 50).expect("search should succeed");
+        let handles: Vec<_> = users.iter().map(|u| u.handle.0.as_str()).collect();
+        assert!(handles.contains(&"alice"));
+        assert!(handles.contains(&"alicia"));
+        assert_eq!(handles.len(), 2);
+    }
+
+    #[test]
+    fn test_search_profiles_should_match_middle_substring() {
+        setup();
+        seed_two_active_alikes();
+
+        let users = UserRepository::search_profiles("lic", 0, 50).expect("search should succeed");
+        let handles: Vec<_> = users.iter().map(|u| u.handle.0.as_str()).collect();
+        assert!(handles.contains(&"alice"));
+        assert!(handles.contains(&"alicia"));
+    }
+
+    #[test]
+    fn test_search_profiles_empty_query_returns_all_active() {
+        setup();
+        seed_two_active_alikes();
+
+        let users = UserRepository::search_profiles("", 0, 50).expect("search should succeed");
+        assert_eq!(users.len(), 2);
+    }
+
+    #[test]
+    fn test_search_profiles_pagination() {
+        setup();
+        seed_two_active_alikes();
+
+        let page1 = UserRepository::search_profiles("", 0, 1).expect("search should succeed");
+        assert_eq!(page1.len(), 1);
+
+        let page2 = UserRepository::search_profiles("", 1, 1).expect("search should succeed");
+        assert_eq!(page2.len(), 1);
+        assert_ne!(page1[0].handle.0, page2[0].handle.0);
+
+        let page3 = UserRepository::search_profiles("", 2, 1).expect("search should succeed");
+        assert!(page3.is_empty());
+    }
+
+    #[test]
+    fn test_search_profiles_no_match_returns_empty() {
+        setup();
+        seed_two_active_alikes();
+
+        let users =
+            UserRepository::search_profiles("zorblax", 0, 50).expect("search should succeed");
+        assert!(users.is_empty());
+    }
+
+    #[test]
+    fn test_search_profiles_should_exclude_creation_pending() {
+        setup();
+        // CreationPending: signed up, no canister set yet.
+        UserRepository::sign_up(alice_user(), "alice".to_string()).unwrap();
+
+        let users = UserRepository::search_profiles("alice", 0, 50).expect("search should succeed");
+        assert!(users.is_empty(), "CreationPending users must be excluded");
+    }
+
+    #[test]
+    fn test_search_profiles_should_exclude_creation_failed() {
+        setup();
+        UserRepository::sign_up(alice_user(), "alice".to_string()).unwrap();
+        UserRepository::set_failed_user_canister_create(alice_user()).unwrap();
+
+        let users = UserRepository::search_profiles("alice", 0, 50).expect("search should succeed");
+        assert!(users.is_empty(), "CreationFailed users must be excluded");
+    }
+
+    #[test]
+    fn test_search_profiles_should_exclude_deletion_pending() {
+        setup();
+        UserRepository::sign_up(alice_user(), "alice".to_string()).unwrap();
+        UserRepository::set_user_canister(alice_user(), canister(100)).unwrap();
+        UserRepository::mark_user_for_deletion(alice_user()).unwrap();
+
+        let users = UserRepository::search_profiles("alice", 0, 50).expect("search should succeed");
+        assert!(users.is_empty(), "DeletionPending users must be excluded");
+    }
+
+    #[test]
+    fn test_search_profiles_should_exclude_suspended() {
+        setup();
+        UserRepository::sign_up(alice_user(), "alice".to_string()).unwrap();
+        UserRepository::set_user_canister(alice_user(), canister(100)).unwrap();
+        set_canister_status(alice_user(), did::directory::UserCanisterStatus::Suspended);
+
+        let users = UserRepository::search_profiles("alice", 0, 50).expect("search should succeed");
+        assert!(users.is_empty(), "Suspended users must be excluded");
     }
 }

--- a/crates/canisters/directory/src/domain/users/search_profiles.rs
+++ b/crates/canisters/directory/src/domain/users/search_profiles.rs
@@ -1,0 +1,185 @@
+//! Search profiles domain flow (UC8).
+//!
+//! Implements the `search_profiles` query exposed by the Directory canister.
+//! Argument validation lives in [`crate::api::inspect::inspect_search_profiles`]
+//! and runs before this function via either `inspect_message` (update calls) or
+//! a defensive trap on the query path.
+//!
+//! Behavior:
+//! - The raw query is normalized by [`HandleSanitizer`] (strips leading `@`,
+//!   trims whitespace, lowercases) — same pipeline as handle insertion, so
+//!   `@Alice` matches `alice`.
+//! - The repository performs a case-insensitive substring (`LIKE %x%`) match
+//!   over `users.handle`, filtered to `canister_status = Active` and
+//!   `canister_id IS NOT NULL`.
+//! - Suspended, DeletionPending, CreationPending and CreationFailed users are
+//!   excluded by construction.
+//! - Empty queries return all Active users, paginated.
+
+use db_utils::handle::HandleSanitizer;
+use did::directory::{SearchProfileEntry, SearchProfilesArgs, SearchProfilesResponse};
+
+use crate::domain::users::repository::UserRepository;
+
+/// Implements the `search_profiles` Directory query. See module docs for
+/// behavior. Returns [`SearchProfilesResponse::Err`] only on internal storage
+/// errors; argument validation is upstream.
+pub fn search_profiles(
+    SearchProfilesArgs {
+        query,
+        limit,
+        offset,
+    }: SearchProfilesArgs,
+) -> SearchProfilesResponse {
+    let handle = HandleSanitizer::sanitize_handle(&query);
+    ic_utils::log!(
+        "search_profiles called with query: {query}, sanitized handle: {handle}, limit: {limit}, offset: {offset}"
+    );
+
+    match UserRepository::search_profiles(&handle, offset as usize, limit as usize) {
+        Err(err) => {
+            ic_utils::log!("Error searching profiles: {err}");
+            SearchProfilesResponse::Err(did::directory::SearchProfilesError::Internal(
+                err.to_string(),
+            ))
+        }
+        Ok(profiles) => {
+            ic_utils::log!("Found {} profiles for query '{query}'", profiles.len());
+            SearchProfilesResponse::Ok(
+                profiles
+                    .into_iter()
+                    .map(|profile| SearchProfileEntry {
+                        handle: profile.handle.0,
+                        // Repository filters `canister_id IS NOT NULL`, so this is always Some.
+                        canister_id: profile.canister_id.into_opt().unwrap_or_default().0,
+                    })
+                    .collect(),
+            )
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use candid::Principal;
+    use did::directory::{SearchProfilesArgs, SearchProfilesResponse, UserCanisterStatus};
+
+    use super::*;
+    use crate::domain::users::repository::UserRepository;
+    use crate::test_utils::{bob, rey_canisteryo, setup, setup_registered_user_with_canister};
+
+    fn args(query: &str, offset: u64, limit: u64) -> SearchProfilesArgs {
+        SearchProfilesArgs {
+            query: query.to_string(),
+            offset,
+            limit,
+        }
+    }
+
+    #[test]
+    fn test_should_return_active_users() {
+        setup();
+        setup_registered_user_with_canister(rey_canisteryo(), "rey_canisteryo", bob());
+
+        let SearchProfilesResponse::Ok(results) = search_profiles(args("rey", 0, 50)) else {
+            panic!("expected Ok");
+        };
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].handle, "rey_canisteryo");
+        assert_eq!(results[0].canister_id, bob());
+    }
+
+    #[test]
+    fn test_should_sanitize_query_at_prefix() {
+        setup();
+        setup_registered_user_with_canister(rey_canisteryo(), "rey_canisteryo", bob());
+
+        let SearchProfilesResponse::Ok(results) = search_profiles(args("@REY", 0, 50)) else {
+            panic!("expected Ok");
+        };
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].handle, "rey_canisteryo");
+    }
+
+    #[test]
+    fn test_should_exclude_pending_users() {
+        setup();
+        // CreationPending: signed up but no canister set.
+        crate::test_utils::setup_registered_user(rey_canisteryo(), "rey_canisteryo");
+
+        let SearchProfilesResponse::Ok(results) = search_profiles(args("rey", 0, 50)) else {
+            panic!("expected Ok");
+        };
+        assert!(results.is_empty());
+    }
+
+    #[test]
+    fn test_should_paginate() {
+        setup();
+        setup_registered_user_with_canister(
+            rey_canisteryo(),
+            "rey_canisteryo",
+            Principal::self_authenticating([42u8; 32]),
+        );
+        setup_registered_user_with_canister(bob(), "bobby_canister", bob());
+
+        let SearchProfilesResponse::Ok(page1) = search_profiles(args("", 0, 1)) else {
+            panic!("expected Ok");
+        };
+        assert_eq!(page1.len(), 1);
+
+        let SearchProfilesResponse::Ok(page2) = search_profiles(args("", 1, 1)) else {
+            panic!("expected Ok");
+        };
+        assert_eq!(page2.len(), 1);
+        assert_ne!(page1[0].handle, page2[0].handle);
+    }
+
+    #[test]
+    fn test_should_exclude_suspended_user() {
+        setup();
+        setup_registered_user_with_canister(rey_canisteryo(), "rey_canisteryo", bob());
+
+        // Move to Suspended via repository update directly (no public flow yet).
+        use ic_dbms_canister::prelude::DBMS_CONTEXT;
+        use wasm_dbms::WasmDbmsDatabase;
+        use wasm_dbms_api::prelude::*;
+
+        use crate::schema::{Schema, User, UserUpdateRequest};
+
+        let update = UserUpdateRequest {
+            canister_status: Some(crate::schema::UserCanisterStatus::from(
+                UserCanisterStatus::Suspended,
+            )),
+            where_clause: Some(Filter::eq(
+                User::primary_key(),
+                ic_dbms_canister::prelude::Principal(rey_canisteryo()).into(),
+            )),
+            ..Default::default()
+        };
+        DBMS_CONTEXT.with(|ctx| {
+            let dbms = WasmDbmsDatabase::oneshot(ctx, Schema);
+            dbms.update::<User>(update).unwrap();
+        });
+
+        let SearchProfilesResponse::Ok(results) = search_profiles(args("rey", 0, 50)) else {
+            panic!("expected Ok");
+        };
+        assert!(results.is_empty(), "suspended user must not be returned");
+    }
+
+    #[test]
+    fn test_should_exclude_deletion_pending_user() {
+        setup();
+        setup_registered_user_with_canister(rey_canisteryo(), "rey_canisteryo", bob());
+        UserRepository::mark_user_for_deletion(rey_canisteryo()).unwrap();
+
+        let SearchProfilesResponse::Ok(results) = search_profiles(args("rey", 0, 50)) else {
+            panic!("expected Ok");
+        };
+        assert!(
+            results.is_empty(),
+            "deletion-pending user must not be returned"
+        );
+    }
+}

--- a/crates/canisters/directory/src/inspect.rs
+++ b/crates/canisters/directory/src/inspect.rs
@@ -10,6 +10,17 @@ pub fn inspect() {
             let caller = ic_utils::caller();
             if caller == Principal::anonymous() {
                 ic_cdk::api::msg_reject("Anonymous caller cannot do this");
+                return;
+            }
+        }
+        "search_profiles" => {
+            // check limit and offset
+            let args = ic_cdk::api::msg_arg_data();
+            let args = candid::decode_one::<did::directory::SearchProfilesArgs>(&args)
+                .expect("failed to decode arguments");
+            if let Err(err) = crate::api::inspect::inspect_search_profiles(&args) {
+                ic_cdk::api::msg_reject(err);
+                return;
             }
         }
         _ => {}

--- a/crates/canisters/directory/src/lib.rs
+++ b/crates/canisters/directory/src/lib.rs
@@ -12,8 +12,8 @@ mod test_utils;
 use candid::Principal;
 use did::directory::{
     DeleteProfileResponse, DirectoryInstallArgs, GetUserArgs, GetUserResponse,
-    RetryDeleteProfileResponse, RetrySignUpResponse, SignUpRequest, SignUpResponse,
-    UserCanisterResponse, WhoAmIResponse,
+    RetryDeleteProfileResponse, RetrySignUpResponse, SearchProfilesArgs, SearchProfilesResponse,
+    SignUpRequest, SignUpResponse, UserCanisterResponse, WhoAmIResponse,
 };
 
 #[ic_cdk::init]
@@ -49,6 +49,11 @@ fn retry_sign_up() -> RetrySignUpResponse {
 #[ic_cdk::update]
 fn retry_delete_profile() -> RetryDeleteProfileResponse {
     api::retry_delete_profile()
+}
+
+#[ic_cdk::query]
+fn search_profiles(query: SearchProfilesArgs) -> SearchProfilesResponse {
+    api::search_profiles(query)
 }
 
 #[ic_cdk::update]

--- a/crates/canisters/directory/src/schema/user_canister_status.rs
+++ b/crates/canisters/directory/src/schema/user_canister_status.rs
@@ -39,6 +39,7 @@ impl fmt::Display for UserCanisterStatus {
             DidUserCanisterStatus::CreationPending => "creation_pending",
             DidUserCanisterStatus::CreationFailed => "creation_failed",
             DidUserCanisterStatus::DeletionPending => "deletion_pending",
+            DidUserCanisterStatus::Suspended => "suspended",
         };
         write!(f, "{}", activity_str)
     }
@@ -55,6 +56,7 @@ impl Encode for UserCanisterStatus {
             DidUserCanisterStatus::CreationPending => 1,
             DidUserCanisterStatus::CreationFailed => 2,
             DidUserCanisterStatus::DeletionPending => 3,
+            DidUserCanisterStatus::Suspended => 4,
         }])
     }
 
@@ -72,6 +74,7 @@ impl Encode for UserCanisterStatus {
             1 => DidUserCanisterStatus::CreationPending,
             2 => DidUserCanisterStatus::CreationFailed,
             3 => DidUserCanisterStatus::DeletionPending,
+            4 => DidUserCanisterStatus::Suspended,
             _ => {
                 return Err(MemoryError::DecodeError(DecodeError::InvalidDiscriminant(
                     byte,
@@ -111,6 +114,8 @@ mod tests {
             DidUserCanisterStatus::Active,
             DidUserCanisterStatus::CreationPending,
             DidUserCanisterStatus::CreationFailed,
+            DidUserCanisterStatus::DeletionPending,
+            DidUserCanisterStatus::Suspended,
         ];
 
         for ap_type in cases {
@@ -137,6 +142,16 @@ mod tests {
             )),
             DidUserCanisterStatus::CreationFailed
         );
+        assert_eq!(
+            DidUserCanisterStatus::from(UserCanisterStatus::from(
+                DidUserCanisterStatus::DeletionPending
+            )),
+            DidUserCanisterStatus::DeletionPending
+        );
+        assert_eq!(
+            DidUserCanisterStatus::from(UserCanisterStatus::from(DidUserCanisterStatus::Suspended)),
+            DidUserCanisterStatus::Suspended
+        );
     }
 
     #[test]
@@ -153,6 +168,14 @@ mod tests {
             UserCanisterStatus::from(DidUserCanisterStatus::CreationFailed).to_string(),
             "creation_failed"
         );
+        assert_eq!(
+            UserCanisterStatus::from(DidUserCanisterStatus::DeletionPending).to_string(),
+            "deletion_pending"
+        );
+        assert_eq!(
+            UserCanisterStatus::from(DidUserCanisterStatus::Suspended).to_string(),
+            "suspended"
+        );
     }
 
     #[test]
@@ -161,6 +184,8 @@ mod tests {
             DidUserCanisterStatus::Active,
             DidUserCanisterStatus::CreationPending,
             DidUserCanisterStatus::CreationFailed,
+            DidUserCanisterStatus::DeletionPending,
+            DidUserCanisterStatus::Suspended,
         ];
 
         for ap_type in cases {
@@ -190,6 +215,18 @@ mod tests {
                 .encode()
                 .as_ref(),
             &[2]
+        );
+        assert_eq!(
+            UserCanisterStatus::from(DidUserCanisterStatus::DeletionPending)
+                .encode()
+                .as_ref(),
+            &[3]
+        );
+        assert_eq!(
+            UserCanisterStatus::from(DidUserCanisterStatus::Suspended)
+                .encode()
+                .as_ref(),
+            &[4]
         );
     }
 
@@ -228,9 +265,13 @@ mod tests {
         let active = UserCanisterStatus::from(DidUserCanisterStatus::Active);
         let pending = UserCanisterStatus::from(DidUserCanisterStatus::CreationPending);
         let failed = UserCanisterStatus::from(DidUserCanisterStatus::CreationFailed);
+        let deletion_pending = UserCanisterStatus::from(DidUserCanisterStatus::DeletionPending);
+        let suspended = UserCanisterStatus::from(DidUserCanisterStatus::Suspended);
 
         assert!(active < pending);
         assert!(pending < failed);
+        assert!(failed < deletion_pending);
+        assert!(deletion_pending < suspended);
     }
 
     #[test]

--- a/crates/libs/did/src/directory.rs
+++ b/crates/libs/did/src/directory.rs
@@ -90,6 +90,8 @@ pub enum UserCanisterStatus {
     CreationFailed,
     /// Deletion pending
     DeletionPending,
+    /// Suspended by moderators
+    Suspended,
 }
 
 /// `who_am_i` method data to be returned in case the caller is registered in the directory.
@@ -268,10 +270,12 @@ pub struct SearchProfileEntry {
 }
 
 /// Error types for the `search_profiles` method.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, CandidType, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, CandidType, Serialize, Deserialize)]
 pub enum SearchProfilesError {
-    /// The caller is not permitted to search profiles.
-    Unauthorized,
+    /// The search query is invalid (invalid limit or offset, or query string is too long).
+    BadArgs,
+    /// Internal error
+    Internal(String),
 }
 
 /// Response type for the `search_profiles` method.

--- a/crates/libs/did/src/directory/tests.rs
+++ b/crates/libs/did/src/directory/tests.rs
@@ -241,7 +241,7 @@ fn test_should_roundtrip_search_profiles_response_ok() {
 
 #[test]
 fn test_should_roundtrip_search_profiles_response_err() {
-    let resp = SearchProfilesResponse::Err(SearchProfilesError::Unauthorized);
+    let resp = SearchProfilesResponse::Err(SearchProfilesError::Internal("err".to_string()));
     let bytes = Encode!(&resp).unwrap();
     let decoded = Decode!(&bytes, SearchProfilesResponse).unwrap();
     assert_eq!(resp, decoded);

--- a/docs/src/architecture.md
+++ b/docs/src/architecture.md
@@ -86,8 +86,10 @@ moderation policies.
 - **Moderation** -- moderators (stored in the `moderators` table) can
   suspend users and manage the moderator list. The initial moderator is
   set at install time.
-- **Profile search** -- `search_profiles` provides full-text lookup over
-  registered handles.
+- **Profile search** -- `search_profiles` provides paginated,
+  case-insensitive substring lookup over registered handles. Only Active
+  users with a canister are returned; suspended, pending, failed, and
+  deletion-pending accounts are filtered out.
 
 ### Directory Storage
 

--- a/docs/src/directory.did
+++ b/docs/src/directory.did
@@ -78,6 +78,34 @@ type RetrySignUpError = variant {
 };
 // Response result type for the `retry_sign_up` method.
 type RetrySignUpResponse = variant { Ok; Err : RetrySignUpError };
+// A single entry in the search results for the `search_profiles` method.
+type SearchProfileEntry = record {
+  // Principal of the matched user's canister.
+  canister_id : principal;
+  // The matched user's handle.
+  handle : text;
+};
+// Request arguments for the `search_profiles` method.
+type SearchProfilesArgs = record {
+  // Free-text search string matched against handles.
+  "query" : text;
+  // Number of results to skip (for pagination).
+  offset : nat64;
+  // Maximum number of results to return.
+  limit : nat64;
+};
+// Error types for the `search_profiles` method.
+type SearchProfilesError = variant {
+  // Internal error
+  Internal : text;
+  // The search query is invalid (invalid limit or offset, or query string is too long).
+  BadArgs;
+};
+// Response type for the `search_profiles` method.
+type SearchProfilesResponse = variant {
+  Ok : vec SearchProfileEntry;
+  Err : SearchProfilesError;
+};
 // Response error types for the `sign_up` method. Registers a new user in the
 // directory, creating a User Canister and mapping the caller's principal to the
 // chosen handle.
@@ -127,6 +155,8 @@ type UserCanisterStatus = variant {
   Active;
   // Creation pending
   CreationPending;
+  // Suspended by moderators
+  Suspended;
 };
 // `who_am_i` method data to be returned in case the caller is registered in the directory.
 type WhoAmI = record {
@@ -152,6 +182,7 @@ service : (DirectoryInstallArgs) -> {
   get_user : (GetUserArgs) -> (GetUserResponse) query;
   retry_delete_profile : () -> (RetryDeleteProfileResponse);
   retry_sign_up : () -> (RetrySignUpResponse);
+  search_profiles : (SearchProfilesArgs) -> (SearchProfilesResponse) query;
   sign_up : (SignUpRequest) -> (SignUpResponse);
   user_canister : (opt principal) -> (UserCanisterResponse) query;
   whoami : () -> (WhoAmIResponse) query;

--- a/docs/src/interface/types.md
+++ b/docs/src/interface/types.md
@@ -208,20 +208,25 @@ type RetrySignUpError = variant {
 
 ### UserCanisterStatus
 
-The status of a user's canister, indicating whether it is active, pending
-creation, or failed to create. Used in the
-[WhoAmI](#whoami) response.
+The lifecycle state of a user's canister. Used in the [WhoAmI](#whoami)
+response and as the eligibility filter for [SearchProfiles](#searchprofiles).
 
 - **Active**: the canister is created and operational.
 - **CreationPending**: canister creation is in progress.
 - **CreationFailed**: canister creation failed; the user may retry via
   `retry_sign_up`.
+- **DeletionPending**: the user has requested account deletion and the
+  canister is being torn down asynchronously.
+- **Suspended**: a moderator has suspended the user; the canister exists
+  but is hidden from public discovery.
 
 ```candid
 type UserCanisterStatus = variant {
   Active;
   CreationPending;
   CreationFailed;
+  DeletionPending;
+  Suspended;
 };
 ```
 
@@ -392,23 +397,41 @@ type SuspendError = variant {
 
 ### SearchProfiles
 
-Request, response, and error types for the `search_profiles` method. Searches
-registered user profiles by a text query with pagination support.
+Request, response, and error types for the `search_profiles` query. Searches
+registered user handles by case-insensitive substring match with pagination.
 
-| Field    | Description                                      |
-| -------- | ------------------------------------------------ |
-| `query`  | Free-text search string matched against handles. |
-| `offset` | Number of results to skip (for pagination).      |
-| `limit`  | Maximum number of results to return.             |
+The `query` is sanitized before matching: a leading `@` is stripped,
+whitespace is trimmed, and the string is lowercased — the same pipeline
+applied to handles on insert. So `@Alice`, `alice`, and `  ALICE  ` all
+match the handle `alice`.
+
+Only users with `canister_status = Active` and a non-null `canister_id`
+are returned. `CreationPending`, `CreationFailed`, `DeletionPending`, and
+`Suspended` users are excluded by construction.
+
+An empty `query` returns all eligible users, paginated.
+
+| Field    | Description                                              |
+| :------- | :------------------------------------------------------- |
+| `query`  | Free-text search string matched against handles.         |
+| `offset` | Number of results to skip (for pagination).              |
+| `limit`  | Maximum results to return; must be in `1..=50`.          |
 
 Each result entry contains:
 
 | Field         | Description                                |
-| ------------- | ------------------------------------------ |
+| :------------ | :----------------------------------------- |
 | `handle`      | The matched user's handle.                 |
 | `canister_id` | Principal of the matched user's canister.  |
 
-- **Unauthorized**: the caller is not permitted to search profiles.
+Errors:
+
+- **BadArgs**: the request was rejected (`limit == 0`, `limit > 50`, or
+  the sanitized query failed handle validation). In practice the canister
+  traps on these inputs at message-inspect time; the variant is reserved
+  for parity with other endpoints.
+- **Internal**: an internal storage error occurred while running the
+  query.
 
 ```candid
 type SearchProfilesArgs = record {
@@ -428,7 +451,8 @@ type SearchProfilesResponse = variant {
 };
 
 type SearchProfilesError = variant {
-  Unauthorized;
+  BadArgs;
+  Internal : text;
 };
 ```
 

--- a/integration-tests/src/directory_client.rs
+++ b/integration-tests/src/directory_client.rs
@@ -1,7 +1,8 @@
 use candid::{Encode, Principal};
 use did::directory::{
     DeleteProfileResponse, GetUserArgs, GetUserResponse, RetryDeleteProfileResponse,
-    RetrySignUpResponse, SignUpRequest, SignUpResponse, UserCanisterResponse, WhoAmIResponse,
+    RetrySignUpResponse, SearchProfilesArgs, SearchProfilesResponse, SignUpRequest, SignUpResponse,
+    UserCanisterResponse, WhoAmIResponse,
 };
 use pocket_ic_harness::PocketIcTestEnv;
 
@@ -79,6 +80,22 @@ impl DirectoryClient<'_> {
             )
             .await
             .expect("Failed to call user_canister")
+    }
+
+    pub async fn search_profiles(
+        &self,
+        caller: Principal,
+        args: SearchProfilesArgs,
+    ) -> SearchProfilesResponse {
+        self.env
+            .query(
+                self.canister_id(),
+                caller,
+                "search_profiles",
+                Encode!(&args).expect("Failed to encode search_profiles args"),
+            )
+            .await
+            .expect("Failed to call search_profiles")
     }
 
     pub async fn whoami(&self, user: Principal) -> WhoAmIResponse {

--- a/integration-tests/tests/search_profiles.rs
+++ b/integration-tests/tests/search_profiles.rs
@@ -1,0 +1,255 @@
+//! Integration tests for the Directory `search_profiles` query (UC8).
+
+use std::collections::HashSet;
+
+use did::directory::{SearchProfilesArgs, SearchProfilesResponse};
+use integration_tests::helpers::sign_up_user;
+use integration_tests::{DirectoryClient, MasticCanisterSetup, carol, charlie};
+use pocket_ic_harness::{PocketIcTestEnv, bob};
+
+fn args(query: &str, offset: u64, limit: u64) -> SearchProfilesArgs {
+    SearchProfilesArgs {
+        query: query.to_string(),
+        offset,
+        limit,
+    }
+}
+
+#[pocket_ic_harness::test]
+async fn test_should_match_exact_handle(env: PocketIcTestEnv<MasticCanisterSetup>) {
+    let client = DirectoryClient::new(&env);
+
+    sign_up_user(&env, bob(), "bob".to_string()).await;
+    sign_up_user(&env, charlie(), "charlie".to_string()).await;
+
+    let SearchProfilesResponse::Ok(results) =
+        client.search_profiles(bob(), args("bob", 0, 50)).await
+    else {
+        panic!("expected Ok");
+    };
+    let handles: HashSet<_> = results.iter().map(|e| e.handle.as_str()).collect();
+    assert!(handles.contains("bob"));
+    assert!(!handles.contains("charlie"));
+}
+
+#[pocket_ic_harness::test]
+async fn test_should_match_prefix_substring(env: PocketIcTestEnv<MasticCanisterSetup>) {
+    let client = DirectoryClient::new(&env);
+
+    sign_up_user(&env, bob(), "alice".to_string()).await;
+    sign_up_user(&env, charlie(), "alicia".to_string()).await;
+    sign_up_user(&env, carol(), "bob_smith".to_string()).await;
+
+    let SearchProfilesResponse::Ok(results) =
+        client.search_profiles(bob(), args("ali", 0, 50)).await
+    else {
+        panic!("expected Ok");
+    };
+    let handles: HashSet<_> = results.iter().map(|e| e.handle.clone()).collect();
+    assert_eq!(handles.len(), 2);
+    assert!(handles.contains("alice"));
+    assert!(handles.contains("alicia"));
+}
+
+#[pocket_ic_harness::test]
+async fn test_should_match_middle_substring(env: PocketIcTestEnv<MasticCanisterSetup>) {
+    let client = DirectoryClient::new(&env);
+
+    sign_up_user(&env, bob(), "alice".to_string()).await;
+    sign_up_user(&env, charlie(), "malice".to_string()).await;
+
+    let SearchProfilesResponse::Ok(results) =
+        client.search_profiles(bob(), args("lic", 0, 50)).await
+    else {
+        panic!("expected Ok");
+    };
+    let handles: HashSet<_> = results.iter().map(|e| e.handle.clone()).collect();
+    assert!(handles.contains("alice"));
+    assert!(handles.contains("malice"));
+}
+
+#[pocket_ic_harness::test]
+async fn test_should_match_case_insensitively(env: PocketIcTestEnv<MasticCanisterSetup>) {
+    let client = DirectoryClient::new(&env);
+
+    sign_up_user(&env, bob(), "alice".to_string()).await;
+
+    let SearchProfilesResponse::Ok(results) =
+        client.search_profiles(bob(), args("ALICE", 0, 50)).await
+    else {
+        panic!("expected Ok");
+    };
+    let handles: HashSet<_> = results.iter().map(|e| e.handle.clone()).collect();
+    assert!(handles.contains("alice"));
+}
+
+#[pocket_ic_harness::test]
+async fn test_should_sanitize_at_prefix(env: PocketIcTestEnv<MasticCanisterSetup>) {
+    let client = DirectoryClient::new(&env);
+
+    sign_up_user(&env, bob(), "alice".to_string()).await;
+
+    let SearchProfilesResponse::Ok(results) =
+        client.search_profiles(bob(), args("@Alice", 0, 50)).await
+    else {
+        panic!("expected Ok");
+    };
+    let handles: HashSet<_> = results.iter().map(|e| e.handle.clone()).collect();
+    assert!(handles.contains("alice"));
+}
+
+#[pocket_ic_harness::test]
+async fn test_empty_query_returns_all_active(env: PocketIcTestEnv<MasticCanisterSetup>) {
+    let client = DirectoryClient::new(&env);
+
+    sign_up_user(&env, bob(), "bob".to_string()).await;
+    sign_up_user(&env, charlie(), "charlie".to_string()).await;
+    sign_up_user(&env, carol(), "carol".to_string()).await;
+
+    let SearchProfilesResponse::Ok(results) = client.search_profiles(bob(), args("", 0, 50)).await
+    else {
+        panic!("expected Ok");
+    };
+    let handles: HashSet<_> = results.iter().map(|e| e.handle.clone()).collect();
+    assert!(handles.contains("bob"));
+    assert!(handles.contains("charlie"));
+    assert!(handles.contains("carol"));
+    assert_eq!(handles.len(), 3);
+}
+
+#[pocket_ic_harness::test]
+async fn test_pagination(env: PocketIcTestEnv<MasticCanisterSetup>) {
+    let client = DirectoryClient::new(&env);
+
+    sign_up_user(&env, bob(), "bob".to_string()).await;
+    sign_up_user(&env, charlie(), "charlie".to_string()).await;
+    sign_up_user(&env, carol(), "carol".to_string()).await;
+
+    let SearchProfilesResponse::Ok(page1) = client.search_profiles(bob(), args("", 0, 2)).await
+    else {
+        panic!("expected Ok");
+    };
+    assert_eq!(page1.len(), 2);
+
+    let SearchProfilesResponse::Ok(page2) = client.search_profiles(bob(), args("", 2, 2)).await
+    else {
+        panic!("expected Ok");
+    };
+    assert_eq!(page2.len(), 1);
+
+    let page1_handles: HashSet<_> = page1.iter().map(|e| e.handle.clone()).collect();
+    let page2_handles: HashSet<_> = page2.iter().map(|e| e.handle.clone()).collect();
+    assert!(page1_handles.is_disjoint(&page2_handles));
+}
+
+#[pocket_ic_harness::test]
+async fn test_no_match_returns_empty(env: PocketIcTestEnv<MasticCanisterSetup>) {
+    let client = DirectoryClient::new(&env);
+
+    sign_up_user(&env, bob(), "bob".to_string()).await;
+
+    let SearchProfilesResponse::Ok(results) =
+        client.search_profiles(bob(), args("zorblax", 0, 50)).await
+    else {
+        panic!("expected Ok");
+    };
+    assert!(results.is_empty());
+}
+
+#[pocket_ic_harness::test]
+async fn test_should_exclude_deletion_pending(env: PocketIcTestEnv<MasticCanisterSetup>) {
+    use std::time::Duration;
+
+    use did::directory::{DeleteProfileResponse, WhoAmIError, WhoAmIResponse};
+
+    let client = DirectoryClient::new(&env);
+
+    sign_up_user(&env, bob(), "bob".to_string()).await;
+    sign_up_user(&env, charlie(), "charlie".to_string()).await;
+
+    // Trigger profile deletion for charlie. The state machine sets
+    // canister_status = DeletionPending, then asynchronously stops/destroys
+    // the canister and removes the row.
+    assert_eq!(
+        client.delete_profile(charlie()).await,
+        DeleteProfileResponse::Ok
+    );
+
+    // Wait until charlie is fully gone.
+    let started_at = std::time::Instant::now();
+    loop {
+        if started_at.elapsed() > Duration::from_secs(60) {
+            panic!("timeout waiting for charlie deletion");
+        }
+        if let WhoAmIResponse::Err(WhoAmIError::NotRegistered) = client.whoami(charlie()).await {
+            break;
+        }
+        tokio::time::sleep(Duration::from_secs(1)).await;
+        env.pic.advance_time(Duration::from_secs(1)).await;
+        env.pic.tick().await;
+    }
+
+    // After deletion: search must not return charlie at all.
+    let SearchProfilesResponse::Ok(results) = client.search_profiles(bob(), args("", 0, 50)).await
+    else {
+        panic!("expected Ok");
+    };
+    let handles: HashSet<_> = results.iter().map(|e| e.handle.clone()).collect();
+    assert!(handles.contains("bob"));
+    assert!(!handles.contains("charlie"));
+}
+
+/// Calls `search_profiles` directly through the env so a trap surfaces as an
+/// error rather than a panic in the [`DirectoryClient`] wrapper.
+async fn raw_search(
+    env: &PocketIcTestEnv<MasticCanisterSetup>,
+    args: SearchProfilesArgs,
+) -> Result<SearchProfilesResponse, String> {
+    use candid::Encode;
+    use integration_tests::MasticCanister;
+
+    let canister = env.canister_id(&MasticCanister::Directory);
+    env.query(
+        canister,
+        bob(),
+        "search_profiles",
+        Encode!(&args).expect("encode"),
+    )
+    .await
+    .map_err(|e| e.to_string())
+}
+
+#[pocket_ic_harness::test]
+async fn test_should_reject_zero_limit(env: PocketIcTestEnv<MasticCanisterSetup>) {
+    sign_up_user(&env, bob(), "bob".to_string()).await;
+
+    let result = raw_search(&env, args("bob", 0, 0)).await;
+    assert!(result.is_err(), "limit=0 must trap");
+}
+
+#[pocket_ic_harness::test]
+async fn test_should_reject_oversize_limit(env: PocketIcTestEnv<MasticCanisterSetup>) {
+    sign_up_user(&env, bob(), "bob".to_string()).await;
+
+    let result = raw_search(&env, args("bob", 0, 51)).await;
+    assert!(result.is_err(), "limit > 50 must trap");
+}
+
+#[pocket_ic_harness::test]
+async fn test_anonymous_caller_can_search(env: PocketIcTestEnv<MasticCanisterSetup>) {
+    use candid::Principal;
+
+    let client = DirectoryClient::new(&env);
+
+    sign_up_user(&env, bob(), "bob".to_string()).await;
+
+    // Search is a public query — anonymous calls must succeed.
+    let SearchProfilesResponse::Ok(results) = client
+        .search_profiles(Principal::anonymous(), args("bob", 0, 50))
+        .await
+    else {
+        panic!("expected Ok");
+    };
+    let handles: HashSet<_> = results.iter().map(|e| e.handle.clone()).collect();
+    assert!(handles.contains("bob"));
+}


### PR DESCRIPTION
## Summary

Implements the `search_profiles` Directory query for user discovery (WI-1.5, closes #16).

- Substring case-insensitive match over `users.handle`, paginated (limit capped at 50, `0` rejected)
- Filters to `canister_status = Active` AND `canister_id IS NOT NULL` — `CreationPending`, `CreationFailed`, `DeletionPending`, and the new `Suspended` status are excluded
- Empty queries return all eligible users, paginated
- Adds `UserCanisterStatus::Suspended` (encode/decode/order/display) for cross-ref with WI-1.9
- Replaces stale `SearchProfilesError::Unauthorized` with `BadArgs` + `Internal(String)`
- Tightens CLAUDE.md guidance to always update `docs/src/SUMMARY.md` when docs pages are added/removed

## Test plan

- [x] `just check_code` — clippy + fmt clean
- [x] `just build_all` — WASM build succeeds
- [x] Unit tests (162 in directory crate, +23 new) cover: exact/prefix/middle substring, empty query, pagination, no-match, exclusion of every non-Active status, sanitization (`@`-prefix, case)
- [x] `cargo test --test search_profiles` (12 pocket-ic tests) — full Candid wire coverage including anonymous caller and trap on `limit=0` / `limit>50`
- [x] Docs (`docs/src/interface/types.md`, `docs/src/architecture.md`) updated to reflect filter semantics and error variants