### PR TITLE
feat(user): implement like_status flow (UC10)

### DIFF
--- a/crates/canisters/user/src/api.rs
+++ b/crates/canisters/user/src/api.rs
@@ -2,15 +2,7 @@
 
 pub mod inspect;
 
-use did::user::{
-    AcceptFollowArgs, AcceptFollowResponse, EmitDeleteProfileActivityResponse, FollowUserArgs,
-    FollowUserResponse, GetFollowRequestsArgs, GetFollowRequestsResponse, GetFollowersArgs,
-    GetFollowersResponse, GetFollowingArgs, GetFollowingResponse, GetProfileResponse,
-    GetStatusesArgs, GetStatusesResponse, PublishStatusArgs, PublishStatusResponse, ReadFeedArgs,
-    ReadFeedResponse, ReceiveActivityArgs, ReceiveActivityResponse, RejectFollowArgs,
-    RejectFollowResponse, UnfollowUserArgs, UnfollowUserResponse, UpdateProfileArgs,
-    UpdateProfileResponse, UserInstallArgs,
-};
+use did::user::*;
 use ic_dbms_canister::prelude::DBMS_CONTEXT;
 
 use crate::schema::Schema;
@@ -95,6 +87,17 @@ pub async fn accept_follow(args: AcceptFollowArgs) -> AcceptFollowResponse {
     crate::domain::follower::accept_follow(args).await
 }
 
+/// Emit a `Delete(Person)` activity to followers on profile deletion.
+///
+/// This function can only be called by the directory canister.
+pub async fn emit_delete_profile_activity() -> EmitDeleteProfileActivityResponse {
+    if !inspect::is_directory_canister(ic_utils::caller()) {
+        ic_utils::trap!("Only the directory canister can emit delete profile activity");
+    }
+
+    crate::domain::profile::emit_delete_profile_activity().await
+}
+
 /// Follows another user.
 ///
 /// This function can only be called by the owner of the canister.
@@ -125,6 +128,11 @@ pub fn get_following(args: GetFollowingArgs) -> GetFollowingResponse {
     crate::domain::following::get_following(args)
 }
 
+/// Likes a status.
+pub fn get_liked(args: GetLikedArgs) -> GetLikedResponse {
+    crate::domain::liked::get_liked(args)
+}
+
 /// Gets the user profile.
 pub fn get_profile() -> GetProfileResponse {
     crate::domain::profile::get_profile()
@@ -135,6 +143,16 @@ pub async fn get_statuses(args: GetStatusesArgs) -> GetStatusesResponse {
     let caller = ic_utils::caller();
 
     crate::domain::status::get_statuses(args, caller).await
+}
+
+/// Likes a status.
+pub async fn like_status(args: LikeStatusArgs) -> LikeStatusResponse {
+    let caller = ic_utils::caller();
+    if !inspect::is_owner(caller) {
+        ic_utils::trap!("Only the owner can like statuses");
+    }
+
+    crate::domain::liked::like_status(args).await
 }
 
 /// Publishes a new status.
@@ -177,17 +195,6 @@ pub async fn reject_follow(args: RejectFollowArgs) -> RejectFollowResponse {
     crate::domain::follower::reject_follow(args).await
 }
 
-/// Emit a `Delete(Person)` activity to followers on profile deletion.
-///
-/// This function can only be called by the directory canister.
-pub async fn emit_delete_profile_activity() -> EmitDeleteProfileActivityResponse {
-    if !inspect::is_directory_canister(ic_utils::caller()) {
-        ic_utils::trap!("Only the directory canister can emit delete profile activity");
-    }
-
-    crate::domain::profile::emit_delete_profile_activity().await
-}
-
 /// Unfollows a user.
 pub async fn unfollow_user(args: UnfollowUserArgs) -> UnfollowUserResponse {
     if !inspect::is_owner(ic_utils::caller()) {
@@ -195,6 +202,16 @@ pub async fn unfollow_user(args: UnfollowUserArgs) -> UnfollowUserResponse {
     }
 
     crate::domain::following::unfollow_user(args).await
+}
+
+/// Unlikes a status.
+pub async fn unlike_status(args: UnlikeStatusArgs) -> UnlikeStatusResponse {
+    let caller = ic_utils::caller();
+    if !inspect::is_owner(caller) {
+        ic_utils::trap!("Only the owner can unlike statuses");
+    }
+
+    crate::domain::liked::unlike_status(args).await
 }
 
 /// Updates the user's profile.

--- a/crates/canisters/user/src/domain.rs
+++ b/crates/canisters/user/src/domain.rs
@@ -10,6 +10,7 @@ pub mod feed;
 pub mod follow_request;
 pub mod follower;
 pub mod following;
+pub mod liked;
 pub mod profile;
 pub mod snowflake;
 pub mod status;

--- a/crates/canisters/user/src/domain/activity/handle_incoming.rs
+++ b/crates/canisters/user/src/domain/activity/handle_incoming.rs
@@ -9,6 +9,7 @@ use crate::domain::follow_request::FollowRequestRepository;
 use crate::domain::follower::FollowerRepository;
 use crate::domain::following::FollowingRepository;
 use crate::domain::snowflake::Snowflake;
+use crate::domain::status::StatusRepository;
 use crate::error::CanisterError;
 use crate::schema::{
     ActivityType as DbActivityType, FeedEntry, FeedEntryInsertRequest, FeedSource, FollowStatus,
@@ -32,6 +33,7 @@ pub fn handle_incoming(
         ActivityType::Follow => handle_follow(&activity),
         ActivityType::Accept => handle_accept(&activity),
         ActivityType::Reject => handle_reject(&activity),
+        ActivityType::Like => handle_like(&activity),
         ActivityType::Undo => handle_undo(&activity),
         other => {
             // Unknown / not-yet-implemented activity types are silently accepted.
@@ -192,12 +194,15 @@ fn handle_reject(activity: &Activity) -> Result<(), ReceiveActivityError> {
         .map(|_| ())
 }
 
-/// Handle an incoming `Undo(Follow)` activity.
+/// Handle an incoming `Undo(Follow)` or `Undo(Like)` activity.
 ///
-/// Removes the sender from the `followers` table (accepted inbound follow)
-/// and from the `follow_requests` table (pending inbound follow). Idempotent:
-/// missing entries do not produce an error. `Undo` of any inner activity
-/// other than `Follow` is silently ignored (out of scope here).
+/// - `Undo(Follow)`: removes the sender from the `followers` table
+///   (accepted inbound follow) and from the `follow_requests` table
+///   (pending inbound follow). Idempotent: missing entries do not produce
+///   an error.
+/// - `Undo(Like)`: decrements the cached `like_count` of the targeted local
+///   status when the URI points at one of our statuses; ignored otherwise.
+/// - Any other inner activity is silently accepted but not acted on.
 fn handle_undo(activity: &Activity) -> Result<(), ReceiveActivityError> {
     let sender_uri = activity
         .actor
@@ -209,26 +214,119 @@ fn handle_undo(activity: &Activity) -> Result<(), ReceiveActivityError> {
         return Err(ReceiveActivityError::ProcessingFailed);
     };
 
-    if inner.base.kind != ActivityType::Follow {
-        ic_utils::log!(
-            "handle_incoming: ignoring Undo of unsupported inner type: {:?}",
-            inner.base.kind
-        );
+    match inner.base.kind {
+        ActivityType::Follow => {
+            ic_utils::log!("handle_incoming: Undo(Follow) from {sender_uri}");
+
+            FollowerRepository::delete_by_actor_uri(sender_uri).map_err(|e| {
+                ic_utils::log!("handle_incoming: failed to delete follower: {e}");
+                ReceiveActivityError::Internal(e.to_string())
+            })?;
+            FollowRequestRepository::delete_by_actor_uri(sender_uri).map_err(|e| {
+                ic_utils::log!("handle_incoming: failed to delete follow request: {e}");
+                ReceiveActivityError::Internal(e.to_string())
+            })?;
+            Ok(())
+        }
+        ActivityType::Like => handle_undo_like(inner, sender_uri),
+        other => {
+            ic_utils::log!("handle_incoming: ignoring Undo of unsupported inner type: {other:?}");
+            Ok(())
+        }
+    }
+}
+
+/// Extract the status URI targeted by a `Like` activity, accepting either
+/// `object` as a bare id string or a wrapped object whose `id` is the URI.
+fn extract_like_target_uri(activity: &Activity) -> Option<String> {
+    match activity.object.as_ref()? {
+        ActivityObject::Id(uri) => Some(uri.clone()),
+        ActivityObject::Object(obj) => obj.id.clone(),
+        ActivityObject::Activity(_) | ActivityObject::Actor(_) => None,
+    }
+}
+
+/// Handle an incoming `Like` activity.
+///
+/// Increments the cached `like_count` on the targeted local status. The
+/// status URI is parsed against this canister's `public_url`; URIs that
+/// point at a different host or a different local handle are ignored.
+/// We cannot authoritatively prove that a remote sender's `Like` actually
+/// references a status we own beyond URI matching, so the count is
+/// best-effort.
+///
+/// Idempotency note: ActivityPub does not require unique delivery, so the
+/// same `Like` may be received multiple times. We have no `(actor, status)`
+/// table to deduplicate against — the cached count is a hint, not a
+/// reconciled total.
+fn handle_like(activity: &Activity) -> Result<(), ReceiveActivityError> {
+    let actor_uri = activity
+        .actor
+        .as_deref()
+        .ok_or(ReceiveActivityError::ProcessingFailed)?;
+    let Some(status_uri) = extract_like_target_uri(activity) else {
+        ic_utils::log!("handle_incoming: Like missing object URI");
+        return Err(ReceiveActivityError::ProcessingFailed);
+    };
+    ic_utils::log!("handle_incoming: Like from {actor_uri} on {status_uri}");
+
+    let Some((_handle, id)) = parse_local_status(&status_uri)? else {
+        ic_utils::log!("handle_incoming: Like target {status_uri} is not a local status");
         return Ok(());
+    };
+
+    if !StatusRepository::increment_like_count(id).map_err(|e| {
+        ic_utils::log!("handle_incoming: failed to increment like_count: {e}");
+        ReceiveActivityError::Internal(e.to_string())
+    })? {
+        ic_utils::log!("handle_incoming: Like target status {id} not found, ignoring");
+    }
+    Ok(())
+}
+
+/// Handle an `Undo(Like)` body: decrement the cached `like_count` if the
+/// inner activity refers to a local status. Ignored otherwise.
+fn handle_undo_like(inner: &Activity, sender_uri: &str) -> Result<(), ReceiveActivityError> {
+    let Some(status_uri) = extract_like_target_uri(inner) else {
+        ic_utils::log!("handle_incoming: Undo(Like) missing object URI");
+        return Err(ReceiveActivityError::ProcessingFailed);
+    };
+    ic_utils::log!("handle_incoming: Undo(Like) from {sender_uri} on {status_uri}");
+
+    let Some((_handle, id)) = parse_local_status(&status_uri)? else {
+        ic_utils::log!("handle_incoming: Undo(Like) target {status_uri} is not local");
+        return Ok(());
+    };
+
+    if !StatusRepository::decrement_like_count(id).map_err(|e| {
+        ic_utils::log!("handle_incoming: failed to decrement like_count: {e}");
+        ReceiveActivityError::Internal(e.to_string())
+    })? {
+        ic_utils::log!("handle_incoming: Undo(Like) target status {id} not found, ignoring");
+    }
+    Ok(())
+}
+
+/// Confirm the status URI is hosted on this canister's instance and points
+/// at this user's handle, returning `(handle, id)` when so.
+fn parse_local_status(status_uri: &str) -> Result<Option<(String, u64)>, ReceiveActivityError> {
+    let parsed = crate::domain::urls::parse_local_status_uri(status_uri).map_err(|e| {
+        ic_utils::log!("handle_incoming: failed to parse status URI: {e}");
+        ReceiveActivityError::Internal(e.to_string())
+    })?;
+    let Some((handle, id)) = parsed else {
+        return Ok(None);
+    };
+
+    let own = crate::domain::profile::ProfileRepository::get_profile().map_err(|e| {
+        ic_utils::log!("handle_incoming: failed to load own profile: {e}");
+        ReceiveActivityError::Internal(e.to_string())
+    })?;
+    if handle != own.handle.0 {
+        return Ok(None);
     }
 
-    ic_utils::log!("handle_incoming: Undo(Follow) from {sender_uri}");
-
-    FollowerRepository::delete_by_actor_uri(sender_uri).map_err(|e| {
-        ic_utils::log!("handle_incoming: failed to delete follower: {e}");
-        ReceiveActivityError::Internal(e.to_string())
-    })?;
-    FollowRequestRepository::delete_by_actor_uri(sender_uri).map_err(|e| {
-        ic_utils::log!("handle_incoming: failed to delete follow request: {e}");
-        ReceiveActivityError::Internal(e.to_string())
-    })?;
-
-    Ok(())
+    Ok(Some((handle, id)))
 }
 
 #[cfg(test)]
@@ -242,6 +340,7 @@ mod tests {
     use crate::domain::follow_request::FollowRequestRepository;
     use crate::domain::follower::FollowerRepository;
     use crate::domain::following::FollowingRepository;
+    use crate::domain::status::StatusRepository;
     use crate::schema::FollowStatus;
     use crate::test_utils::setup;
 
@@ -618,6 +717,7 @@ mod tests {
     fn test_should_ignore_undo_of_unsupported_inner_type() {
         setup();
 
+        // Undo(Block) is not implemented; expected to be silently accepted.
         let activity = Activity {
             base: BaseObject {
                 kind: ActivityType::Undo,
@@ -626,12 +726,12 @@ mod tests {
             actor: Some("https://mastic.social/users/alice".to_string()),
             object: Some(ActivityObject::Activity(Box::new(Activity {
                 base: BaseObject {
-                    kind: ActivityType::Like,
+                    kind: ActivityType::Block,
                     ..Default::default()
                 },
                 actor: Some("https://mastic.social/users/alice".to_string()),
                 object: Some(ActivityObject::Id(
-                    "https://mastic.social/statuses/1".to_string(),
+                    "https://mastic.social/users/rey_canisteryo".to_string(),
                 )),
                 target: None,
                 result: None,
@@ -650,5 +750,206 @@ mod tests {
         });
 
         assert_eq!(response, ReceiveActivityResponse::Ok);
+    }
+
+    fn make_like_json(actor_uri: &str, status_uri: &str) -> String {
+        let activity = Activity {
+            base: BaseObject {
+                kind: ActivityType::Like,
+                ..Default::default()
+            },
+            actor: Some(actor_uri.to_string()),
+            object: Some(ActivityObject::Id(status_uri.to_string())),
+            target: None,
+            result: None,
+            origin: None,
+            instrument: None,
+        };
+        serde_json::to_string(&activity).unwrap()
+    }
+
+    fn make_undo_like_json(actor_uri: &str, status_uri: &str) -> String {
+        let activity = Activity {
+            base: BaseObject {
+                kind: ActivityType::Undo,
+                ..Default::default()
+            },
+            actor: Some(actor_uri.to_string()),
+            object: Some(ActivityObject::Activity(Box::new(Activity {
+                base: BaseObject {
+                    kind: ActivityType::Like,
+                    ..Default::default()
+                },
+                actor: Some(actor_uri.to_string()),
+                object: Some(ActivityObject::Id(status_uri.to_string())),
+                target: None,
+                result: None,
+                origin: None,
+                instrument: None,
+            }))),
+            target: None,
+            result: None,
+            origin: None,
+            instrument: None,
+        };
+        serde_json::to_string(&activity).unwrap()
+    }
+
+    #[test]
+    fn test_should_increment_like_count_on_local_like() {
+        setup();
+        crate::test_utils::insert_status(42, "Hello", did::common::Visibility::Public, 1_000_000);
+
+        let json = make_like_json(
+            "https://mastic.social/users/alice",
+            "https://mastic.social/users/rey_canisteryo/statuses/42",
+        );
+        let response = handle_incoming(ReceiveActivityArgs {
+            activity_json: json,
+        });
+        assert_eq!(response, ReceiveActivityResponse::Ok);
+
+        let status = StatusRepository::find_by_id(42)
+            .expect("should query")
+            .expect("should find");
+        assert_eq!(status.like_count.0, 1);
+    }
+
+    #[test]
+    fn test_should_decrement_like_count_on_undo_like() {
+        setup();
+        crate::test_utils::insert_status(42, "Hello", did::common::Visibility::Public, 1_000_000);
+
+        // Increment first via Like, then decrement via Undo(Like).
+        let like_json = make_like_json(
+            "https://mastic.social/users/alice",
+            "https://mastic.social/users/rey_canisteryo/statuses/42",
+        );
+        assert_eq!(
+            handle_incoming(ReceiveActivityArgs {
+                activity_json: like_json,
+            }),
+            ReceiveActivityResponse::Ok
+        );
+
+        let undo_json = make_undo_like_json(
+            "https://mastic.social/users/alice",
+            "https://mastic.social/users/rey_canisteryo/statuses/42",
+        );
+        assert_eq!(
+            handle_incoming(ReceiveActivityArgs {
+                activity_json: undo_json,
+            }),
+            ReceiveActivityResponse::Ok
+        );
+
+        let status = StatusRepository::find_by_id(42)
+            .expect("should query")
+            .expect("should find");
+        assert_eq!(status.like_count.0, 0);
+    }
+
+    #[test]
+    fn test_should_ignore_like_targeting_remote_status() {
+        setup();
+
+        let json = make_like_json(
+            "https://mastic.social/users/alice",
+            "https://other.example/users/bob/statuses/99",
+        );
+        let response = handle_incoming(ReceiveActivityArgs {
+            activity_json: json,
+        });
+        // Acknowledged but no local effect since URI is not on this instance.
+        assert_eq!(response, ReceiveActivityResponse::Ok);
+    }
+
+    #[test]
+    fn test_should_ignore_like_targeting_other_local_handle() {
+        setup();
+        crate::test_utils::insert_status(42, "Hello", did::common::Visibility::Public, 1_000_000);
+
+        let json = make_like_json(
+            "https://mastic.social/users/alice",
+            "https://mastic.social/users/someone_else/statuses/42",
+        );
+        assert_eq!(
+            handle_incoming(ReceiveActivityArgs {
+                activity_json: json,
+            }),
+            ReceiveActivityResponse::Ok
+        );
+
+        let status = StatusRepository::find_by_id(42)
+            .expect("should query")
+            .expect("should find");
+        assert_eq!(
+            status.like_count.0, 0,
+            "like_count must not change when handle does not match"
+        );
+    }
+
+    #[test]
+    fn test_should_succeed_like_when_target_status_missing() {
+        setup();
+
+        let json = make_like_json(
+            "https://mastic.social/users/alice",
+            "https://mastic.social/users/rey_canisteryo/statuses/9999",
+        );
+        assert_eq!(
+            handle_incoming(ReceiveActivityArgs {
+                activity_json: json,
+            }),
+            ReceiveActivityResponse::Ok
+        );
+    }
+
+    #[test]
+    fn test_should_saturate_undo_like_at_zero() {
+        setup();
+        crate::test_utils::insert_status(42, "Hello", did::common::Visibility::Public, 1_000_000);
+
+        let json = make_undo_like_json(
+            "https://mastic.social/users/alice",
+            "https://mastic.social/users/rey_canisteryo/statuses/42",
+        );
+        assert_eq!(
+            handle_incoming(ReceiveActivityArgs {
+                activity_json: json,
+            }),
+            ReceiveActivityResponse::Ok
+        );
+
+        let status = StatusRepository::find_by_id(42)
+            .expect("should query")
+            .expect("should find");
+        assert_eq!(status.like_count.0, 0);
+    }
+
+    #[test]
+    fn test_should_fail_like_with_missing_object() {
+        setup();
+
+        let activity = Activity {
+            base: BaseObject {
+                kind: ActivityType::Like,
+                ..Default::default()
+            },
+            actor: Some("https://mastic.social/users/alice".to_string()),
+            object: None,
+            target: None,
+            result: None,
+            origin: None,
+            instrument: None,
+        };
+        let json = serde_json::to_string(&activity).unwrap();
+
+        assert_eq!(
+            handle_incoming(ReceiveActivityArgs {
+                activity_json: json,
+            }),
+            ReceiveActivityResponse::Err(ReceiveActivityError::ProcessingFailed)
+        );
     }
 }

--- a/crates/canisters/user/src/domain/feed/read_feed.rs
+++ b/crates/canisters/user/src/domain/feed/read_feed.rs
@@ -103,6 +103,9 @@ fn hydrate_outbox(db: &impl Database, id: u64, owner_actor_uri: &str) -> Option<
     let db_vis: DbVisibility = find_value(row, "visibility")?.as_custom_type()?;
     let created_at = find_value(row, "created_at")?.as_uint64()?.0;
 
+    let like_count = find_value(row, "like_count")?.as_uint64()?.0;
+    let boost_count = find_value(row, "boost_count")?.as_uint64()?.0;
+
     Some(FeedItem {
         status: Status {
             id,
@@ -110,6 +113,8 @@ fn hydrate_outbox(db: &impl Database, id: u64, owner_actor_uri: &str) -> Option<
             author: owner_actor_uri.to_string(),
             created_at,
             visibility: db_vis.into(),
+            like_count,
+            boost_count,
         },
         boosted_by: None, // FIXME: eventually support boosts in M1
     })
@@ -149,6 +154,8 @@ fn hydrate_inbox(db: &impl Database, id: u64, owner_actor_uri: &str) -> Option<F
             author: author_uri,
             created_at,
             visibility,
+            like_count: 0,
+            boost_count: 0,
         },
         boosted_by: None, // FIXME: eventually support boosts in M1
     })

--- a/crates/canisters/user/src/domain/liked.rs
+++ b/crates/canisters/user/src/domain/liked.rs
@@ -1,0 +1,10 @@
+//! Liked status domain.
+
+mod get_liked;
+mod like;
+mod repository;
+mod unlike;
+
+pub use get_liked::get_liked;
+pub use like::like_status;
+pub use unlike::unlike_status;

--- a/crates/canisters/user/src/domain/liked/get_liked.rs
+++ b/crates/canisters/user/src/domain/liked/get_liked.rs
@@ -1,0 +1,90 @@
+//! Domain logic for the `get_liked` query.
+//!
+//! Returns the paginated list of status URIs the canister owner has liked,
+//! ordered as stored in the `liked` table. The response only contains URIs
+//! — the canister has no authoritative copy of remote statuses, and no
+//! cheap way to verify a URI still resolves on the author's instance.
+//! Clients are expected to fetch each status individually if they need to
+//! render content.
+
+use did::user::{GetLikedArgs, GetLikedError, GetLikedResponse};
+
+use crate::domain::liked::repository::LikedRepository;
+
+/// Execute the get-liked flow.
+///
+/// `offset` and `limit` are forwarded as a simple slice over the stored
+/// rows; no `LimitExceeded` guard is enforced here because the row payload
+/// (a single URI) is small and bounded by the schema validators.
+pub fn get_liked(GetLikedArgs { offset, limit }: GetLikedArgs) -> GetLikedResponse {
+    ic_utils::log!("Getting liked statuses with offset {offset} and limit {limit}");
+
+    match LikedRepository::get_liked(offset as usize, limit as usize) {
+        Ok(liked) => GetLikedResponse::Ok(liked),
+        Err(err) => {
+            ic_utils::log!("Failed to get liked statuses: {err}");
+            GetLikedResponse::Err(GetLikedError::Internal(err.to_string()))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    use did::user::{GetLikedArgs, GetLikedResponse};
+
+    use super::get_liked;
+    use crate::domain::liked::repository::LikedRepository;
+    use crate::test_utils::setup;
+
+    #[test]
+    fn test_should_return_empty_when_no_likes() {
+        setup();
+
+        let response = get_liked(GetLikedArgs {
+            offset: 0,
+            limit: 10,
+        });
+        let GetLikedResponse::Ok(liked) = response else {
+            panic!("expected Ok, got {response:?}");
+        };
+        assert!(liked.is_empty());
+    }
+
+    #[test]
+    fn test_should_return_liked_status_uris() {
+        setup();
+        LikedRepository::like_status("https://mastic.social/users/alice/statuses/1")
+            .expect("should insert");
+        LikedRepository::like_status("https://mastic.social/users/bob/statuses/2")
+            .expect("should insert");
+
+        let response = get_liked(GetLikedArgs {
+            offset: 0,
+            limit: 10,
+        });
+        let GetLikedResponse::Ok(liked) = response else {
+            panic!("expected Ok, got {response:?}");
+        };
+        assert_eq!(liked.len(), 2);
+        assert!(liked.contains(&"https://mastic.social/users/alice/statuses/1".to_string()));
+        assert!(liked.contains(&"https://mastic.social/users/bob/statuses/2".to_string()));
+    }
+
+    #[test]
+    fn test_should_paginate_liked_results() {
+        setup();
+        for i in 0..5 {
+            LikedRepository::like_status(&format!("https://mastic.social/users/a/statuses/{i}"))
+                .expect("should insert");
+        }
+
+        let GetLikedResponse::Ok(page) = get_liked(GetLikedArgs {
+            offset: 1,
+            limit: 2,
+        }) else {
+            panic!("expected Ok");
+        };
+        assert_eq!(page.len(), 2);
+    }
+}

--- a/crates/canisters/user/src/domain/liked/like.rs
+++ b/crates/canisters/user/src/domain/liked/like.rs
@@ -1,0 +1,173 @@
+//! Domain logic for the `like_status` flow.
+//!
+//! The flow consists of:
+//! 1. Check the `liked` table to ensure the like is idempotent: if the
+//!    caller already liked the status the call returns `Ok` without
+//!    inserting a duplicate row or re-emitting an activity.
+//! 2. Insert a new entry in the `liked` table.
+//! 3. Build a `Like` activity targeting the status URI and dispatch it
+//!    via the Federation Canister to the status author's inbox.
+//!
+//! The status URI is treated as opaque: the author's inbox is derived
+//! from the URI by stripping the trailing `/statuses/{id}` segment and
+//! appending `/inbox`. The author's User Canister is responsible for
+//! validating that the URI points at a status it owns and incrementing
+//! the cached `like_count` (see
+//! [`crate::domain::activity::handle_incoming`]).
+
+use activitypub::activity::{Activity, ActivityObject, ActivityType};
+use activitypub::context::ACTIVITY_STREAMS_CONTEXT;
+use activitypub::object::{BaseObject, OneOrMany};
+use did::federation::{SendActivityArgs, SendActivityArgsObject};
+use did::user::{LikeStatusArgs, LikeStatusError, LikeStatusResponse};
+
+use crate::domain::liked::repository::LikedRepository;
+use crate::domain::profile::ProfileRepository;
+use crate::error::CanisterResult;
+
+/// Execute the like-status flow.
+pub async fn like_status(LikeStatusArgs { status_url }: LikeStatusArgs) -> LikeStatusResponse {
+    match like_status_inner(status_url).await {
+        Ok(()) => LikeStatusResponse::Ok,
+        Err(err) => {
+            ic_utils::log!("Failed to like status: {err}");
+            LikeStatusResponse::Err(LikeStatusError::Internal(err.to_string()))
+        }
+    }
+}
+
+async fn like_status_inner(status_uri: String) -> CanisterResult<()> {
+    ic_utils::log!("Liking status with URI: {status_uri}");
+
+    // Idempotent: if already liked, do not duplicate or re-emit.
+    if LikedRepository::is_liked(&status_uri)? {
+        ic_utils::log!("Status already liked: {status_uri}");
+        return Ok(());
+    }
+
+    // Insert the like into the database first; if federation dispatch
+    // later fails, the user can re-trigger and the row already exists,
+    // making the second call a no-op.
+    LikedRepository::like_status(&status_uri)?;
+
+    // Derive the author's actor URI and inbox from the status URI.
+    let Some(author_actor_uri) = crate::domain::urls::actor_uri_from_status_uri(&status_uri) else {
+        ic_utils::log!("like_status: could not derive author actor URI from {status_uri}");
+        return Ok(());
+    };
+    let target_inbox = crate::domain::urls::inbox_url_from_actor_uri(&author_actor_uri);
+
+    // Build the Like activity actored by the caller.
+    let own_profile = ProfileRepository::get_profile()?;
+    let own_actor_uri = crate::domain::urls::actor_uri(&own_profile.handle.0)?;
+    let activity = make_like_activity(&own_actor_uri, &author_actor_uri, &status_uri);
+
+    let args = SendActivityArgs::One(SendActivityArgsObject {
+        activity_json: serde_json::to_string(&activity)
+            .expect("Activity serialization must not fail"),
+        target_inbox,
+    });
+
+    crate::adapters::federation::send_activity(args).await?;
+
+    Ok(())
+}
+
+/// Build a `Like` [`Activity`] addressed to the status author and pointing
+/// at the status URI.
+fn make_like_activity(own_actor_uri: &str, author_actor_uri: &str, status_uri: &str) -> Activity {
+    Activity {
+        base: BaseObject {
+            context: Some(activitypub::context::Context::Uri(
+                ACTIVITY_STREAMS_CONTEXT.to_string(),
+            )),
+            kind: ActivityType::Like,
+            to: Some(OneOrMany::One(author_actor_uri.to_string())),
+            ..Default::default()
+        },
+        actor: Some(own_actor_uri.to_string()),
+        object: Some(ActivityObject::Id(status_uri.to_string())),
+        target: None,
+        result: None,
+        origin: None,
+        instrument: None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    use did::federation::{SendActivityArgs, SendActivityArgsObject};
+
+    use super::*;
+    use crate::adapters::federation::mock::captured;
+    use crate::test_utils::setup;
+
+    const STATUS_URI: &str = "https://mastic.social/users/alice/statuses/42";
+    const AUTHOR_URI: &str = "https://mastic.social/users/alice";
+    const OWN_URI: &str = "https://mastic.social/users/rey_canisteryo";
+
+    #[tokio::test]
+    async fn test_should_like_status() {
+        setup();
+
+        let response = like_status(LikeStatusArgs {
+            status_url: STATUS_URI.to_string(),
+        })
+        .await;
+
+        assert_eq!(response, LikeStatusResponse::Ok);
+        assert!(LikedRepository::is_liked(STATUS_URI).expect("should query"));
+
+        let captured = captured();
+        assert_eq!(captured.len(), 1, "exactly one activity dispatched");
+        let SendActivityArgs::One(SendActivityArgsObject {
+            activity_json,
+            target_inbox,
+        }) = &captured[0]
+        else {
+            panic!("expected SendActivityArgs::One");
+        };
+        assert_eq!(target_inbox, &format!("{AUTHOR_URI}/inbox"));
+
+        let activity: Activity = serde_json::from_str(activity_json).expect("valid activity");
+        assert_eq!(activity.base.kind, ActivityType::Like);
+        assert_eq!(activity.actor.as_deref(), Some(OWN_URI));
+        let ActivityObject::Id(obj) = activity.object.expect("object") else {
+            panic!("expected Id variant");
+        };
+        assert_eq!(obj, STATUS_URI);
+    }
+
+    #[tokio::test]
+    async fn test_should_be_idempotent_when_already_liked() {
+        setup();
+
+        let first = like_status(LikeStatusArgs {
+            status_url: STATUS_URI.to_string(),
+        })
+        .await;
+        assert_eq!(first, LikeStatusResponse::Ok);
+
+        let second = like_status(LikeStatusArgs {
+            status_url: STATUS_URI.to_string(),
+        })
+        .await;
+        assert_eq!(second, LikeStatusResponse::Ok);
+
+        // Only one activity dispatched across both calls.
+        assert_eq!(captured().len(), 1);
+    }
+
+    #[test]
+    fn test_make_like_activity_should_address_author() {
+        let activity = make_like_activity(OWN_URI, AUTHOR_URI, STATUS_URI);
+
+        assert_eq!(activity.base.kind, ActivityType::Like);
+        assert_eq!(
+            activity.base.to,
+            Some(OneOrMany::One(AUTHOR_URI.to_string()))
+        );
+        assert_eq!(activity.actor.as_deref(), Some(OWN_URI));
+    }
+}

--- a/crates/canisters/user/src/domain/liked/repository.rs
+++ b/crates/canisters/user/src/domain/liked/repository.rs
@@ -1,0 +1,72 @@
+use ic_dbms_canister::prelude::DBMS_CONTEXT;
+use wasm_dbms::WasmDbmsDatabase;
+use wasm_dbms_api::prelude::{Database, DeleteBehavior, Filter, Query, TableSchema};
+
+use crate::error::{CanisterError, CanisterResult};
+use crate::schema::{Liked, LikedInsertRequest, Schema};
+
+pub struct LikedRepository;
+
+impl LikedRepository {
+    /// Inserts a liked status into the database.
+    pub fn like_status(status_uri: &str) -> CanisterResult<()> {
+        DBMS_CONTEXT
+            .with(|ctx| {
+                let db = WasmDbmsDatabase::oneshot(ctx, Schema);
+
+                db.insert::<Liked>(LikedInsertRequest {
+                    status_uri: status_uri.into(),
+                    created_at: ic_utils::now().into(),
+                })
+            })
+            .map_err(CanisterError::from)
+    }
+
+    /// Deletes a liked status from the database.
+    pub fn unlike_status(status_uri: &str) -> CanisterResult<()> {
+        DBMS_CONTEXT
+            .with(|ctx| {
+                let db = WasmDbmsDatabase::oneshot(ctx, Schema);
+
+                db.delete::<Liked>(
+                    DeleteBehavior::Cascade,
+                    Some(Filter::eq(Liked::primary_key(), status_uri.into())),
+                )
+            })
+            .map(|_| ())
+            .map_err(CanisterError::from)
+    }
+
+    /// Checks if a status is liked by the user.
+    pub fn is_liked(status_uri: &str) -> CanisterResult<bool> {
+        DBMS_CONTEXT
+            .with(|ctx| {
+                let db = WasmDbmsDatabase::oneshot(ctx, Schema);
+
+                db.select::<Liked>(
+                    Query::builder()
+                        .and_where(Filter::eq(Liked::primary_key(), status_uri.into()))
+                        .limit(1)
+                        .build(),
+                )
+            })
+            .map(|count| !count.is_empty())
+            .map_err(CanisterError::from)
+    }
+
+    pub fn get_liked(offset: usize, limit: usize) -> CanisterResult<Vec<String>> {
+        DBMS_CONTEXT
+            .with(|ctx| {
+                let db = WasmDbmsDatabase::oneshot(ctx, Schema);
+
+                db.select::<Liked>(Query::builder().all().offset(offset).limit(limit).build())
+            })
+            .map(|records| {
+                records
+                    .into_iter()
+                    .map(|record| record.status_uri.unwrap_or_default().0)
+                    .collect()
+            })
+            .map_err(CanisterError::from)
+    }
+}

--- a/crates/canisters/user/src/domain/liked/unlike.rs
+++ b/crates/canisters/user/src/domain/liked/unlike.rs
@@ -1,0 +1,190 @@
+//! Domain logic for the `unlike_status` flow.
+//!
+//! The flow consists of:
+//! 1. Look up the status URI in the `liked` table.
+//! 2. If absent, return success (idempotent — nothing to undo).
+//! 3. Delete the row.
+//! 4. Build an `Undo(Like)` activity wrapping the original `Like` and
+//!    dispatch it via the Federation Canister to the status author's
+//!    inbox.
+//!
+//! Like the `like_status` flow, the status URI is opaque and the
+//! author's inbox is derived by stripping `/statuses/{id}` and appending
+//! `/inbox`.
+
+use activitypub::activity::{Activity, ActivityObject, ActivityType};
+use activitypub::context::ACTIVITY_STREAMS_CONTEXT;
+use activitypub::object::{BaseObject, OneOrMany};
+use did::federation::{SendActivityArgs, SendActivityArgsObject};
+use did::user::{UnlikeStatusArgs, UnlikeStatusError, UnlikeStatusResponse};
+
+use crate::domain::liked::repository::LikedRepository;
+use crate::domain::profile::ProfileRepository;
+use crate::error::CanisterResult;
+
+/// Execute the unlike-status flow.
+pub async fn unlike_status(
+    UnlikeStatusArgs { status_url }: UnlikeStatusArgs,
+) -> UnlikeStatusResponse {
+    match unlike_status_inner(status_url).await {
+        Ok(()) => UnlikeStatusResponse::Ok,
+        Err(err) => {
+            ic_utils::log!("Failed to unlike status: {err}");
+            UnlikeStatusResponse::Err(UnlikeStatusError::Internal(err.to_string()))
+        }
+    }
+}
+
+async fn unlike_status_inner(status_uri: String) -> CanisterResult<()> {
+    ic_utils::log!("Unliking status with URI: {status_uri}");
+
+    // Idempotent: nothing to do if the row is absent.
+    if !LikedRepository::is_liked(&status_uri)? {
+        ic_utils::log!("Status not liked: {status_uri}; nothing to do");
+        return Ok(());
+    }
+
+    LikedRepository::unlike_status(&status_uri)?;
+
+    let Some(author_actor_uri) = crate::domain::urls::actor_uri_from_status_uri(&status_uri) else {
+        ic_utils::log!("unlike_status: could not derive author actor URI from {status_uri}");
+        return Ok(());
+    };
+    let target_inbox = crate::domain::urls::inbox_url_from_actor_uri(&author_actor_uri);
+
+    let own_profile = ProfileRepository::get_profile()?;
+    let own_actor_uri = crate::domain::urls::actor_uri(&own_profile.handle.0)?;
+    let activity = make_undo_like_activity(&own_actor_uri, &author_actor_uri, &status_uri);
+
+    let args = SendActivityArgs::One(SendActivityArgsObject {
+        activity_json: serde_json::to_string(&activity)
+            .expect("Activity serialization must not fail"),
+        target_inbox,
+    });
+
+    crate::adapters::federation::send_activity(args).await?;
+
+    Ok(())
+}
+
+/// Build an `Undo(Like)` [`Activity`] cancelling a previous like.
+fn make_undo_like_activity(
+    own_actor_uri: &str,
+    author_actor_uri: &str,
+    status_uri: &str,
+) -> Activity {
+    let inner_like = Activity {
+        base: BaseObject {
+            kind: ActivityType::Like,
+            ..Default::default()
+        },
+        actor: Some(own_actor_uri.to_string()),
+        object: Some(ActivityObject::Id(status_uri.to_string())),
+        target: None,
+        result: None,
+        origin: None,
+        instrument: None,
+    };
+
+    Activity {
+        base: BaseObject {
+            context: Some(activitypub::context::Context::Uri(
+                ACTIVITY_STREAMS_CONTEXT.to_string(),
+            )),
+            kind: ActivityType::Undo,
+            to: Some(OneOrMany::One(author_actor_uri.to_string())),
+            ..Default::default()
+        },
+        actor: Some(own_actor_uri.to_string()),
+        object: Some(ActivityObject::Activity(Box::new(inner_like))),
+        target: None,
+        result: None,
+        origin: None,
+        instrument: None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    use did::federation::{SendActivityArgs, SendActivityArgsObject};
+
+    use super::*;
+    use crate::adapters::federation::mock::captured;
+    use crate::test_utils::setup;
+
+    const STATUS_URI: &str = "https://mastic.social/users/alice/statuses/42";
+    const AUTHOR_URI: &str = "https://mastic.social/users/alice";
+    const OWN_URI: &str = "https://mastic.social/users/rey_canisteryo";
+
+    #[tokio::test]
+    async fn test_should_unlike_status_after_like() {
+        setup();
+
+        LikedRepository::like_status(STATUS_URI).expect("should insert liked");
+
+        let response = unlike_status(UnlikeStatusArgs {
+            status_url: STATUS_URI.to_string(),
+        })
+        .await;
+
+        assert_eq!(response, UnlikeStatusResponse::Ok);
+        assert!(!LikedRepository::is_liked(STATUS_URI).expect("should query"));
+
+        let captured = captured();
+        assert_eq!(captured.len(), 1);
+        let SendActivityArgs::One(SendActivityArgsObject {
+            activity_json,
+            target_inbox,
+        }) = &captured[0]
+        else {
+            panic!("expected SendActivityArgs::One");
+        };
+        assert_eq!(target_inbox, &format!("{AUTHOR_URI}/inbox"));
+
+        let activity: Activity = serde_json::from_str(activity_json).expect("valid activity");
+        assert_eq!(activity.base.kind, ActivityType::Undo);
+        let ActivityObject::Activity(inner) = activity.object.expect("inner") else {
+            panic!("expected wrapped activity");
+        };
+        assert_eq!(inner.base.kind, ActivityType::Like);
+        let ActivityObject::Id(obj) = inner.object.expect("inner object") else {
+            panic!("expected Id");
+        };
+        assert_eq!(obj, STATUS_URI);
+    }
+
+    #[tokio::test]
+    async fn test_should_be_idempotent_when_not_liked() {
+        setup();
+
+        let response = unlike_status(UnlikeStatusArgs {
+            status_url: STATUS_URI.to_string(),
+        })
+        .await;
+
+        assert_eq!(response, UnlikeStatusResponse::Ok);
+        assert!(captured().is_empty(), "no activity dispatched");
+    }
+
+    #[test]
+    fn test_make_undo_like_activity_should_wrap_inner_like() {
+        let activity = make_undo_like_activity(OWN_URI, AUTHOR_URI, STATUS_URI);
+
+        assert_eq!(activity.base.kind, ActivityType::Undo);
+        assert_eq!(
+            activity.base.to,
+            Some(OneOrMany::One(AUTHOR_URI.to_string()))
+        );
+
+        let ActivityObject::Activity(inner) = activity.object.expect("inner") else {
+            panic!("expected Activity variant");
+        };
+        assert_eq!(inner.base.kind, ActivityType::Like);
+        assert_eq!(inner.actor.as_deref(), Some(OWN_URI));
+        let ActivityObject::Id(obj) = inner.object.expect("inner object") else {
+            panic!("expected Id");
+        };
+        assert_eq!(obj, STATUS_URI);
+    }
+}

--- a/crates/canisters/user/src/domain/status/get_statuses.rs
+++ b/crates/canisters/user/src/domain/status/get_statuses.rs
@@ -126,6 +126,8 @@ fn status_to_did(owner_actor_uri: &str, status: crate::schema::Status) -> Status
         visibility: status.visibility.into(),
         created_at: status.created_at.0,
         author: owner_actor_uri.to_string(),
+        like_count: status.like_count.0,
+        boost_count: status.boost_count.0,
     }
 }
 

--- a/crates/canisters/user/src/domain/status/publish.rs
+++ b/crates/canisters/user/src/domain/status/publish.rs
@@ -86,6 +86,8 @@ async fn save_status_and_publish_to_federation(
         author: owner_actor_uri,
         created_at,
         visibility,
+        like_count: 0,
+        boost_count: 0,
     };
 
     let recipients = match visibility {
@@ -480,6 +482,8 @@ mod tests {
             author: "https://mastic.social/users/rey_canisteryo".to_string(),
             created_at: 0,
             visibility,
+            like_count: 0,
+            boost_count: 0,
         }
     }
 
@@ -491,6 +495,8 @@ mod tests {
             author: "https://mastic.social/users/rey_canisteryo".to_string(),
             created_at: 1_000_000,
             visibility: Visibility::Public,
+            like_count: 0,
+            boost_count: 0,
         };
 
         let args = make_activity(BOB_URI, &status, &[]);

--- a/crates/canisters/user/src/domain/status/repository.rs
+++ b/crates/canisters/user/src/domain/status/repository.rs
@@ -9,7 +9,7 @@ use crate::domain::snowflake::Snowflake;
 use crate::error::CanisterResult;
 use crate::schema::{
     FeedEntry, FeedEntryInsertRequest, FeedSource, Schema, Status, StatusInsertRequest,
-    StatusRecord,
+    StatusRecord, StatusUpdateRequest,
 };
 
 /// Interface for the [`Status`] repository.
@@ -85,6 +85,66 @@ impl StatusRepository {
             let results = db.select::<Status>(query.build())?;
             Ok(results.into_iter().map(Self::record_to_status).collect())
         })
+    }
+
+    /// Look up a single [`Status`] by its [`Snowflake`] id, returning [`None`]
+    /// if no row matches.
+    pub fn find_by_id(id: u64) -> CanisterResult<Option<Status>> {
+        DBMS_CONTEXT.with(|ctx| {
+            let db = WasmDbmsDatabase::oneshot(ctx, Schema);
+            let rows = db.select::<Status>(
+                Query::builder()
+                    .all()
+                    .and_where(Filter::eq(Status::primary_key(), Value::from(id)))
+                    .limit(1)
+                    .build(),
+            )?;
+            Ok(rows.into_iter().next().map(Self::record_to_status))
+        })
+    }
+
+    /// Increment the cached `like_count` of the [`Status`] with the given id.
+    ///
+    /// Returns `Ok(true)` when the row exists and was updated, `Ok(false)`
+    /// when no row matched (silently ignored: a missing target means we are
+    /// not the author of that status, so the counter does not concern us).
+    pub fn increment_like_count(id: u64) -> CanisterResult<bool> {
+        Self::adjust_like_count(id, 1, true)
+    }
+
+    /// Saturating-decrement the cached `like_count` of the [`Status`] with the
+    /// given id. Decrementing from `0` is a no-op rather than an underflow.
+    ///
+    /// Returns `Ok(true)` when the row exists, `Ok(false)` when no row matched.
+    pub fn decrement_like_count(id: u64) -> CanisterResult<bool> {
+        Self::adjust_like_count(id, 1, false)
+    }
+
+    fn adjust_like_count(id: u64, delta: u64, increment: bool) -> CanisterResult<bool> {
+        let Some(status) = Self::find_by_id(id)? else {
+            return Ok(false);
+        };
+        let current = status.like_count.0;
+        let next = if increment {
+            current.saturating_add(delta)
+        } else {
+            current.saturating_sub(delta)
+        };
+        if next == current {
+            return Ok(true);
+        }
+
+        let patch = StatusUpdateRequest {
+            like_count: Some(next.into()),
+            where_clause: Some(Filter::eq(Status::primary_key(), Value::from(id))),
+            ..Default::default()
+        };
+
+        DBMS_CONTEXT.with(|ctx| {
+            let db = WasmDbmsDatabase::oneshot(ctx, Schema);
+            db.update::<Status>(patch)
+        })?;
+        Ok(true)
     }
 
     fn record_to_status(record: StatusRecord) -> Status {

--- a/crates/canisters/user/src/domain/urls.rs
+++ b/crates/canisters/user/src/domain/urls.rs
@@ -43,6 +43,51 @@ pub fn inbox_url_from_actor_uri(actor_uri: &str) -> String {
     format!("{actor_uri}/inbox")
 }
 
+/// Build the canonical status URI: `{public_url}/users/{handle}/statuses/{id}`.
+#[cfg_attr(
+    not(test),
+    allow(dead_code, reason = "used by future status URI minting")
+)]
+pub fn status_uri(handle: &str, id: u64) -> CanisterResult<String> {
+    let public_url = crate::settings::get_public_url()?;
+    Ok(format!("{public_url}/users/{handle}/statuses/{id}"))
+}
+
+/// Extract the author actor URI from a status URI by stripping the trailing
+/// `/statuses/{id}` segment.
+///
+/// Returns [`None`] when the URI does not have the expected
+/// `…/statuses/{id}` shape (e.g. it contains a sub-path after the id).
+pub fn actor_uri_from_status_uri(uri: &str) -> Option<String> {
+    let (head, tail) = uri.rsplit_once("/statuses/")?;
+    if tail.is_empty() || tail.contains('/') {
+        return None;
+    }
+    Some(head.to_string())
+}
+
+/// Parse a local status URI of the form
+/// `{public_url}/users/{handle}/statuses/{id}`, returning `(handle, id)` when
+/// the URI is hosted on this instance and the path matches the canonical
+/// shape. Returns [`None`] for remote or malformed URIs.
+pub fn parse_local_status_uri(uri: &str) -> CanisterResult<Option<(String, u64)>> {
+    let public_url = crate::settings::get_public_url()?;
+    let prefix = format!("{public_url}/users/");
+    let Some(rest) = uri.strip_prefix(&prefix) else {
+        return Ok(None);
+    };
+    let Some((handle, tail)) = rest.split_once("/statuses/") else {
+        return Ok(None);
+    };
+    if handle.is_empty() || handle.contains('/') {
+        return Ok(None);
+    }
+    let Ok(id) = tail.parse::<u64>() else {
+        return Ok(None);
+    };
+    Ok(Some((handle.to_string(), id)))
+}
+
 #[cfg(test)]
 mod tests {
 
@@ -100,5 +145,66 @@ mod tests {
             following_url("alice").unwrap(),
             "https://mastic.social/users/alice/following"
         );
+    }
+
+    #[test]
+    fn test_status_uri() {
+        setup();
+        assert_eq!(
+            status_uri("alice", 42).unwrap(),
+            "https://mastic.social/users/alice/statuses/42"
+        );
+    }
+
+    #[test]
+    fn test_actor_uri_from_status_uri() {
+        assert_eq!(
+            actor_uri_from_status_uri("https://mastic.social/users/alice/statuses/42").as_deref(),
+            Some("https://mastic.social/users/alice")
+        );
+    }
+
+    #[test]
+    fn test_actor_uri_from_status_uri_rejects_subpath() {
+        assert!(
+            actor_uri_from_status_uri("https://mastic.social/users/alice/statuses/42/foo")
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn test_actor_uri_from_status_uri_rejects_missing_id() {
+        assert!(actor_uri_from_status_uri("https://mastic.social/users/alice/statuses/").is_none());
+    }
+
+    #[test]
+    fn test_parse_local_status_uri_ok() {
+        setup();
+        let parsed =
+            parse_local_status_uri("https://mastic.social/users/alice/statuses/42").unwrap();
+        assert_eq!(parsed, Some(("alice".to_string(), 42)));
+    }
+
+    #[test]
+    fn test_parse_local_status_uri_rejects_remote() {
+        setup();
+        let parsed =
+            parse_local_status_uri("https://other.example/users/alice/statuses/42").unwrap();
+        assert!(parsed.is_none());
+    }
+
+    #[test]
+    fn test_parse_local_status_uri_rejects_non_numeric_id() {
+        setup();
+        let parsed =
+            parse_local_status_uri("https://mastic.social/users/alice/statuses/abc").unwrap();
+        assert!(parsed.is_none());
+    }
+
+    #[test]
+    fn test_parse_local_status_uri_rejects_unexpected_path() {
+        setup();
+        let parsed = parse_local_status_uri("https://mastic.social/users/alice/inbox").unwrap();
+        assert!(parsed.is_none());
     }
 }

--- a/crates/canisters/user/src/inspect.rs
+++ b/crates/canisters/user/src/inspect.rs
@@ -7,10 +7,12 @@ pub fn inspect() {
         "accept_follow"
         | "follow_user"
         | "get_follow_requests"
+        | "like_status"
         | "publish_status"
         | "read_feed"
         | "reject_follow"
         | "unfollow_user"
+        | "unlike_status"
         | "update_profile" => {
             let caller = ic_utils::caller();
             if !crate::api::inspect::is_owner(caller) {

--- a/crates/canisters/user/src/lib.rs
+++ b/crates/canisters/user/src/lib.rs
@@ -8,15 +8,7 @@ mod settings;
 #[cfg(test)]
 mod test_utils;
 
-use did::user::{
-    AcceptFollowArgs, AcceptFollowResponse, EmitDeleteProfileActivityResponse, FollowUserArgs,
-    FollowUserResponse, GetFollowRequestsArgs, GetFollowRequestsResponse, GetFollowersArgs,
-    GetFollowersResponse, GetFollowingArgs, GetFollowingResponse, GetProfileResponse,
-    GetStatusesArgs, GetStatusesResponse, PublishStatusArgs, PublishStatusResponse, ReadFeedArgs,
-    ReadFeedResponse, ReceiveActivityArgs, ReceiveActivityResponse, RejectFollowArgs,
-    RejectFollowResponse, UnfollowUserArgs, UnfollowUserResponse, UpdateProfileArgs,
-    UpdateProfileResponse, UserInstallArgs,
-};
+use did::user::*;
 
 #[ic_cdk::init]
 fn init(args: UserInstallArgs) {
@@ -64,6 +56,11 @@ fn get_following(args: GetFollowingArgs) -> GetFollowingResponse {
 }
 
 #[ic_cdk::query]
+fn get_liked(args: GetLikedArgs) -> GetLikedResponse {
+    api::get_liked(args)
+}
+
+#[ic_cdk::query]
 fn get_profile() -> GetProfileResponse {
     api::get_profile()
 }
@@ -71,6 +68,11 @@ fn get_profile() -> GetProfileResponse {
 #[ic_cdk::query(composite = true)]
 async fn get_statuses(args: GetStatusesArgs) -> GetStatusesResponse {
     api::get_statuses(args).await
+}
+
+#[ic_cdk::update]
+async fn like_status(args: LikeStatusArgs) -> LikeStatusResponse {
+    api::like_status(args).await
 }
 
 #[ic_cdk::update]
@@ -96,6 +98,11 @@ async fn reject_follow(args: RejectFollowArgs) -> RejectFollowResponse {
 #[ic_cdk::update]
 async fn unfollow_user(args: UnfollowUserArgs) -> UnfollowUserResponse {
     api::unfollow_user(args).await
+}
+
+#[ic_cdk::update]
+async fn unlike_status(args: UnlikeStatusArgs) -> UnlikeStatusResponse {
+    api::unlike_status(args).await
 }
 
 #[ic_cdk::update]

--- a/crates/libs/db-utils/src/hashtag.rs
+++ b/crates/libs/db-utils/src/hashtag.rs
@@ -38,13 +38,17 @@ pub struct HashtagValidator;
 impl HashtagValidator {
     /// Check that a tag is valid according to the following rules:
     ///
-    /// | Rule               | Value                        |
-    /// | :----------------- | :--------------------------- |
-    /// | Allowed characters | `a-z`, `0-9`, `_`            |
-    /// | Minimum length     | 1                            |
-    /// | Maximum length     | 30 Unicode scalar values     |
-    /// | Case sensitivity   | Case-insensitive             |
-    /// | Storage            | Stored as lowercase, no `#`  |
+    /// | Rule               | Value                                            |
+    /// | :----------------- | :----------------------------------------------- |
+    /// | Allowed characters | Unicode letters, Unicode numbers, `_`            |
+    /// | Minimum length     | 1                                                |
+    /// | Maximum length     | 30 Unicode scalar values                         |
+    /// | Case sensitivity   | Case-insensitive (Unicode-aware)                 |
+    /// | Storage            | Stored as lowercase, no `#`                      |
+    ///
+    /// Cased letters must be lowercase (the [`HashtagSanitizer`] handles
+    /// this prior to validation). Non-cased scripts (e.g. Han, Myanmar,
+    /// Arabic) are accepted as-is.
     pub fn check_tag(tag: &str) -> Result<(), String> {
         let len = tag.chars().count();
         if len == 0 || len > MAX_HASHTAG_LENGTH {
@@ -55,10 +59,11 @@ impl HashtagValidator {
 
         if !tag
             .chars()
-            .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '_')
+            .all(|c| (c.is_alphanumeric() && !c.is_uppercase()) || c == '_')
         {
             return Err(
-                "tag can only contain lowercase letters, digits, and underscores".to_string(),
+                "tag can only contain Unicode letters, digits, and underscores, all lowercase"
+                    .to_string(),
             );
         }
 
@@ -210,6 +215,44 @@ mod tests {
         let validator = HashtagValidator;
         let value: Value = "rust-lang".to_string().into();
         assert!(validator.validate(&value).is_err());
+    }
+
+    #[test]
+    fn test_should_validate_tag_with_unicode_letters() {
+        let validator = HashtagValidator;
+        // Cyrillic, Greek, accented Latin, Han, Myanmar Shan letter, Arabic
+        for tag in ["русский", "ελληνικά", "café", "汉字", "ꩰ", "العربية"]
+        {
+            let value: Value = tag.to_string().into();
+            assert!(
+                validator.validate(&value).is_ok(),
+                "expected `{tag}` to be valid"
+            );
+        }
+    }
+
+    #[test]
+    fn test_should_validate_tag_with_unicode_digits() {
+        let validator = HashtagValidator;
+        // Arabic-Indic digit 5, Devanagari digit 9
+        let value: Value = "rust٥९".to_string().into();
+        assert!(validator.validate(&value).is_ok());
+    }
+
+    #[test]
+    fn test_should_reject_tag_with_uppercase_unicode_letters() {
+        let validator = HashtagValidator;
+        // Greek capital alpha
+        let value: Value = "Ελληνικά".to_string().into();
+        assert!(validator.validate(&value).is_err());
+    }
+
+    #[test]
+    fn test_should_sanitize_tag_lowercasing_unicode() {
+        let sanitizer = HashtagSanitizer;
+        let value: Value = "Ελληνικά".to_string().into();
+        let result = sanitizer.sanitize(value).unwrap();
+        assert_eq!(result, Value::Text("ελληνικά".into()));
     }
 
     #[test]

--- a/crates/libs/did/src/common.rs
+++ b/crates/libs/did/src/common.rs
@@ -53,6 +53,10 @@ pub struct Status {
     pub created_at: u64,
     /// The visibility setting of the status, controlling its audience.
     pub visibility: Visibility,
+    /// Cached count of `Like` activities received for this status.
+    pub like_count: u64,
+    /// Cached count of `Announce` (boost) activities received for this status.
+    pub boost_count: u64,
 }
 
 /// A single entry in a user's feed. Wraps a [`Status`] and optionally indicates

--- a/crates/libs/did/src/common/tests.rs
+++ b/crates/libs/did/src/common/tests.rs
@@ -54,6 +54,8 @@ fn test_should_roundtrip_status() {
         author: "https://mastic.social/users/alice".to_string(),
         created_at: 1_000_000_000,
         visibility: Visibility::Public,
+        like_count: 0,
+        boost_count: 0,
     };
     let bytes = Encode!(&status).unwrap();
     let decoded = Decode!(&bytes, Status).unwrap();
@@ -69,6 +71,8 @@ fn test_should_roundtrip_feed_item() {
             author: "https://mastic.social/users/alice".to_string(),
             created_at: 42,
             visibility: Visibility::FollowersOnly,
+            like_count: 0,
+            boost_count: 0,
         },
         boosted_by: Some("https://mastic.social/users/bob".to_string()),
     };
@@ -86,6 +90,8 @@ fn test_should_roundtrip_feed_item_without_boost() {
             author: "https://mastic.social/users/alice".to_string(),
             created_at: 42,
             visibility: Visibility::Unlisted,
+            like_count: 0,
+            boost_count: 0,
         },
         boosted_by: None,
     };

--- a/crates/libs/did/src/user.rs
+++ b/crates/libs/did/src/user.rs
@@ -347,23 +347,18 @@ pub enum DeleteStatusResponse {
 /// Request arguments for the `like_status` method.
 #[derive(Debug, Clone, PartialEq, Eq, CandidType, Serialize, Deserialize)]
 pub struct LikeStatusArgs {
-    /// The unique ID of the status to like.
-    pub status_id: String,
-    /// Principal of the User Canister that authored the status.
-    pub author_canister: candid::Principal,
+    /// ActivityPub URI of the status to like.
+    pub status_url: String,
 }
 
 /// Error types for the `like_status` method.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, CandidType, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, CandidType, Serialize, Deserialize)]
 pub enum LikeStatusError {
-    /// The caller is not the canister owner.
-    Unauthorized,
-    /// The caller has already liked this status.
-    AlreadyLiked,
+    Internal(String),
 }
 
 /// Response type for the `like_status` method.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, CandidType, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, CandidType, Serialize, Deserialize)]
 pub enum LikeStatusResponse {
     Ok,
     Err(LikeStatusError),
@@ -371,27 +366,23 @@ pub enum LikeStatusResponse {
 
 /// Request arguments for the `undo_like` method.
 #[derive(Debug, Clone, PartialEq, Eq, CandidType, Serialize, Deserialize)]
-pub struct UndoLikeArgs {
-    /// The unique ID of the status to unlike.
-    pub status_id: String,
-    /// Principal of the User Canister that authored the status.
-    pub author_canister: candid::Principal,
+pub struct UnlikeStatusArgs {
+    /// ActivityPub URI of the status to unlike.
+    pub status_url: String,
 }
 
 /// Error types for the `undo_like` method.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, CandidType, Serialize, Deserialize)]
-pub enum UndoLikeError {
-    /// The caller is not the canister owner.
-    Unauthorized,
-    /// No like exists for the given status.
-    NotFound,
+#[derive(Debug, Clone, PartialEq, Eq, CandidType, Serialize, Deserialize)]
+pub enum UnlikeStatusError {
+    /// Internal error occurred while undoing the like.
+    Internal(String),
 }
 
 /// Response type for the `undo_like` method.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, CandidType, Serialize, Deserialize)]
-pub enum UndoLikeResponse {
+#[derive(Debug, Clone, PartialEq, Eq, CandidType, Serialize, Deserialize)]
+pub enum UnlikeStatusResponse {
     Ok,
-    Err(UndoLikeError),
+    Err(UnlikeStatusError),
 }
 
 /// Request arguments for the `boost_status` method.
@@ -454,10 +445,9 @@ pub struct GetLikedArgs {
 }
 
 /// Error types for the `get_liked` method.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, CandidType, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, CandidType, Serialize, Deserialize)]
 pub enum GetLikedError {
-    /// The caller is not the canister owner.
-    Unauthorized,
+    Internal(String),
 }
 
 /// Response type for the `get_liked` method.

--- a/crates/libs/did/src/user/tests.rs
+++ b/crates/libs/did/src/user/tests.rs
@@ -343,6 +343,8 @@ fn test_should_roundtrip_publish_status_response_ok() {
         author: "https://mastic.social/users/alice".to_string(),
         created_at: 42,
         visibility: crate::common::Visibility::Public,
+        like_count: 0,
+        boost_count: 0,
     });
     let bytes = Encode!(&resp).unwrap();
     let decoded = Decode!(&bytes, PublishStatusResponse).unwrap();
@@ -396,8 +398,7 @@ fn test_should_roundtrip_delete_status_response_err() {
 #[test]
 fn test_should_roundtrip_like_status_args() {
     let args = LikeStatusArgs {
-        status_id: "test-id".to_string(),
-        author_canister: candid::Principal::anonymous(),
+        status_url: "https://example.com/users/alice/statuses/123".to_string(),
     };
     let bytes = Encode!(&args).unwrap();
     let decoded = Decode!(&bytes, LikeStatusArgs).unwrap();
@@ -414,41 +415,36 @@ fn test_should_roundtrip_like_status_response_ok() {
 
 #[test]
 fn test_should_roundtrip_like_status_response_err() {
-    for error in [LikeStatusError::Unauthorized, LikeStatusError::AlreadyLiked] {
-        let resp = LikeStatusResponse::Err(error);
-        let bytes = Encode!(&resp).unwrap();
-        let decoded = Decode!(&bytes, LikeStatusResponse).unwrap();
-        assert_eq!(resp, decoded);
-    }
+    let resp = LikeStatusResponse::Err(LikeStatusError::Internal("err".to_string()));
+    let bytes = Encode!(&resp).unwrap();
+    let decoded = Decode!(&bytes, LikeStatusResponse).unwrap();
+    assert_eq!(resp, decoded);
 }
 
 #[test]
 fn test_should_roundtrip_undo_like_args() {
-    let args = UndoLikeArgs {
-        status_id: "test-id".to_string(),
-        author_canister: candid::Principal::anonymous(),
+    let args = UnlikeStatusArgs {
+        status_url: "https://example.com/users/alice/statuses/123".to_string(),
     };
     let bytes = Encode!(&args).unwrap();
-    let decoded = Decode!(&bytes, UndoLikeArgs).unwrap();
+    let decoded = Decode!(&bytes, UnlikeStatusArgs).unwrap();
     assert_eq!(args, decoded);
 }
 
 #[test]
 fn test_should_roundtrip_undo_like_response_ok() {
-    let resp = UndoLikeResponse::Ok;
+    let resp = UnlikeStatusResponse::Ok;
     let bytes = Encode!(&resp).unwrap();
-    let decoded = Decode!(&bytes, UndoLikeResponse).unwrap();
+    let decoded = Decode!(&bytes, UnlikeStatusResponse).unwrap();
     assert_eq!(resp, decoded);
 }
 
 #[test]
 fn test_should_roundtrip_undo_like_response_err() {
-    for error in [UndoLikeError::Unauthorized, UndoLikeError::NotFound] {
-        let resp = UndoLikeResponse::Err(error);
-        let bytes = Encode!(&resp).unwrap();
-        let decoded = Decode!(&bytes, UndoLikeResponse).unwrap();
-        assert_eq!(resp, decoded);
-    }
+    let resp = UnlikeStatusResponse::Err(UnlikeStatusError::Internal("test".to_string()));
+    let bytes = Encode!(&resp).unwrap();
+    let decoded = Decode!(&bytes, UnlikeStatusResponse).unwrap();
+    assert_eq!(resp, decoded);
 }
 
 #[test]
@@ -533,7 +529,7 @@ fn test_should_roundtrip_get_liked_response_ok() {
 
 #[test]
 fn test_should_roundtrip_get_liked_response_err() {
-    let resp = GetLikedResponse::Err(GetLikedError::Unauthorized);
+    let resp = GetLikedResponse::Err(GetLikedError::Internal("test".to_string()));
     let bytes = Encode!(&resp).unwrap();
     let decoded = Decode!(&bytes, GetLikedResponse).unwrap();
     assert_eq!(resp, decoded);
@@ -558,6 +554,8 @@ fn test_should_roundtrip_get_statuses_response_ok() {
         author: "https://mastic.social/users/alice".to_string(),
         created_at: 42,
         visibility: crate::common::Visibility::Public,
+        like_count: 0,
+        boost_count: 0,
     }]);
     let bytes = Encode!(&resp).unwrap();
     let decoded = Decode!(&bytes, GetStatusesResponse).unwrap();
@@ -597,6 +595,8 @@ fn test_should_roundtrip_read_feed_response_ok() {
             author: "https://mastic.social/users/alice".to_string(),
             created_at: 42,
             visibility: crate::common::Visibility::Public,
+            like_count: 0,
+            boost_count: 0,
         },
         boosted_by: None,
     }]);

--- a/docs/src/interface.md
+++ b/docs/src/interface.md
@@ -39,18 +39,20 @@ This directory contains the Candid interface definitions for the various caniste
       delete_profile : () -> (DeleteProfileResponse);
       delete_status : (DeleteStatusArgs) -> (DeleteStatusResponse);
       follow_user : (FollowUserArgs) -> (FollowUserResponse);
+      get_follow_requests : (GetFollowRequestsArgs) -> (GetFollowRequestsResponse) query;
       get_followers : (GetFollowersArgs) -> (GetFollowersResponse) query;
       get_following : (GetFollowingArgs) -> (GetFollowingResponse) query;
       get_liked : (GetLikedArgs) -> (GetLikedResponse) query;
       get_profile : () -> (GetProfileResponse) query;
+      get_statuses : (GetStatusesArgs) -> (GetStatusesResponse) composite_query;
       like_status : (LikeStatusArgs) -> (LikeStatusResponse);
       publish_status : (PublishStatusArgs) -> (PublishStatusResponse);
       read_feed : (ReadFeedArgs) -> (ReadFeedResponse) query;
       receive_activity : (ReceiveActivityArgs) -> (ReceiveActivityResponse);
       reject_follow : (RejectFollowArgs) -> (RejectFollowResponse);
       undo_boost : (UndoBoostArgs) -> (UndoBoostResponse);
-      undo_like : (UndoLikeArgs) -> (UndoLikeResponse);
       unfollow_user : (UnfollowUserArgs) -> (UnfollowUserResponse);
+      unlike_status : (UnlikeStatusArgs) -> (UnlikeStatusResponse);
       update_profile : (UpdateProfileArgs) -> (UpdateProfileResponse)
     }
     ```

--- a/docs/src/interface/types.md
+++ b/docs/src/interface/types.md
@@ -33,7 +33,7 @@
     - [PublishStatus](#publishstatus)
     - [DeleteStatus](#deletestatus)
     - [LikeStatus](#likestatus)
-    - [UndoLike](#undolike)
+    - [UnlikeStatus](#undolike)
     - [BoostStatus](#booststatus)
     - [UndoBoost](#undoboost)
     - [GetLiked](#getliked)
@@ -93,21 +93,25 @@ type UserProfile = record {
 A single post authored by a user. Each status has a unique ID, content body,
 author principal, creation timestamp, and visibility setting.
 
-| Field        | Description                                                       |
-| ------------ | ----------------------------------------------------------------- |
-| `id`         | Unique identifier for this status (UUID).                         |
-| `content`    | The text content of the post.                                     |
-| `author`     | Principal of the User Canister that authored the status.          |
-| `created_at` | Timestamp (nanoseconds since epoch) when the status was created.  |
-| `visibility` | Audience control for this status (see [Visibility](#visibility)). |
+| Field         | Description                                                        |
+| ------------- | ------------------------------------------------------------------ |
+| `id`          | Snowflake identifier of the status assigned by the User Canister.  |
+| `content`     | The text content of the post.                                      |
+| `author`      | ActivityPub actor URI of the status author.                        |
+| `created_at`  | Timestamp (milliseconds since epoch) when the status was created.  |
+| `visibility`  | Audience control for this status (see [Visibility](#visibility)).  |
+| `like_count`  | Cached count of `Like` activities received for this status.        |
+| `boost_count` | Cached count of `Announce` (boost) activities received.            |
 
 ```candid
 type Status = record {
-  id : text;
+  id : nat64;
   content : text;
-  author : principal;
+  author : text;
   created_at : nat64;
   visibility : Visibility;
+  like_count : nat64;
+  boost_count : nat64;
 };
 ```
 
@@ -829,18 +833,22 @@ type DeleteStatusError = variant {
 Request, response, and error types for the `like_status` method. Records a
 like on a status authored by another user.
 
-| Field              | Description                                              |
-| ------------------ | -------------------------------------------------------- |
-| `status_id`        | The unique ID of the status to like.                     |
-| `author_canister`  | Principal of the User Canister that authored the status. |
+`like_status` is **idempotent**: calling it for a status the caller has
+already liked returns `Ok` without recording a duplicate row in the
+liked collection and without re-emitting a `Like` activity. Only the
+caller (canister owner) is authorized; non-owner calls are rejected at
+the inspect layer.
 
-- **Unauthorized**: the caller is not the canister owner.
-- **AlreadyLiked**: the caller has already liked this status.
+| Field        | Description                              |
+| ------------ | ---------------------------------------- |
+| `status_url` | ActivityPub URI of the status to like.   |
+
+- **Internal**: an unexpected internal error occurred (database access
+  failure, federation dispatch failure, etc.).
 
 ```candid
 type LikeStatusArgs = record {
-  status_id : text;
-  author_canister : principal;
+  status_url : text;
 };
 
 type LikeStatusResponse = variant {
@@ -849,36 +857,33 @@ type LikeStatusResponse = variant {
 };
 
 type LikeStatusError = variant {
-  Unauthorized;
-  AlreadyLiked;
+  Internal : text;
 };
 ```
 
-### UndoLike
+### UnlikeStatus
 
 Request, response, and error types for the `undo_like` method. Removes a
 previously recorded like from a status.
 
-| Field              | Description                                              |
-| ------------------ | -------------------------------------------------------- |
-| `status_id`        | The unique ID of the status to unlike.                   |
-| `author_canister`  | Principal of the User Canister that authored the status. |
+| Field        | Description                              |
+| ------------ | ---------------------------------------- |
+| `status_url` | ActivityPub URI of the status to unlike. |
 
 - **Unauthorized**: the caller is not the canister owner.
 - **NotFound**: no like exists for the given status.
 
 ```candid
-type UndoLikeArgs = record {
-  status_id : text;
-  author_canister : principal;
+type UnlikeStatusArgs = record {
+  status_url : text;
 };
 
-type UndoLikeResponse = variant {
+type UnlikeStatusResponse = variant {
   Ok;
-  Err : UndoLikeError;
+  Err : UnlikeStatusError;
 };
 
-type UndoLikeError = variant {
+type UnlikeStatusError = variant {
   Unauthorized;
   NotFound;
 };

--- a/docs/src/milestones/milestone-1.md
+++ b/docs/src/milestones/milestone-1.md
@@ -170,17 +170,20 @@ via an Undo(Follow) activity.
   - Record the like in the user's liked collection (stable memory)
   - Build a `Like` activity targeting the status
   - Send the activity to the Federation Canister
+  - **Idempotent**: if the caller has already liked the status, return
+    `Ok` without inserting a duplicate row and without re-sending the
+    `Like` activity
 - Implement `get_liked(GetLikedArgs)` query:
   - Return the paginated list of statuses liked by the user
-- Implement `undo_like(UndoLikeArgs)`:
+- Implement `undo_like(UnlikeStatusArgs)`:
   - Remove the like from the liked collection
   - Send an `Undo(Like)` activity to the Federation Canister
 - **User Canister** `receive_activity` handler: handle incoming `Like`:
   - Increment the like count on the target status
 - Handle incoming `Undo(Like)`:
   - Decrement the like count on the target status
-- Define `LikeStatusArgs`, `LikeStatusResponse`, `UndoLikeArgs`,
-  `UndoLikeResponse`, `GetLikedArgs`, `GetLikedResponse` in the `did` crate
+- Define `LikeStatusArgs`, `LikeStatusResponse`, `UnlikeStatusArgs`,
+  `UnlikeStatusResponse`, `GetLikedArgs`, `GetLikedResponse` in the `did` crate
 - Add `Like` to `ActivityType`
 
 **Acceptance Criteria:**
@@ -190,8 +193,12 @@ via an Undo(Follow) activity.
 - The author's status like count is incremented
 - `get_liked` returns the correct list
 - Undoing a like removes it and sends an `Undo(Like)` activity
-- Cannot like the same status twice
+- Liking a status the caller already liked is idempotent: returns `Ok`,
+  does not insert a duplicate, and does not re-send the `Like` activity
 - Integration test: Alice likes Bob's status, verify like count and liked list
+- Integration test: Alice calls `like_status` twice on the same status,
+  verify second call returns `Ok`, liked list contains a single entry,
+  and Bob's status like count is incremented exactly once
 
 ### WI-1.7: Implement User Canister - boost status (UC11)
 

--- a/docs/src/project.md
+++ b/docs/src/project.md
@@ -266,7 +266,7 @@ reject\_follow : (*RejectFollowArgs*) -> (*RejectFollowResponse*);
 
 undo\_boost : (*UndoBoostArgs*) -> (*UndoBoostResponse*);
 
-undo\_like : (*UndoLikeArgs*) -> (*UndoLikeResponse*);
+undo\_like : (*UnlikeStatusArgs*) -> (*UnlikeStatusResponse*);
 
 unfollow\_user : (*UnfollowUserArgs*) -> (*UnfollowUserResponse*);
 
@@ -357,10 +357,11 @@ update\_profile : (*UpdateProfileArgs*) -> (*UpdateProfileResponse*)
 ### UC10: As a User, I should be able to like a Status
 
 - **Alice** signs in and obtains her **User Canister** principal via the **Directory Canister**
-- **Alice** calls *like\_status* on her **User Canister** with the status ID
-- The **User Canister** records the like in Alice’s outbox
+- **Alice** calls *like\_status* on her **User Canister** with the status URL
+- The **User Canister** records the like in Alice’s liked collection
 - The **User Canister** sends a *Like* activity to the **Federation Canister**
 - The **Federation Canister** routes the activity to the status author’s **User Canister** (local) or forwards it via HTTP (remote)
+- *like\_status* is **idempotent**: if Alice has already liked the status, the call returns `Ok` without inserting a duplicate or re-sending the *Like* activity
 
 ### UC11: As a User, I should be able to boost a Status
 

--- a/docs/src/specs/handles.md
+++ b/docs/src/specs/handles.md
@@ -18,21 +18,68 @@ A **local handle** is the username portion of a Mastic account (e.g. `alice` in 
 
 **Regex**: `^[a-z0-9_]{1,30}$`
 
-Underscores are allowed in any position, including leading, trailing, and consecutive.
+Underscores are allowed in any position, including leading, trailing, and
+consecutive.
+
+Local handles are intentionally restricted to ASCII. Mastic owns the
+local namespace and the `users.handle` column carries a unique index
+that must remain free of Unicode normalization ambiguity (NFC vs NFD,
+confusables, IDN homograph). Users on other fediverse instances may
+have Unicode handles — see the next section.
 
 ## Remote Handle Format
 
-A **remote handle** identifies a user on another fediverse instance (e.g. `@bob@mastodon.social`).
-To maintain federation compatibility with Pleroma, Misskey, GoToSocial, and other ActivityPub
-implementations, remote handles accept a broader character set.
+A **remote handle** identifies a user on another fediverse instance
+(e.g. `@bob@mastodon.social`, `@user@ꩰ.com`). Remote handles are
+discovered via WebFinger ([RFC 7033](https://tools.ietf.org/html/rfc7033))
+using the `acct:` URI scheme defined by
+[RFC 7565](https://tools.ietf.org/html/rfc7565), where both the
+userpart and the host are UTF-8.
 
-| Rule               | Value                       |
-| :----------------- | :-------------------------- |
-| Allowed characters | `a-z`, `0-9`, `_`, `.`, `-` |
-| Minimum length     | 1                           |
-| Maximum length     | 30                          |
+To remain federation-compatible with Mastodon, Pleroma, Misskey,
+GoToSocial, and other ActivityPub implementations — many of which allow
+Unicode usernames and IDN domains — Mastic accepts a broader character
+set for remote handles.
 
-**Regex**: `^[a-z0-9_.-]{1,30}$`
+### Userpart
+
+| Rule               | Value                                              |
+| :----------------- | :------------------------------------------------- |
+| Allowed characters | Unicode letters, Unicode numbers, `_`, `.`, `-`    |
+| Minimum length     | 1                                                  |
+| Maximum length     | 64 Unicode scalar values                           |
+| Case sensitivity   | Compared case-insensitively (Unicode-aware fold)   |
+
+**Pattern** (PCRE-style): `^[\p{L}\p{N}_.\-]{1,64}$`.
+
+Punctuation other than `_`, `.`, `-` is rejected. Whitespace and control
+characters are rejected.
+
+### Host (domain)
+
+The host is treated as an
+[Internationalized Domain Name](https://datatracker.ietf.org/doc/html/rfc5890)
+(IDN). Unicode domains such as `ꩰ.com` are accepted; for storage and
+comparison the host is normalized to its ASCII Compatible Encoding
+(Punycode, [UTS #46](https://www.unicode.org/reports/tr46/)).
+
+| Rule               | Value                                              |
+| :----------------- | :------------------------------------------------- |
+| Input form         | U-label (Unicode) or A-label (Punycode/ACE)        |
+| Stored form        | A-label (lowercase, ASCII)                         |
+| Maximum length     | 253 octets in A-label form (DNS limit)             |
+
+### Storage
+
+Remote handles are stored in canonical form
+`<unicode_userpart>@<ace_domain>`, with the userpart Unicode-lowercased
+and the domain in lowercase A-label form. Two handles compare equal iff
+their canonical forms are byte-equal.
+
+> **Implementation note.** Mastic does not yet perform IDN normalization
+> at runtime; remote handles arriving with Unicode hosts are accepted
+> but stored as received. Punycode normalization will be wired into the
+> federation canister alongside WebFinger lookup (tracked separately).
 
 ## Reserved Handles
 

--- a/docs/src/specs/hashtags.md
+++ b/docs/src/specs/hashtags.md
@@ -15,23 +15,32 @@ across the instance.
 A **tag** is the text portion of a hashtag, stripped of the leading `#`.
 For example, the hashtag `#rust` has tag `rust`.
 
-| Rule               | Value                       |
-| :----------------- | :-------------------------- |
-| Allowed characters | `a-z`, `0-9`, `_`           |
-| Minimum length     | 1                           |
-| Maximum length     | 30 Unicode scalar values    |
-| Case sensitivity   | Case-insensitive            |
-| Storage            | Stored as lowercase, no `#` |
+| Rule               | Value                                                  |
+| :----------------- | :----------------------------------------------------- |
+| Allowed characters | Unicode letters, Unicode numbers, `_`                  |
+| Minimum length     | 1                                                      |
+| Maximum length     | 30 Unicode scalar values                               |
+| Case sensitivity   | Case-insensitive (Unicode-aware lowercasing)           |
+| Storage            | Stored as lowercase, no `#`                            |
 
-**Regex**: `^[a-z0-9_]{1,30}$`
+**Pattern** (PCRE-style): `^[\p{L}\p{N}_]{1,30}$`, with the additional
+constraint that no character may be in uppercase form after sanitization.
 
 Underscores are allowed in any position, including leading, trailing, and
-consecutive.
+consecutive. Cased Unicode letters (Latin, Greek, Cyrillic, etc.) are
+folded to lowercase by the sanitizer; non-cased scripts (Han, Arabic,
+Myanmar, etc.) are accepted as-is.
 
-Hyphens (`-`), dots (`.`), whitespace, and any non-ASCII characters are
-**not** allowed. Strict ASCII enforcement keeps the uniqueness constraint
-on the `hashtags.tag` column well-defined and avoids Unicode
-normalization ambiguity.
+Hyphens (`-`), dots (`.`), whitespace, punctuation, and emoji are **not**
+allowed.
+
+### Unicode normalization
+
+Mastic does **not** currently apply Unicode Normalization Form C (NFC) to
+incoming tags. Producers SHOULD send tags in NFC form. Two visually
+identical tags that differ only in normalization (e.g. precomposed `é`
+vs `e + COMBINING ACUTE`) will be treated as distinct values until
+normalization is added (tracked separately).
 
 ## Sanitization
 
@@ -46,17 +55,21 @@ validation to fail.
 
 ### Examples
 
-| Input          | Sanitized | Valid |
-| :------------- | :-------- | :---- |
-| `rust`         | `rust`    | yes   |
-| `Rust`         | `rust`    | yes   |
-| `  #Rust  `    | `rust`    | yes   |
-| `web3`         | `web3`    | yes   |
-| `rust_lang`    | `rust_lang` | yes |
-| `rust-lang`    | `rust-lang` | no (hyphen) |
-| `#rust#2`      | `rust#2`  | no (`#` in middle) |
-| `` (empty)     | ``        | no (too short) |
-| `a` × 31       | `a` × 31  | no (too long) |
+| Input         | Sanitized   | Valid              |
+| :------------ | :---------- | :----------------- |
+| `rust`        | `rust`      | yes                |
+| `Rust`        | `rust`      | yes                |
+| `  #Rust  `   | `rust`      | yes                |
+| `web3`        | `web3`      | yes                |
+| `rust_lang`   | `rust_lang` | yes                |
+| `汉字`        | `汉字`      | yes (Han)          |
+| `Café`        | `café`      | yes                |
+| `Ελληνικά`    | `ελληνικά`  | yes (Greek)        |
+| `rust-lang`   | `rust-lang` | no (hyphen)        |
+| `#rust#2`     | `rust#2`    | no (`#` in middle) |
+| `🦀`          | `🦀`        | no (emoji)         |
+| `` (empty)    | ``          | no (too short)     |
+| `a` × 31      | `a` × 31    | no (too long)      |
 
 ## Implementation
 

--- a/docs/src/user.did
+++ b/docs/src/user.did
@@ -108,6 +108,17 @@ type GetFollowersError = variant {
 };
 // Response type for the `get_followers` method.
 type GetFollowersResponse = variant { Ok : vec text; Err : GetFollowersError };
+// Request arguments for the `get_liked` method.
+type GetLikedArgs = record {
+  // Number of results to skip (for pagination).
+  offset : nat64;
+  // Maximum number of results to return.
+  limit : nat64;
+};
+// Error types for the `get_liked` method.
+type GetLikedError = variant { Internal : text };
+// Response type for the `get_liked` method.
+type GetLikedResponse = variant { Ok : vec text; Err : GetLikedError };
 // Error types for the `get_profile` method.
 type GetProfileError = variant {
   // Internal error occurred while fetching the profile.
@@ -117,13 +128,6 @@ type GetProfileError = variant {
 };
 // Response type for the `get_profile` method.
 type GetProfileResponse = variant { Ok : UserProfile; Err : GetProfileError };
-// Request arguments for the `get_statuses` method.
-type GetStatusesArgs = record {
-  // Number of results to skip (for pagination).
-  offset : nat64;
-  // Maximum number of results to return.
-  limit : nat64;
-};
 // Error types for the `get_statuses` method.
 type GetStatusesError = variant {
   // Internal error occurred while fetching statuses.
@@ -133,6 +137,13 @@ type GetStatusesError = variant {
 };
 // Response type for the `get_statuses` method.
 type GetStatusesResponse = variant { Ok : vec Status; Err : GetStatusesError };
+// Request arguments for the `like_status` method.
+type LikeStatusArgs = record {
+  // ActivityPub URI of the status to like.
+  status_url : text;
+};
+// Response type for the `like_status` method.
+type LikeStatusResponse = variant { Ok; Err : GetLikedError };
 // Request arguments for the `publish_status` method.
 type PublishStatusArgs = record {
   // The text content of the new post.
@@ -162,13 +173,6 @@ type PublishStatusError = variant {
 // Response type for the `publish_status` method.
 // On success, returns the created [`Status`] with its assigned ID and timestamp.
 type PublishStatusResponse = variant { Ok : Status; Err : PublishStatusError };
-// Request arguments for the `read_feed` method.
-type ReadFeedArgs = record {
-  // Number of results to skip (for pagination).
-  offset : nat64;
-  // Maximum number of results to return.
-  limit : nat64;
-};
 // Error types for the `read_feed` method.
 type ReadFeedError = variant {
   // Internal error occurred while reading the feed.
@@ -202,20 +206,17 @@ type Status = record {
   id : nat64;
   // The text content of the status.
   content : text;
+  // Cached count of `Like` activities received for this status.
+  like_count : nat64;
   // Timestamp (milliseconds since epoch) of when the status was created.
   created_at : nat64;
   // The actor URI of the status author (e.g. `https://mastic.social/users/alice`).
   author : text;
   // The visibility setting of the status, controlling its audience.
   visibility : Visibility;
+  // Cached count of `Announce` (boost) activities received for this status.
+  boost_count : nat64;
 };
-// Error types for the `unfollow_user` method.
-type UnfollowUserError = variant {
-  // Internal error occurred while processing the unfollow request.
-  Internal : text;
-};
-// Response type for the `unfollow_user` method.
-type UnfollowUserResponse = variant { Ok; Err : UnfollowUserError };
 // Request arguments for the `update_profile` method.
 // All fields are optional; only provided fields are updated.
 type UpdateProfileArgs = record {
@@ -278,12 +279,15 @@ service : (UserInstallArgs) -> {
     ) query;
   get_followers : (GetFollowersArgs) -> (GetFollowersResponse) query;
   get_following : (GetFollowersArgs) -> (GetFollowersResponse) query;
+  get_liked : (GetLikedArgs) -> (GetLikedResponse) query;
   get_profile : () -> (GetProfileResponse) query;
-  get_statuses : (GetStatusesArgs) -> (GetStatusesResponse) composite_query;
+  get_statuses : (GetLikedArgs) -> (GetStatusesResponse) composite_query;
+  like_status : (LikeStatusArgs) -> (LikeStatusResponse);
   publish_status : (PublishStatusArgs) -> (PublishStatusResponse);
-  read_feed : (ReadFeedArgs) -> (ReadFeedResponse) query;
+  read_feed : (GetLikedArgs) -> (ReadFeedResponse) query;
   receive_activity : (ReceiveActivityArgs) -> (ReceiveActivityResponse);
   reject_follow : (AcceptFollowArgs) -> (AcceptFollowResponse);
-  unfollow_user : (AcceptFollowArgs) -> (UnfollowUserResponse);
-  update_profile : (UpdateProfileArgs) -> (UnfollowUserResponse);
+  unfollow_user : (AcceptFollowArgs) -> (LikeStatusResponse);
+  unlike_status : (LikeStatusArgs) -> (LikeStatusResponse);
+  update_profile : (UpdateProfileArgs) -> (LikeStatusResponse);
 }

--- a/integration-tests/src/user_client.rs
+++ b/integration-tests/src/user_client.rs
@@ -3,9 +3,10 @@ use did::common::Visibility;
 use did::user::{
     AcceptFollowArgs, AcceptFollowResponse, FollowUserArgs, FollowUserResponse,
     GetFollowRequestsArgs, GetFollowRequestsResponse, GetFollowersArgs, GetFollowersResponse,
-    GetFollowingArgs, GetFollowingResponse, GetProfileResponse, GetStatusesArgs,
-    GetStatusesResponse, PublishStatusArgs, PublishStatusResponse, ReadFeedArgs, ReadFeedResponse,
-    RejectFollowArgs, RejectFollowResponse, UnfollowUserArgs, UnfollowUserResponse,
+    GetFollowingArgs, GetFollowingResponse, GetLikedArgs, GetLikedResponse, GetProfileResponse,
+    GetStatusesArgs, GetStatusesResponse, LikeStatusArgs, LikeStatusResponse, PublishStatusArgs,
+    PublishStatusResponse, ReadFeedArgs, ReadFeedResponse, RejectFollowArgs, RejectFollowResponse,
+    UnfollowUserArgs, UnfollowUserResponse, UnlikeStatusArgs, UnlikeStatusResponse,
     UpdateProfileArgs, UpdateProfileResponse,
 };
 use pocket_ic_harness::PocketIcTestEnv;
@@ -211,6 +212,52 @@ impl UserClient<'_> {
             )
             .await
             .expect("Failed to call get_statuses")
+    }
+
+    pub async fn like_status(&self, caller: Principal, status_url: String) -> LikeStatusResponse {
+        let args = LikeStatusArgs { status_url };
+
+        self.env
+            .update(
+                self.canister_id,
+                caller,
+                "like_status",
+                Encode!(&args).expect("Failed to encode like_status arguments"),
+            )
+            .await
+            .expect("Failed to call like_status")
+    }
+
+    pub async fn unlike_status(
+        &self,
+        caller: Principal,
+        status_url: String,
+    ) -> UnlikeStatusResponse {
+        let args = UnlikeStatusArgs { status_url };
+
+        self.env
+            .update(
+                self.canister_id,
+                caller,
+                "unlike_status",
+                Encode!(&args).expect("Failed to encode unlike_status arguments"),
+            )
+            .await
+            .expect("Failed to call unlike_status")
+    }
+
+    pub async fn get_liked(&self, caller: Principal, offset: u64, limit: u64) -> GetLikedResponse {
+        let args = GetLikedArgs { offset, limit };
+
+        self.env
+            .query(
+                self.canister_id,
+                caller,
+                "get_liked",
+                Encode!(&args).expect("Failed to encode get_liked arguments"),
+            )
+            .await
+            .expect("Failed to call get_liked")
     }
 
     pub async fn update_profile(

--- a/integration-tests/tests/like.rs
+++ b/integration-tests/tests/like.rs
@@ -1,0 +1,170 @@
+use did::common::Visibility;
+use did::user::{
+    GetLikedResponse, GetStatusesResponse, LikeStatusResponse, PublishStatusResponse,
+    UnlikeStatusResponse,
+};
+use integration_tests::helpers::{follow_and_accept, sign_up_user};
+use integration_tests::{MasticCanisterSetup, PUBLIC_URL, UserClient};
+use pocket_ic_harness::{PocketIcTestEnv, alice, bob};
+
+fn status_uri(handle: &str, id: u64) -> String {
+    format!("{PUBLIC_URL}/users/{handle}/statuses/{id}")
+}
+
+/// Publish a public status as `bob` and return its assigned id.
+async fn publish_bob_status(
+    env: &PocketIcTestEnv<MasticCanisterSetup>,
+    bob_canister: candid::Principal,
+) -> u64 {
+    let bob_client = UserClient::new(env, bob_canister);
+    let resp = bob_client
+        .publish_status(bob(), "hello".to_string(), Visibility::Public, vec![])
+        .await;
+    let PublishStatusResponse::Ok(status) = resp else {
+        panic!("publish_status failed: {resp:?}");
+    };
+    status.id
+}
+
+#[pocket_ic_harness::test]
+async fn test_should_like_status_and_increment_count(env: PocketIcTestEnv<MasticCanisterSetup>) {
+    let bob_canister = sign_up_user(&env, bob(), "bob".to_string()).await;
+    let alice_canister =
+        follow_and_accept(&env, alice(), "alice", bob(), bob_canister, "bob").await;
+
+    let alice_client = UserClient::new(&env, alice_canister);
+    let bob_client = UserClient::new(&env, bob_canister);
+
+    let bob_status_id = publish_bob_status(&env, bob_canister).await;
+    let bob_status_uri = status_uri("bob", bob_status_id);
+
+    // alice likes bob's status
+    assert_eq!(
+        alice_client
+            .like_status(alice(), bob_status_uri.clone())
+            .await,
+        LikeStatusResponse::Ok
+    );
+
+    // alice's liked collection contains the URI
+    let GetLikedResponse::Ok(liked) = alice_client.get_liked(alice(), 0, 10).await else {
+        panic!("get_liked failed");
+    };
+    assert_eq!(liked, vec![bob_status_uri.clone()]);
+
+    // bob's status now reports like_count = 1
+    let GetStatusesResponse::Ok(bob_statuses) = bob_client.get_statuses(bob(), 0, 10).await else {
+        panic!("get_statuses failed");
+    };
+    assert_eq!(bob_statuses.len(), 1);
+    assert_eq!(bob_statuses[0].id, bob_status_id);
+    assert_eq!(bob_statuses[0].like_count, 1);
+}
+
+#[pocket_ic_harness::test]
+async fn test_should_be_idempotent_when_liking_twice(env: PocketIcTestEnv<MasticCanisterSetup>) {
+    let bob_canister = sign_up_user(&env, bob(), "bob".to_string()).await;
+    let alice_canister =
+        follow_and_accept(&env, alice(), "alice", bob(), bob_canister, "bob").await;
+
+    let alice_client = UserClient::new(&env, alice_canister);
+    let bob_client = UserClient::new(&env, bob_canister);
+
+    let bob_status_id = publish_bob_status(&env, bob_canister).await;
+    let bob_status_uri = status_uri("bob", bob_status_id);
+
+    // first like
+    assert_eq!(
+        alice_client
+            .like_status(alice(), bob_status_uri.clone())
+            .await,
+        LikeStatusResponse::Ok
+    );
+    // second like (idempotent)
+    assert_eq!(
+        alice_client
+            .like_status(alice(), bob_status_uri.clone())
+            .await,
+        LikeStatusResponse::Ok
+    );
+
+    // alice's liked list contains a single entry
+    let GetLikedResponse::Ok(liked) = alice_client.get_liked(alice(), 0, 10).await else {
+        panic!("get_liked failed");
+    };
+    assert_eq!(liked, vec![bob_status_uri]);
+
+    // bob's status like_count incremented exactly once
+    let GetStatusesResponse::Ok(bob_statuses) = bob_client.get_statuses(bob(), 0, 10).await else {
+        panic!("get_statuses failed");
+    };
+    assert_eq!(bob_statuses[0].like_count, 1);
+}
+
+#[pocket_ic_harness::test]
+async fn test_should_unlike_status_and_decrement_count(env: PocketIcTestEnv<MasticCanisterSetup>) {
+    let bob_canister = sign_up_user(&env, bob(), "bob".to_string()).await;
+    let alice_canister =
+        follow_and_accept(&env, alice(), "alice", bob(), bob_canister, "bob").await;
+
+    let alice_client = UserClient::new(&env, alice_canister);
+    let bob_client = UserClient::new(&env, bob_canister);
+
+    let bob_status_id = publish_bob_status(&env, bob_canister).await;
+    let bob_status_uri = status_uri("bob", bob_status_id);
+
+    // like, then unlike
+    assert_eq!(
+        alice_client
+            .like_status(alice(), bob_status_uri.clone())
+            .await,
+        LikeStatusResponse::Ok
+    );
+    assert_eq!(
+        alice_client
+            .unlike_status(alice(), bob_status_uri.clone())
+            .await,
+        UnlikeStatusResponse::Ok
+    );
+
+    // alice's liked list is empty
+    let GetLikedResponse::Ok(liked) = alice_client.get_liked(alice(), 0, 10).await else {
+        panic!("get_liked failed");
+    };
+    assert!(liked.is_empty());
+
+    // bob's status like_count back to 0
+    let GetStatusesResponse::Ok(bob_statuses) = bob_client.get_statuses(bob(), 0, 10).await else {
+        panic!("get_statuses failed");
+    };
+    assert_eq!(bob_statuses[0].like_count, 0);
+}
+
+#[pocket_ic_harness::test]
+async fn test_should_succeed_unlike_when_not_liked(env: PocketIcTestEnv<MasticCanisterSetup>) {
+    let bob_canister = sign_up_user(&env, bob(), "bob".to_string()).await;
+    let alice_canister =
+        follow_and_accept(&env, alice(), "alice", bob(), bob_canister, "bob").await;
+
+    let alice_client = UserClient::new(&env, alice_canister);
+    let bob_client = UserClient::new(&env, bob_canister);
+
+    let bob_status_id = publish_bob_status(&env, bob_canister).await;
+    let bob_status_uri = status_uri("bob", bob_status_id);
+
+    // unlike without prior like — silent no-op
+    assert_eq!(
+        alice_client.unlike_status(alice(), bob_status_uri).await,
+        UnlikeStatusResponse::Ok
+    );
+
+    let GetLikedResponse::Ok(liked) = alice_client.get_liked(alice(), 0, 10).await else {
+        panic!("get_liked failed");
+    };
+    assert!(liked.is_empty());
+
+    let GetStatusesResponse::Ok(bob_statuses) = bob_client.get_statuses(bob(), 0, 10).await else {
+        panic!("get_statuses failed");
+    };
+    assert_eq!(bob_statuses[0].like_count, 0);
+}


### PR DESCRIPTION
## Summary

- Implements `like_status`, `unlike_status` and `get_liked` on the User Canister with idempotent semantics and federation dispatch (`Like` / `Undo(Like)`).
- Adds `handle_incoming` cases for inbound `Like` and `Undo(Like)` that adjust the cached `like_count` on local statuses (best-effort, validates URI host + handle, saturating decrement).
- Exposes `like_count` and `boost_count` on the `did::common::Status` DTO so callers can render counters; updates the typed Candid spec accordingly.

Closes #17

## Test plan

- [x] `just check_code` (nightly fmt + clippy `-D warnings`)
- [x] `just build_all` produces all three wasm artifacts
- [x] `just test` — 289 user-canister unit tests pass, including new tests in `liked/{like,unlike,get_liked}.rs`, `urls.rs`, and 6 new `handle_incoming` cases (local Like, Undo(Like), remote-target ignore, mismatched-handle ignore, missing-status no-op, saturating decrement)
- [x] `just integration_test` — full integration suite green, plus 4 new tests in `integration-tests/tests/like.rs`:
  - like + count incremented and liked list contains the URI
  - double-like idempotency (single liked entry, like_count == 1)
  - unlike decrements count back to 0 and clears liked list
  - unlike-without-prior-like is a silent no-op

## Notes

- Federation `send_activity` already routes opaque JSON to the target inbox, so no Like-specific code was needed there.
- The User Canister cannot authoritatively prove that an inbound `Like` references a status it owns beyond URI matching — `handle_like` ignores remote URIs and mismatched handles, and falls through silently when the target id is missing. The cached `like_count` is therefore a hint, not a reconciled total. Documented inline in the handler.