### PR TITLE
feat(user): WI-1.7 boost/undo + repo refactor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,5 +28,6 @@ docs/book/
 .claude/plans/
 .claude/settings.local.json
 .claude/specs/
+.claude/*.lock
 
 docs/superpowers/

--- a/crates/canisters/directory/src/domain/moderators.rs
+++ b/crates/canisters/directory/src/domain/moderators.rs
@@ -1,5 +1,6 @@
 //! Moderation functions for the Directory canister.
 
+use db_utils::repository::Repository;
 mod repository;
 
 use candid::Principal;

--- a/crates/canisters/directory/src/domain/moderators.rs
+++ b/crates/canisters/directory/src/domain/moderators.rs
@@ -10,21 +10,21 @@ use crate::error::CanisterResult;
 /// Adds a moderator to the directory canister.
 pub fn add_moderator(principal: Principal) -> CanisterResult<()> {
     ic_utils::log!("add_moderator: adding {principal}");
-    ModeratorsRepository::add_moderator(principal)
+    ModeratorsRepository::oneshot().add_moderator(principal)
 }
 
 /// Returns true if the given principal is a moderator, false otherwise.
 #[cfg_attr(not(test), expect(dead_code))]
 pub fn is_moderator(principal: Principal) -> CanisterResult<bool> {
     ic_utils::log!("is_moderator: checking {principal}");
-    ModeratorsRepository::is_moderator(principal)
+    ModeratorsRepository::oneshot().is_moderator(principal)
 }
 
 /// Removes a moderator from the directory canister.
 #[cfg_attr(not(test), expect(dead_code))]
 pub fn remove_moderator(principal: Principal) -> CanisterResult<()> {
     ic_utils::log!("remove_moderator: removing {principal}");
-    ModeratorsRepository::remove_moderator(principal)
+    ModeratorsRepository::oneshot().remove_moderator(principal)
 }
 
 #[cfg(test)]

--- a/crates/canisters/directory/src/domain/moderators/repository.rs
+++ b/crates/canisters/directory/src/domain/moderators/repository.rs
@@ -1,23 +1,46 @@
 //! Moderators repository for the directory canister.
 
 use candid::Principal;
-use ic_dbms_canister::prelude::DBMS_CONTEXT;
+use ic_dbms_canister::prelude::{DBMS_CONTEXT, IcAccessControlList, IcMemoryProvider};
 use wasm_dbms::WasmDbmsDatabase;
+use wasm_dbms::prelude::DbmsContext;
 use wasm_dbms_api::prelude::*;
 
 use crate::error::{CanisterError, CanisterResult};
 use crate::schema::{Moderator, ModeratorInsertRequest, Schema};
 
-pub struct ModeratorsRepository;
+pub struct ModeratorsRepository {
+    tx: Option<TransactionId>,
+}
 
 impl ModeratorsRepository {
+    pub const fn oneshot() -> Self {
+        Self { tx: None }
+    }
+
+    // Reserved for future cross-repo atomic flows that need to splice moderator
+    // reads/writes into an externally-driven transaction. Not yet wired up.
+    #[allow(dead_code)]
+    pub const fn with_transaction(tx: TransactionId) -> Self {
+        Self { tx: Some(tx) }
+    }
+
+    fn db<'a>(
+        &self,
+        ctx: &'a DbmsContext<IcMemoryProvider, IcAccessControlList>,
+    ) -> WasmDbmsDatabase<'a, IcMemoryProvider, IcAccessControlList> {
+        match self.tx {
+            Some(id) => WasmDbmsDatabase::from_transaction(ctx, Schema, id),
+            None => WasmDbmsDatabase::oneshot(ctx, Schema),
+        }
+    }
+
     /// Adds a moderator to the directory canister.
-    pub fn add_moderator(principal: Principal) -> CanisterResult<()> {
+    pub fn add_moderator(&self, principal: Principal) -> CanisterResult<()> {
         ic_utils::log!("ModeratorsRepository::add_moderator: inserting {principal}");
         DBMS_CONTEXT
             .with(|ctx| {
-                let db = WasmDbmsDatabase::oneshot(ctx, Schema);
-                db.insert::<Moderator>(ModeratorInsertRequest {
+                self.db(ctx).insert::<Moderator>(ModeratorInsertRequest {
                     principal: ic_dbms_canister::prelude::Principal(principal),
                     created_at: ic_utils::now().into(),
                 })
@@ -26,11 +49,10 @@ impl ModeratorsRepository {
     }
 
     /// Returns true if the given principal is a moderator, false otherwise.
-    pub fn is_moderator(principal: Principal) -> CanisterResult<bool> {
+    pub fn is_moderator(&self, principal: Principal) -> CanisterResult<bool> {
         let principal = ic_dbms_canister::prelude::Principal(principal);
         DBMS_CONTEXT.with(|ctx| {
-            let db = WasmDbmsDatabase::oneshot(ctx, Schema);
-            let rows = db.select::<Moderator>(
+            let rows = self.db(ctx).select::<Moderator>(
                 Query::builder()
                     .and_where(Filter::eq("principal", Value::from(principal)))
                     .limit(1)
@@ -41,13 +63,12 @@ impl ModeratorsRepository {
     }
 
     /// Removes a moderator from the directory canister.
-    pub fn remove_moderator(principal: Principal) -> CanisterResult<()> {
+    pub fn remove_moderator(&self, principal: Principal) -> CanisterResult<()> {
         ic_utils::log!("ModeratorsRepository::remove_moderator: removing {principal}");
         let principal = ic_dbms_canister::prelude::Principal(principal);
         DBMS_CONTEXT
             .with(|ctx| {
-                let db = WasmDbmsDatabase::oneshot(ctx, Schema);
-                db.delete::<Moderator>(
+                self.db(ctx).delete::<Moderator>(
                     DeleteBehavior::Cascade,
                     Some(Filter::eq("principal", Value::from(principal))),
                 )
@@ -67,10 +88,14 @@ mod tests {
     fn test_should_add_and_check_moderator() {
         setup();
 
-        ModeratorsRepository::add_moderator(rey_canisteryo()).expect("should add moderator");
+        ModeratorsRepository::oneshot()
+            .add_moderator(rey_canisteryo())
+            .expect("should add moderator");
 
         assert!(
-            ModeratorsRepository::is_moderator(rey_canisteryo()).expect("should check moderator")
+            ModeratorsRepository::oneshot()
+                .is_moderator(rey_canisteryo())
+                .expect("should check moderator")
         );
     }
 
@@ -78,11 +103,17 @@ mod tests {
     fn test_should_remove_moderator() {
         setup();
 
-        ModeratorsRepository::add_moderator(rey_canisteryo()).expect("should add moderator");
-        ModeratorsRepository::remove_moderator(rey_canisteryo()).expect("should remove moderator");
+        ModeratorsRepository::oneshot()
+            .add_moderator(rey_canisteryo())
+            .expect("should add moderator");
+        ModeratorsRepository::oneshot()
+            .remove_moderator(rey_canisteryo())
+            .expect("should remove moderator");
 
         assert!(
-            !ModeratorsRepository::is_moderator(rey_canisteryo()).expect("should check moderator")
+            !ModeratorsRepository::oneshot()
+                .is_moderator(rey_canisteryo())
+                .expect("should check moderator")
         );
     }
 
@@ -91,7 +122,9 @@ mod tests {
         setup();
 
         assert!(
-            !ModeratorsRepository::is_moderator(rey_canisteryo()).expect("should check moderator")
+            !ModeratorsRepository::oneshot()
+                .is_moderator(rey_canisteryo())
+                .expect("should check moderator")
         );
     }
 }

--- a/crates/canisters/directory/src/domain/moderators/repository.rs
+++ b/crates/canisters/directory/src/domain/moderators/repository.rs
@@ -1,9 +1,8 @@
 //! Moderators repository for the directory canister.
 
 use candid::Principal;
-use ic_dbms_canister::prelude::{DBMS_CONTEXT, IcAccessControlList, IcMemoryProvider};
-use wasm_dbms::WasmDbmsDatabase;
-use wasm_dbms::prelude::DbmsContext;
+use db_utils::repository::Repository;
+use ic_dbms_canister::prelude::DBMS_CONTEXT;
 use wasm_dbms_api::prelude::*;
 
 use crate::error::{CanisterError, CanisterResult};
@@ -14,27 +13,6 @@ pub struct ModeratorsRepository {
 }
 
 impl ModeratorsRepository {
-    pub const fn oneshot() -> Self {
-        Self { tx: None }
-    }
-
-    // Reserved for future cross-repo atomic flows that need to splice moderator
-    // reads/writes into an externally-driven transaction. Not yet wired up.
-    #[allow(dead_code)]
-    pub const fn with_transaction(tx: TransactionId) -> Self {
-        Self { tx: Some(tx) }
-    }
-
-    fn db<'a>(
-        &self,
-        ctx: &'a DbmsContext<IcMemoryProvider, IcAccessControlList>,
-    ) -> WasmDbmsDatabase<'a, IcMemoryProvider, IcAccessControlList> {
-        match self.tx {
-            Some(id) => WasmDbmsDatabase::from_transaction(ctx, Schema, id),
-            None => WasmDbmsDatabase::oneshot(ctx, Schema),
-        }
-    }
-
     /// Adds a moderator to the directory canister.
     pub fn add_moderator(&self, principal: Principal) -> CanisterResult<()> {
         ic_utils::log!("ModeratorsRepository::add_moderator: inserting {principal}");
@@ -75,6 +53,26 @@ impl ModeratorsRepository {
             })
             .map(|_| ())
             .map_err(CanisterError::from)
+    }
+}
+
+impl Repository for ModeratorsRepository {
+    type Schema = Schema;
+
+    fn schema() -> Self::Schema {
+        Schema
+    }
+
+    fn oneshot() -> Self {
+        Self { tx: None }
+    }
+
+    fn with_transaction(tx: TransactionId) -> Self {
+        Self { tx: Some(tx) }
+    }
+
+    fn tx(&self) -> Option<TransactionId> {
+        self.tx
     }
 }
 

--- a/crates/canisters/directory/src/domain/tombstone/repository.rs
+++ b/crates/canisters/directory/src/domain/tombstone/repository.rs
@@ -1,9 +1,8 @@
 //! Tombstone repository
 
 use candid::Principal;
-use ic_dbms_canister::prelude::{DBMS_CONTEXT, IcAccessControlList, IcMemoryProvider};
-use wasm_dbms::WasmDbmsDatabase;
-use wasm_dbms::prelude::DbmsContext;
+use db_utils::repository::Repository;
+use ic_dbms_canister::prelude::DBMS_CONTEXT;
 use wasm_dbms_api::prelude::{Database as _, Filter, Query, TransactionId};
 
 use crate::error::CanisterResult;
@@ -18,27 +17,6 @@ pub struct TombstoneRepository {
 }
 
 impl TombstoneRepository {
-    pub const fn oneshot() -> Self {
-        Self { tx: None }
-    }
-
-    // Reserved for future cross-repo atomic flows that need to splice tombstone
-    // reads/writes into an externally-driven transaction. Not yet wired up.
-    #[allow(dead_code)]
-    pub const fn with_transaction(tx: TransactionId) -> Self {
-        Self { tx: Some(tx) }
-    }
-
-    fn db<'a>(
-        &self,
-        ctx: &'a DbmsContext<IcMemoryProvider, IcAccessControlList>,
-    ) -> WasmDbmsDatabase<'a, IcMemoryProvider, IcAccessControlList> {
-        match self.tx {
-            Some(id) => WasmDbmsDatabase::from_transaction(ctx, Schema, id),
-            None => WasmDbmsDatabase::oneshot(ctx, Schema),
-        }
-    }
-
     /// Inserts a [`Tombstone`] record for the given user principal and handle.
     pub fn insert_or_update(
         &self,
@@ -104,6 +82,26 @@ impl TombstoneRepository {
         let deleted_at = row.deleted_at.expect("must be set").0;
 
         Ok(ic_utils::now() - deleted_at < TOMBSTONE_TTL_SECONDS)
+    }
+}
+
+impl Repository for TombstoneRepository {
+    type Schema = Schema;
+
+    fn schema() -> Self::Schema {
+        Schema
+    }
+
+    fn oneshot() -> Self {
+        Self { tx: None }
+    }
+
+    fn with_transaction(tx: TransactionId) -> Self {
+        Self { tx: Some(tx) }
+    }
+
+    fn tx(&self) -> Option<TransactionId> {
+        self.tx
     }
 }
 

--- a/crates/canisters/directory/src/domain/tombstone/repository.rs
+++ b/crates/canisters/directory/src/domain/tombstone/repository.rs
@@ -1,9 +1,10 @@
 //! Tombstone repository
 
 use candid::Principal;
-use ic_dbms_canister::prelude::DBMS_CONTEXT;
+use ic_dbms_canister::prelude::{DBMS_CONTEXT, IcAccessControlList, IcMemoryProvider};
 use wasm_dbms::WasmDbmsDatabase;
-use wasm_dbms_api::prelude::{Database as _, Filter, Query};
+use wasm_dbms::prelude::DbmsContext;
+use wasm_dbms_api::prelude::{Database as _, Filter, Query, TransactionId};
 
 use crate::error::CanisterResult;
 use crate::schema::{Schema, Tombstone, TombstoneInsertRequest, TombstoneUpdateRequest};
@@ -12,16 +13,43 @@ use crate::schema::{Schema, Tombstone, TombstoneInsertRequest, TombstoneUpdateRe
 const TOMBSTONE_TTL_SECONDS: u64 = 60 * 60 * 24 * 30;
 
 /// Repository for managing tombstone records of deleted user profiles.
-pub struct TombstoneRepository;
+pub struct TombstoneRepository {
+    tx: Option<TransactionId>,
+}
 
 impl TombstoneRepository {
+    pub const fn oneshot() -> Self {
+        Self { tx: None }
+    }
+
+    // Reserved for future cross-repo atomic flows that need to splice tombstone
+    // reads/writes into an externally-driven transaction. Not yet wired up.
+    #[allow(dead_code)]
+    pub const fn with_transaction(tx: TransactionId) -> Self {
+        Self { tx: Some(tx) }
+    }
+
+    fn db<'a>(
+        &self,
+        ctx: &'a DbmsContext<IcMemoryProvider, IcAccessControlList>,
+    ) -> WasmDbmsDatabase<'a, IcMemoryProvider, IcAccessControlList> {
+        match self.tx {
+            Some(id) => WasmDbmsDatabase::from_transaction(ctx, Schema, id),
+            None => WasmDbmsDatabase::oneshot(ctx, Schema),
+        }
+    }
+
     /// Inserts a [`Tombstone`] record for the given user principal and handle.
-    pub fn insert_or_update(user_principal: Principal, handle: String) -> CanisterResult<()> {
+    pub fn insert_or_update(
+        &self,
+        user_principal: Principal,
+        handle: String,
+    ) -> CanisterResult<()> {
         ic_utils::log!(
             "TombstoneRepository::insert: inserting tombstone for user {user_principal} with handle {handle}"
         );
 
-        if Self::is_tombstoned(&handle)? {
+        if self.is_tombstoned(&handle)? {
             ic_utils::log!(
                 "TombstoneRepository::insert: existing tombstone found for handle {handle}, updating deleted_at timestamp"
             );
@@ -32,10 +60,7 @@ impl TombstoneRepository {
                 ..Default::default()
             };
 
-            DBMS_CONTEXT.with(|ctx| {
-                let dbms = WasmDbmsDatabase::oneshot(ctx, Schema);
-                dbms.update::<Tombstone>(update_request)
-            })?;
+            DBMS_CONTEXT.with(|ctx| self.db(ctx).update::<Tombstone>(update_request))?;
         } else {
             ic_utils::log!(
                 "TombstoneRepository::insert: no existing tombstone found for handle {handle}, inserting new record"
@@ -47,23 +72,19 @@ impl TombstoneRepository {
                 deleted_at: ic_utils::now().into(),
             };
 
-            DBMS_CONTEXT.with(|ctx| {
-                let dbms = WasmDbmsDatabase::oneshot(ctx, Schema);
-                dbms.insert::<Tombstone>(insert)
-            })?;
+            DBMS_CONTEXT.with(|ctx| self.db(ctx).insert::<Tombstone>(insert))?;
         }
 
         Ok(())
     }
 
     /// Checks if a given handle is currently tombstoned (i.e. has a tombstone record with a `deleted_at` timestamp within the TTL).
-    pub fn is_tombstoned(handle: &str) -> CanisterResult<bool> {
+    pub fn is_tombstoned(&self, handle: &str) -> CanisterResult<bool> {
         ic_utils::log!(
             "TombstoneRepository::is_tombstoned: checking if handle {handle} is tombstoned"
         );
         let rows = DBMS_CONTEXT.with(|ctx| {
-            let dbms = WasmDbmsDatabase::oneshot(ctx, Schema);
-            dbms.select::<Tombstone>(
+            self.db(ctx).select::<Tombstone>(
                 Query::builder()
                     .field("deleted_at")
                     .limit(1)
@@ -83,5 +104,37 @@ impl TombstoneRepository {
         let deleted_at = row.deleted_at.expect("must be set").0;
 
         Ok(ic_utils::now() - deleted_at < TOMBSTONE_TTL_SECONDS)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_utils::{bob, setup};
+
+    #[test]
+    fn test_is_tombstoned_returns_false_for_unknown_handle() {
+        setup();
+
+        assert!(
+            !TombstoneRepository::oneshot()
+                .is_tombstoned("nobody")
+                .expect("should query")
+        );
+    }
+
+    #[test]
+    fn test_insert_or_update_then_is_tombstoned() {
+        setup();
+
+        TombstoneRepository::oneshot()
+            .insert_or_update(bob(), "bob".to_string())
+            .expect("should insert tombstone");
+
+        assert!(
+            TombstoneRepository::oneshot()
+                .is_tombstoned("bob")
+                .expect("should query")
+        );
     }
 }

--- a/crates/canisters/directory/src/domain/users/delete_profile.rs
+++ b/crates/canisters/directory/src/domain/users/delete_profile.rs
@@ -57,7 +57,7 @@ pub fn delete_profile(caller: Principal) -> DeleteProfileResponse {
 
     let handle = user.handle.0.clone();
 
-    if let Err(err) = TombstoneRepository::insert_or_update(caller, handle.clone()) {
+    if let Err(err) = TombstoneRepository::oneshot().insert_or_update(caller, handle.clone()) {
         ic_utils::log!("delete_profile: failed to insert tombstone for {caller}: {err}");
         return DeleteProfileResponse::Err(DeleteProfileError::Internal(err.to_string()));
     }
@@ -201,7 +201,11 @@ mod tests {
             .expect("user should still exist pre-commit");
         assert_eq!(user.canister_status.0, UserCanisterStatus::DeletionPending);
 
-        assert!(TombstoneRepository::is_tombstoned("bob").expect("should query tombstone"));
+        assert!(
+            TombstoneRepository::oneshot()
+                .is_tombstoned("bob")
+                .expect("should query tombstone")
+        );
     }
 
     #[test]

--- a/crates/canisters/directory/src/domain/users/delete_profile.rs
+++ b/crates/canisters/directory/src/domain/users/delete_profile.rs
@@ -1,5 +1,6 @@
 //! Domain logic for deleting a user's profile and associated User Canister.
 
+use db_utils::repository::Repository;
 mod state;
 
 use candid::Principal;

--- a/crates/canisters/directory/src/domain/users/delete_profile.rs
+++ b/crates/canisters/directory/src/domain/users/delete_profile.rs
@@ -29,7 +29,7 @@ pub fn delete_profile(caller: Principal) -> DeleteProfileResponse {
         return DeleteProfileResponse::Err(DeleteProfileError::AnonymousPrincipal);
     }
 
-    let user = match UserRepository::get_user_by_principal(caller) {
+    let user = match UserRepository::oneshot().get_user_by_principal(caller) {
         Ok(Some(user)) => user,
         Ok(None) => {
             ic_utils::log!("delete_profile: user {caller} not registered");
@@ -62,7 +62,7 @@ pub fn delete_profile(caller: Principal) -> DeleteProfileResponse {
         return DeleteProfileResponse::Err(DeleteProfileError::Internal(err.to_string()));
     }
 
-    if let Err(err) = UserRepository::mark_user_for_deletion(caller) {
+    if let Err(err) = UserRepository::oneshot().mark_user_for_deletion(caller) {
         ic_utils::log!("delete_profile: failed to mark user {caller} for deletion: {err}");
         return DeleteProfileResponse::Err(DeleteProfileError::Internal(err.to_string()));
     }
@@ -86,7 +86,7 @@ pub fn retry_delete_profile(caller: Principal) -> RetryDeleteProfileResponse {
         return RetryDeleteProfileResponse::Err(RetryDeleteProfileError::NotRegistered);
     }
 
-    let user = match UserRepository::get_user_by_principal(caller) {
+    let user = match UserRepository::oneshot().get_user_by_principal(caller) {
         Ok(Some(user)) => user,
         Ok(None) => {
             ic_utils::log!("retry_delete_profile: user {caller} not registered");
@@ -178,7 +178,9 @@ mod tests {
     #[test]
     fn test_should_reject_when_canister_not_active() {
         setup();
-        UserRepository::sign_up(bob(), "bob".to_string()).expect("should sign up");
+        UserRepository::oneshot()
+            .sign_up(bob(), "bob".to_string())
+            .expect("should sign up");
 
         let response = delete_profile(bob());
 
@@ -196,7 +198,8 @@ mod tests {
         let response = delete_profile(bob());
         assert_eq!(response, DeleteProfileResponse::Ok);
 
-        let user = UserRepository::get_user_by_principal(bob())
+        let user = UserRepository::oneshot()
+            .get_user_by_principal(bob())
             .expect("should query user")
             .expect("user should still exist pre-commit");
         assert_eq!(user.canister_status.0, UserCanisterStatus::DeletionPending);

--- a/crates/canisters/directory/src/domain/users/delete_profile/state.rs
+++ b/crates/canisters/directory/src/domain/users/delete_profile/state.rs
@@ -10,6 +10,7 @@ use std::collections::HashMap;
 use std::time::Duration;
 
 use candid::Principal;
+use db_utils::repository::Repository;
 
 use crate::adapters::management_canister::ManagementCanister;
 use crate::adapters::user_canister::UserCanister;

--- a/crates/canisters/directory/src/domain/users/delete_profile/state.rs
+++ b/crates/canisters/directory/src/domain/users/delete_profile/state.rs
@@ -201,7 +201,7 @@ where
     }
 
     fn commit(&self) -> crate::error::CanisterResult<()> {
-        UserRepository::remove_user(self.user_id)
+        UserRepository::oneshot().remove_user(self.user_id)
     }
 
     fn finish(&self) {
@@ -414,15 +414,17 @@ mod tests {
     #[tokio::test]
     async fn test_commit_removes_user_row() {
         setup();
-        UserRepository::sign_up(rey_canisteryo(), "alice".to_string())
+        UserRepository::oneshot()
+            .sign_up(rey_canisteryo(), "alice".to_string())
             .expect("should sign up user");
 
         let sm = machine(TestManagementClient::ok(), TestUserCanisterClient::ok());
 
         sm.commit().expect("commit should succeed");
 
-        let user =
-            UserRepository::get_user_by_principal(rey_canisteryo()).expect("should query user");
+        let user = UserRepository::oneshot()
+            .get_user_by_principal(rey_canisteryo())
+            .expect("should query user");
         assert!(user.is_none());
     }
 
@@ -473,7 +475,8 @@ mod tests {
     #[tokio::test]
     async fn test_step_finishes_on_successful_commit() {
         setup();
-        UserRepository::sign_up(rey_canisteryo(), "alice".to_string())
+        UserRepository::oneshot()
+            .sign_up(rey_canisteryo(), "alice".to_string())
             .expect("should sign up user");
 
         let sm = machine(TestManagementClient::ok(), TestUserCanisterClient::ok());

--- a/crates/canisters/directory/src/domain/users/get_user.rs
+++ b/crates/canisters/directory/src/domain/users/get_user.rs
@@ -2,6 +2,7 @@
 
 use candid::Principal;
 use db_utils::handle::{HandleSanitizer, HandleValidator};
+use db_utils::repository::Repository;
 use did::directory::{GetUser, GetUserArgs, GetUserError, GetUserResponse};
 
 use crate::domain::users::repository::UserRepository;

--- a/crates/canisters/directory/src/domain/users/get_user.rs
+++ b/crates/canisters/directory/src/domain/users/get_user.rs
@@ -41,7 +41,10 @@ fn lookup_by_handle(handle: &str) -> Result<User, GetUserError> {
         return Err(GetUserError::InvalidHandle);
     }
 
-    resolve_user(UserRepository::get_user_by_handle(&handle), &handle)
+    resolve_user(
+        UserRepository::oneshot().get_user_by_handle(&handle),
+        &handle,
+    )
 }
 
 /// Look up a user by their IC principal.
@@ -49,7 +52,7 @@ fn lookup_by_principal(principal: Principal) -> Result<User, GetUserError> {
     ic_utils::log!("get_user: looking up user by principal {principal}");
 
     resolve_user(
-        UserRepository::get_user_by_principal(principal),
+        UserRepository::oneshot().get_user_by_principal(principal),
         &principal.to_string(),
     )
 }

--- a/crates/canisters/directory/src/domain/users/repository.rs
+++ b/crates/canisters/directory/src/domain/users/repository.rs
@@ -1,8 +1,9 @@
 //! User repository
 
 use candid::Principal;
-use ic_dbms_canister::prelude::DBMS_CONTEXT;
+use ic_dbms_canister::prelude::{DBMS_CONTEXT, IcAccessControlList, IcMemoryProvider};
 use wasm_dbms::WasmDbmsDatabase;
+use wasm_dbms::prelude::DbmsContext;
 use wasm_dbms_api::prelude::*;
 
 use crate::error::{CanisterError, CanisterResult};
@@ -11,13 +12,36 @@ use crate::schema::{
 };
 
 /// Repository for user-related database operations.
-pub struct UserRepository;
+pub struct UserRepository {
+    tx: Option<TransactionId>,
+}
 
 impl UserRepository {
+    pub const fn oneshot() -> Self {
+        Self { tx: None }
+    }
+
+    // Reserved for future cross-repo atomic flows that need to splice user
+    // reads/writes into an externally-driven transaction. Not yet wired up.
+    #[allow(dead_code)]
+    pub const fn with_transaction(tx: TransactionId) -> Self {
+        Self { tx: Some(tx) }
+    }
+
+    fn db<'a>(
+        &self,
+        ctx: &'a DbmsContext<IcMemoryProvider, IcAccessControlList>,
+    ) -> WasmDbmsDatabase<'a, IcMemoryProvider, IcAccessControlList> {
+        match self.tx {
+            Some(id) => WasmDbmsDatabase::from_transaction(ctx, Schema, id),
+            None => WasmDbmsDatabase::oneshot(ctx, Schema),
+        }
+    }
+
     /// Signs up a new user by creating a canister for them and storing their information in the database.
     ///
     /// The user canister is set to Null and the creation state is marked to pending.
-    pub fn sign_up(user_principal: Principal, handle: String) -> CanisterResult<()> {
+    pub fn sign_up(&self, user_principal: Principal, handle: String) -> CanisterResult<()> {
         ic_utils::log!(
             "UserRepository::sign_up: inserting user {user_principal} with handle {handle:?}"
         );
@@ -32,10 +56,7 @@ impl UserRepository {
             created_at: ic_utils::now().into(),
         };
 
-        DBMS_CONTEXT.with(|ctx| {
-            let dbms = WasmDbmsDatabase::oneshot(ctx, Schema);
-            dbms.insert::<User>(insert)
-        })?;
+        DBMS_CONTEXT.with(|ctx| self.db(ctx).insert::<User>(insert))?;
 
         ic_utils::log!("UserRepository::sign_up: user {user_principal} inserted successfully");
 
@@ -44,6 +65,7 @@ impl UserRepository {
 
     /// Sets the canister ID for a user after successful canister creation and updates their canister status to active.
     pub fn set_user_canister(
+        &self,
         user_principal: Principal,
         canister_id: Principal,
     ) -> CanisterResult<()> {
@@ -64,10 +86,7 @@ impl UserRepository {
             ..Default::default()
         };
 
-        let rows = DBMS_CONTEXT.with(|ctx| {
-            let dbms = WasmDbmsDatabase::oneshot(ctx, Schema);
-            dbms.update::<User>(update)
-        })?;
+        let rows = DBMS_CONTEXT.with(|ctx| self.db(ctx).update::<User>(update))?;
 
         if rows == 0 {
             ic_utils::log!(
@@ -86,7 +105,7 @@ impl UserRepository {
     }
 
     /// Sets the user canister status to creation failed if the canister creation process fails for a user.
-    pub fn set_failed_user_canister_create(user_principal: Principal) -> CanisterResult<()> {
+    pub fn set_failed_user_canister_create(&self, user_principal: Principal) -> CanisterResult<()> {
         ic_utils::log!(
             "UserRepository::set_failed_user_canister_create: marking user {user_principal} as failed"
         );
@@ -101,10 +120,7 @@ impl UserRepository {
             ..Default::default()
         };
 
-        let rows = DBMS_CONTEXT.with(|ctx| {
-            let dbms = WasmDbmsDatabase::oneshot(ctx, Schema);
-            dbms.update::<User>(update)
-        })?;
+        let rows = DBMS_CONTEXT.with(|ctx| self.db(ctx).update::<User>(update))?;
 
         if rows == 0 {
             ic_utils::log!(
@@ -123,7 +139,7 @@ impl UserRepository {
     }
 
     /// Sets the user canister status to creation failed if the canister creation process fails for a user.
-    pub fn retry_user_canister_creation(user_principal: Principal) -> CanisterResult<()> {
+    pub fn retry_user_canister_creation(&self, user_principal: Principal) -> CanisterResult<()> {
         ic_utils::log!(
             "UserRepository::retry_user_canister_creation: retrying for user {user_principal}"
         );
@@ -138,10 +154,7 @@ impl UserRepository {
             ..Default::default()
         };
 
-        let rows = DBMS_CONTEXT.with(|ctx| {
-            let dbms = WasmDbmsDatabase::oneshot(ctx, Schema);
-            dbms.update::<User>(update)
-        })?;
+        let rows = DBMS_CONTEXT.with(|ctx| self.db(ctx).update::<User>(update))?;
 
         if rows == 0 {
             ic_utils::log!(
@@ -160,11 +173,10 @@ impl UserRepository {
     }
 
     /// Retrieves a user's information from the database by their principal.
-    pub fn get_user_by_principal(user_principal: Principal) -> CanisterResult<Option<User>> {
+    pub fn get_user_by_principal(&self, user_principal: Principal) -> CanisterResult<Option<User>> {
         ic_utils::log!("UserRepository::get_user_by_principal: querying user {user_principal}");
         let rows = DBMS_CONTEXT.with(|ctx| {
-            let dbms = WasmDbmsDatabase::oneshot(ctx, Schema);
-            dbms.select::<User>(
+            self.db(ctx).select::<User>(
                 Query::builder()
                     .all()
                     .limit(1)
@@ -185,11 +197,10 @@ impl UserRepository {
     }
 
     /// Retrieves a user's information from the database by their handle.
-    pub fn get_user_by_handle(handle: &str) -> CanisterResult<Option<User>> {
+    pub fn get_user_by_handle(&self, handle: &str) -> CanisterResult<Option<User>> {
         ic_utils::log!("UserRepository::get_user_by_handle: querying handle {handle:?}");
         let rows = DBMS_CONTEXT.with(|ctx| {
-            let dbms = WasmDbmsDatabase::oneshot(ctx, Schema);
-            dbms.select::<User>(
+            self.db(ctx).select::<User>(
                 Query::builder()
                     .all()
                     .limit(1)
@@ -208,7 +219,7 @@ impl UserRepository {
 
     /// Marks a user for deletion by setting their canister status to deletion pending.
     /// The actual deletion of the user record and User Canister is handled asynchronously by the state machine.
-    pub fn mark_user_for_deletion(user_principal: Principal) -> CanisterResult<()> {
+    pub fn mark_user_for_deletion(&self, user_principal: Principal) -> CanisterResult<()> {
         ic_utils::log!(
             "UserRepository::mark_user_for_deletion: marking user {user_principal} for deletion"
         );
@@ -222,10 +233,7 @@ impl UserRepository {
             )),
             ..Default::default()
         };
-        let rows = DBMS_CONTEXT.with(|ctx| {
-            let dbms = WasmDbmsDatabase::oneshot(ctx, Schema);
-            dbms.update::<User>(update)
-        })?;
+        let rows = DBMS_CONTEXT.with(|ctx| self.db(ctx).update::<User>(update))?;
 
         if rows == 0 {
             return Err(CanisterError::SignUpFailed(format!(
@@ -238,12 +246,11 @@ impl UserRepository {
 
     /// Removes a user record from the database. Called by the delete_profile state machine
     /// after the user canister has been stopped and deleted.
-    pub fn remove_user(user_principal: Principal) -> CanisterResult<()> {
+    pub fn remove_user(&self, user_principal: Principal) -> CanisterResult<()> {
         ic_utils::log!("UserRepository::remove_user: removing user {user_principal}");
 
         let deleted = DBMS_CONTEXT.with(|ctx| {
-            let dbms = WasmDbmsDatabase::oneshot(ctx, Schema);
-            dbms.delete::<User>(
+            self.db(ctx).delete::<User>(
                 DeleteBehavior::Restrict,
                 Some(Filter::eq(
                     User::primary_key(),
@@ -264,13 +271,17 @@ impl UserRepository {
     /// Searches for user profiles based on a query string that matches the handle, with pagination support using offset and limit.
     ///
     /// Search only those which are `Active` and have a canister id.
-    pub fn search_profiles(handle: &str, offset: usize, limit: usize) -> CanisterResult<Vec<User>> {
+    pub fn search_profiles(
+        &self,
+        handle: &str,
+        offset: usize,
+        limit: usize,
+    ) -> CanisterResult<Vec<User>> {
         ic_utils::log!(
             "UserRepository::search_profiles: searching for handle {handle:?} with offset {offset} and limit {limit}"
         );
         let rows = DBMS_CONTEXT.with(|ctx| {
-            let dbms = WasmDbmsDatabase::oneshot(ctx, Schema);
-            dbms.select::<User>(
+            self.db(ctx).select::<User>(
                 Query::builder()
                     .all()
                     .offset(offset)
@@ -307,6 +318,8 @@ impl UserRepository {
 #[cfg(test)]
 mod tests {
 
+    use db_utils::transaction::Transaction;
+
     use super::*;
     use crate::test_utils::{bob, rey_canisteryo, setup};
 
@@ -314,10 +327,12 @@ mod tests {
     fn test_should_sign_up_user() {
         setup();
 
-        UserRepository::sign_up(rey_canisteryo(), "rey_canisteryo".to_string())
+        UserRepository::oneshot()
+            .sign_up(rey_canisteryo(), "rey_canisteryo".to_string())
             .expect("should sign up user");
 
-        let user = UserRepository::get_user_by_principal(rey_canisteryo())
+        let user = UserRepository::oneshot()
+            .get_user_by_principal(rey_canisteryo())
             .expect("should query user")
             .expect("user should exist");
 
@@ -334,10 +349,11 @@ mod tests {
     fn test_should_reject_duplicate_principal_on_sign_up() {
         setup();
 
-        UserRepository::sign_up(rey_canisteryo(), "rey_canisteryo".to_string())
+        UserRepository::oneshot()
+            .sign_up(rey_canisteryo(), "rey_canisteryo".to_string())
             .expect("should sign up user");
 
-        let result = UserRepository::sign_up(rey_canisteryo(), "alice2".to_string());
+        let result = UserRepository::oneshot().sign_up(rey_canisteryo(), "alice2".to_string());
         assert!(result.is_err(), "duplicate principal should be rejected");
     }
 
@@ -345,10 +361,11 @@ mod tests {
     fn test_should_reject_duplicate_handle_on_sign_up() {
         setup();
 
-        UserRepository::sign_up(rey_canisteryo(), "rey_canisteryo".to_string())
+        UserRepository::oneshot()
+            .sign_up(rey_canisteryo(), "rey_canisteryo".to_string())
             .expect("should sign up user");
 
-        let result = UserRepository::sign_up(bob(), "rey_canisteryo".to_string());
+        let result = UserRepository::oneshot().sign_up(bob(), "rey_canisteryo".to_string());
         assert!(result.is_err(), "duplicate handle should be rejected");
     }
 
@@ -356,14 +373,17 @@ mod tests {
     fn test_should_set_user_canister() {
         setup();
 
-        UserRepository::sign_up(rey_canisteryo(), "rey_canisteryo".to_string())
+        UserRepository::oneshot()
+            .sign_up(rey_canisteryo(), "rey_canisteryo".to_string())
             .expect("should sign up user");
 
         let canister_id = bob();
-        UserRepository::set_user_canister(rey_canisteryo(), canister_id)
+        UserRepository::oneshot()
+            .set_user_canister(rey_canisteryo(), canister_id)
             .expect("should set user canister");
 
-        let user = UserRepository::get_user_by_principal(rey_canisteryo())
+        let user = UserRepository::oneshot()
+            .get_user_by_principal(rey_canisteryo())
             .expect("should query user")
             .expect("user should exist");
 
@@ -381,7 +401,7 @@ mod tests {
     fn test_should_fail_set_user_canister_for_unknown_principal() {
         setup();
 
-        let result = UserRepository::set_user_canister(rey_canisteryo(), bob());
+        let result = UserRepository::oneshot().set_user_canister(rey_canisteryo(), bob());
         assert!(result.is_err(), "should fail for unknown principal");
     }
 
@@ -389,13 +409,16 @@ mod tests {
     fn test_should_set_failed_user_canister_create() {
         setup();
 
-        UserRepository::sign_up(rey_canisteryo(), "rey_canisteryo".to_string())
+        UserRepository::oneshot()
+            .sign_up(rey_canisteryo(), "rey_canisteryo".to_string())
             .expect("should sign up user");
 
-        UserRepository::set_failed_user_canister_create(rey_canisteryo())
+        UserRepository::oneshot()
+            .set_failed_user_canister_create(rey_canisteryo())
             .expect("should set canister creation failed");
 
-        let user = UserRepository::get_user_by_principal(rey_canisteryo())
+        let user = UserRepository::oneshot()
+            .get_user_by_principal(rey_canisteryo())
             .expect("should query user")
             .expect("user should exist");
 
@@ -409,7 +432,7 @@ mod tests {
     fn test_should_fail_set_failed_canister_create_for_unknown_principal() {
         setup();
 
-        let result = UserRepository::set_failed_user_canister_create(rey_canisteryo());
+        let result = UserRepository::oneshot().set_failed_user_canister_create(rey_canisteryo());
         assert!(result.is_err(), "should fail for unknown principal");
     }
 
@@ -417,16 +440,20 @@ mod tests {
     fn test_should_retry_user_canister_creation() {
         setup();
 
-        UserRepository::sign_up(rey_canisteryo(), "rey_canisteryo".to_string())
+        UserRepository::oneshot()
+            .sign_up(rey_canisteryo(), "rey_canisteryo".to_string())
             .expect("should sign up user");
 
-        UserRepository::set_failed_user_canister_create(rey_canisteryo())
+        UserRepository::oneshot()
+            .set_failed_user_canister_create(rey_canisteryo())
             .expect("should set canister creation failed");
 
-        UserRepository::retry_user_canister_creation(rey_canisteryo())
+        UserRepository::oneshot()
+            .retry_user_canister_creation(rey_canisteryo())
             .expect("should retry user canister creation");
 
-        let user = UserRepository::get_user_by_principal(rey_canisteryo())
+        let user = UserRepository::oneshot()
+            .get_user_by_principal(rey_canisteryo())
             .expect("should query user")
             .expect("user should exist");
 
@@ -440,10 +467,12 @@ mod tests {
     fn test_should_get_user_by_principal() {
         setup();
 
-        UserRepository::sign_up(rey_canisteryo(), "rey_canisteryo".to_string())
+        UserRepository::oneshot()
+            .sign_up(rey_canisteryo(), "rey_canisteryo".to_string())
             .expect("should sign up user");
 
-        let user = UserRepository::get_user_by_principal(rey_canisteryo())
+        let user = UserRepository::oneshot()
+            .get_user_by_principal(rey_canisteryo())
             .expect("should query user")
             .expect("user should exist");
 
@@ -455,8 +484,9 @@ mod tests {
     fn test_should_return_none_for_unknown_principal() {
         setup();
 
-        let user =
-            UserRepository::get_user_by_principal(rey_canisteryo()).expect("should query user");
+        let user = UserRepository::oneshot()
+            .get_user_by_principal(rey_canisteryo())
+            .expect("should query user");
         assert!(user.is_none(), "should return None for unknown principal");
     }
 
@@ -464,10 +494,12 @@ mod tests {
     fn test_should_get_user_by_handle() {
         setup();
 
-        UserRepository::sign_up(rey_canisteryo(), "rey_canisteryo".to_string())
+        UserRepository::oneshot()
+            .sign_up(rey_canisteryo(), "rey_canisteryo".to_string())
             .expect("should sign up user");
 
-        let user = UserRepository::get_user_by_handle("rey_canisteryo")
+        let user = UserRepository::oneshot()
+            .get_user_by_handle("rey_canisteryo")
             .expect("should query user")
             .expect("user should exist");
 
@@ -479,7 +511,9 @@ mod tests {
     fn test_should_return_none_for_unknown_handle() {
         setup();
 
-        let user = UserRepository::get_user_by_handle("nonexistent").expect("should query");
+        let user = UserRepository::oneshot()
+            .get_user_by_handle("nonexistent")
+            .expect("should query");
         assert!(user.is_none(), "should return None for unknown handle");
     }
 
@@ -518,10 +552,11 @@ mod tests {
     /// Seeds two Active users named `alice` and `alicia`, both with a canister id.
     /// Used by tests that exercise matching/pagination behavior.
     fn seed_two_active_alikes() {
-        UserRepository::sign_up(alice_user(), "alice".to_string()).unwrap();
-        UserRepository::set_user_canister(alice_user(), canister(100)).unwrap();
-        UserRepository::sign_up(other_user(), "alicia".to_string()).unwrap();
-        UserRepository::set_user_canister(other_user(), canister(101)).unwrap();
+        let repo = UserRepository::oneshot();
+        repo.sign_up(alice_user(), "alice".to_string()).unwrap();
+        repo.set_user_canister(alice_user(), canister(100)).unwrap();
+        repo.sign_up(other_user(), "alicia".to_string()).unwrap();
+        repo.set_user_canister(other_user(), canister(101)).unwrap();
     }
 
     #[test]
@@ -529,7 +564,9 @@ mod tests {
         setup();
         seed_two_active_alikes();
 
-        let users = UserRepository::search_profiles("alice", 0, 50).expect("search should succeed");
+        let users = UserRepository::oneshot()
+            .search_profiles("alice", 0, 50)
+            .expect("search should succeed");
         let handles: Vec<_> = users.iter().map(|u| u.handle.0.as_str()).collect();
         assert!(handles.contains(&"alice"));
     }
@@ -539,7 +576,9 @@ mod tests {
         setup();
         seed_two_active_alikes();
 
-        let users = UserRepository::search_profiles("ali", 0, 50).expect("search should succeed");
+        let users = UserRepository::oneshot()
+            .search_profiles("ali", 0, 50)
+            .expect("search should succeed");
         let handles: Vec<_> = users.iter().map(|u| u.handle.0.as_str()).collect();
         assert!(handles.contains(&"alice"));
         assert!(handles.contains(&"alicia"));
@@ -551,7 +590,9 @@ mod tests {
         setup();
         seed_two_active_alikes();
 
-        let users = UserRepository::search_profiles("lic", 0, 50).expect("search should succeed");
+        let users = UserRepository::oneshot()
+            .search_profiles("lic", 0, 50)
+            .expect("search should succeed");
         let handles: Vec<_> = users.iter().map(|u| u.handle.0.as_str()).collect();
         assert!(handles.contains(&"alice"));
         assert!(handles.contains(&"alicia"));
@@ -562,7 +603,9 @@ mod tests {
         setup();
         seed_two_active_alikes();
 
-        let users = UserRepository::search_profiles("", 0, 50).expect("search should succeed");
+        let users = UserRepository::oneshot()
+            .search_profiles("", 0, 50)
+            .expect("search should succeed");
         assert_eq!(users.len(), 2);
     }
 
@@ -571,14 +614,20 @@ mod tests {
         setup();
         seed_two_active_alikes();
 
-        let page1 = UserRepository::search_profiles("", 0, 1).expect("search should succeed");
+        let page1 = UserRepository::oneshot()
+            .search_profiles("", 0, 1)
+            .expect("search should succeed");
         assert_eq!(page1.len(), 1);
 
-        let page2 = UserRepository::search_profiles("", 1, 1).expect("search should succeed");
+        let page2 = UserRepository::oneshot()
+            .search_profiles("", 1, 1)
+            .expect("search should succeed");
         assert_eq!(page2.len(), 1);
         assert_ne!(page1[0].handle.0, page2[0].handle.0);
 
-        let page3 = UserRepository::search_profiles("", 2, 1).expect("search should succeed");
+        let page3 = UserRepository::oneshot()
+            .search_profiles("", 2, 1)
+            .expect("search should succeed");
         assert!(page3.is_empty());
     }
 
@@ -587,8 +636,9 @@ mod tests {
         setup();
         seed_two_active_alikes();
 
-        let users =
-            UserRepository::search_profiles("zorblax", 0, 50).expect("search should succeed");
+        let users = UserRepository::oneshot()
+            .search_profiles("zorblax", 0, 50)
+            .expect("search should succeed");
         assert!(users.is_empty());
     }
 
@@ -596,41 +646,202 @@ mod tests {
     fn test_search_profiles_should_exclude_creation_pending() {
         setup();
         // CreationPending: signed up, no canister set yet.
-        UserRepository::sign_up(alice_user(), "alice".to_string()).unwrap();
+        UserRepository::oneshot()
+            .sign_up(alice_user(), "alice".to_string())
+            .unwrap();
 
-        let users = UserRepository::search_profiles("alice", 0, 50).expect("search should succeed");
+        let users = UserRepository::oneshot()
+            .search_profiles("alice", 0, 50)
+            .expect("search should succeed");
         assert!(users.is_empty(), "CreationPending users must be excluded");
     }
 
     #[test]
     fn test_search_profiles_should_exclude_creation_failed() {
         setup();
-        UserRepository::sign_up(alice_user(), "alice".to_string()).unwrap();
-        UserRepository::set_failed_user_canister_create(alice_user()).unwrap();
+        UserRepository::oneshot()
+            .sign_up(alice_user(), "alice".to_string())
+            .unwrap();
+        UserRepository::oneshot()
+            .set_failed_user_canister_create(alice_user())
+            .unwrap();
 
-        let users = UserRepository::search_profiles("alice", 0, 50).expect("search should succeed");
+        let users = UserRepository::oneshot()
+            .search_profiles("alice", 0, 50)
+            .expect("search should succeed");
         assert!(users.is_empty(), "CreationFailed users must be excluded");
     }
 
     #[test]
     fn test_search_profiles_should_exclude_deletion_pending() {
         setup();
-        UserRepository::sign_up(alice_user(), "alice".to_string()).unwrap();
-        UserRepository::set_user_canister(alice_user(), canister(100)).unwrap();
-        UserRepository::mark_user_for_deletion(alice_user()).unwrap();
+        UserRepository::oneshot()
+            .sign_up(alice_user(), "alice".to_string())
+            .unwrap();
+        UserRepository::oneshot()
+            .set_user_canister(alice_user(), canister(100))
+            .unwrap();
+        UserRepository::oneshot()
+            .mark_user_for_deletion(alice_user())
+            .unwrap();
 
-        let users = UserRepository::search_profiles("alice", 0, 50).expect("search should succeed");
+        let users = UserRepository::oneshot()
+            .search_profiles("alice", 0, 50)
+            .expect("search should succeed");
         assert!(users.is_empty(), "DeletionPending users must be excluded");
     }
 
     #[test]
     fn test_search_profiles_should_exclude_suspended() {
         setup();
-        UserRepository::sign_up(alice_user(), "alice".to_string()).unwrap();
-        UserRepository::set_user_canister(alice_user(), canister(100)).unwrap();
+        UserRepository::oneshot()
+            .sign_up(alice_user(), "alice".to_string())
+            .unwrap();
+        UserRepository::oneshot()
+            .set_user_canister(alice_user(), canister(100))
+            .unwrap();
         set_canister_status(alice_user(), did::directory::UserCanisterStatus::Suspended);
 
-        let users = UserRepository::search_profiles("alice", 0, 50).expect("search should succeed");
+        let users = UserRepository::oneshot()
+            .search_profiles("alice", 0, 50)
+            .expect("search should succeed");
         assert!(users.is_empty(), "Suspended users must be excluded");
+    }
+
+    // Transaction-aware tests: validate that callers can splice repository
+    // operations into an externally-driven transaction (commit + rollback).
+
+    #[test]
+    fn test_should_sign_up_user_in_transaction_and_commit() {
+        setup();
+
+        Transaction::run::<_, _, _, CanisterError>(Schema, |tx| {
+            UserRepository::with_transaction(tx)
+                .sign_up(rey_canisteryo(), "rey_canisteryo".to_string())
+        })
+        .expect("transaction should commit");
+
+        let user = UserRepository::oneshot()
+            .get_user_by_principal(rey_canisteryo())
+            .expect("should query user")
+            .expect("user should exist after commit");
+        assert_eq!(user.handle.0, "rey_canisteryo");
+    }
+
+    #[test]
+    fn test_should_rollback_sign_up_when_transaction_errors() {
+        setup();
+
+        let result: Result<(), CanisterError> = Transaction::run(Schema, |tx| {
+            UserRepository::with_transaction(tx)
+                .sign_up(rey_canisteryo(), "rey_canisteryo".to_string())?;
+            Err(CanisterError::Internal("boom".to_string()))
+        });
+        assert!(result.is_err());
+
+        let user = UserRepository::oneshot()
+            .get_user_by_principal(rey_canisteryo())
+            .expect("should query user");
+        assert!(
+            user.is_none(),
+            "user must not persist when transaction rolls back"
+        );
+    }
+
+    #[test]
+    fn test_should_atomically_sign_up_and_set_canister_in_one_transaction() {
+        setup();
+
+        Transaction::run::<_, _, _, CanisterError>(Schema, |tx| {
+            let repo = UserRepository::with_transaction(tx);
+            repo.sign_up(rey_canisteryo(), "rey_canisteryo".to_string())?;
+            repo.set_user_canister(rey_canisteryo(), bob())
+        })
+        .expect("transaction should commit");
+
+        let user = UserRepository::oneshot()
+            .get_user_by_principal(rey_canisteryo())
+            .expect("should query user")
+            .expect("user should exist after commit");
+
+        let Nullable::Value(cid) = user.canister_id else {
+            panic!("canister_id should be set");
+        };
+        assert_eq!(cid.0, bob());
+        assert_eq!(
+            did::directory::UserCanisterStatus::from(user.canister_status),
+            did::directory::UserCanisterStatus::Active
+        );
+    }
+
+    #[test]
+    fn test_should_rollback_combined_writes_when_second_step_errors() {
+        setup();
+
+        // First do a valid sign_up.
+        UserRepository::oneshot()
+            .sign_up(rey_canisteryo(), "rey_canisteryo".to_string())
+            .expect("should sign up user");
+
+        // Now try a tx that updates canister id and then errors. The update
+        // must not be visible after rollback.
+        let result: Result<(), CanisterError> = Transaction::run(Schema, |tx| {
+            UserRepository::with_transaction(tx).set_user_canister(rey_canisteryo(), bob())?;
+            Err(CanisterError::Internal("boom".to_string()))
+        });
+        assert!(result.is_err());
+
+        let user = UserRepository::oneshot()
+            .get_user_by_principal(rey_canisteryo())
+            .expect("should query user")
+            .expect("user must still exist");
+        assert!(
+            user.canister_id.is_null(),
+            "canister update must roll back on tx error"
+        );
+        assert_eq!(
+            did::directory::UserCanisterStatus::from(user.canister_status),
+            did::directory::UserCanisterStatus::CreationPending,
+            "status must roll back on tx error"
+        );
+    }
+
+    #[test]
+    fn test_should_remove_user_in_transaction() {
+        setup();
+
+        UserRepository::oneshot()
+            .sign_up(rey_canisteryo(), "rey_canisteryo".to_string())
+            .expect("should sign up user");
+
+        Transaction::run::<_, _, _, CanisterError>(Schema, |tx| {
+            UserRepository::with_transaction(tx).remove_user(rey_canisteryo())
+        })
+        .expect("transaction should commit");
+
+        let user = UserRepository::oneshot()
+            .get_user_by_principal(rey_canisteryo())
+            .expect("should query user");
+        assert!(user.is_none(), "user must be removed after commit");
+    }
+
+    #[test]
+    fn test_should_rollback_remove_user_when_transaction_errors() {
+        setup();
+
+        UserRepository::oneshot()
+            .sign_up(rey_canisteryo(), "rey_canisteryo".to_string())
+            .expect("should sign up user");
+
+        let result: Result<(), CanisterError> = Transaction::run(Schema, |tx| {
+            UserRepository::with_transaction(tx).remove_user(rey_canisteryo())?;
+            Err(CanisterError::Internal("boom".to_string()))
+        });
+        assert!(result.is_err());
+
+        let user = UserRepository::oneshot()
+            .get_user_by_principal(rey_canisteryo())
+            .expect("should query user");
+        assert!(user.is_some(), "user must persist when tx rolls back");
     }
 }

--- a/crates/canisters/directory/src/domain/users/repository.rs
+++ b/crates/canisters/directory/src/domain/users/repository.rs
@@ -1,9 +1,8 @@
 //! User repository
 
 use candid::Principal;
-use ic_dbms_canister::prelude::{DBMS_CONTEXT, IcAccessControlList, IcMemoryProvider};
-use wasm_dbms::WasmDbmsDatabase;
-use wasm_dbms::prelude::DbmsContext;
+use db_utils::repository::Repository;
+use ic_dbms_canister::prelude::DBMS_CONTEXT;
 use wasm_dbms_api::prelude::*;
 
 use crate::error::{CanisterError, CanisterResult};
@@ -17,27 +16,6 @@ pub struct UserRepository {
 }
 
 impl UserRepository {
-    pub const fn oneshot() -> Self {
-        Self { tx: None }
-    }
-
-    // Reserved for future cross-repo atomic flows that need to splice user
-    // reads/writes into an externally-driven transaction. Not yet wired up.
-    #[allow(dead_code)]
-    pub const fn with_transaction(tx: TransactionId) -> Self {
-        Self { tx: Some(tx) }
-    }
-
-    fn db<'a>(
-        &self,
-        ctx: &'a DbmsContext<IcMemoryProvider, IcAccessControlList>,
-    ) -> WasmDbmsDatabase<'a, IcMemoryProvider, IcAccessControlList> {
-        match self.tx {
-            Some(id) => WasmDbmsDatabase::from_transaction(ctx, Schema, id),
-            None => WasmDbmsDatabase::oneshot(ctx, Schema),
-        }
-    }
-
     /// Signs up a new user by creating a canister for them and storing their information in the database.
     ///
     /// The user canister is set to Null and the creation state is marked to pending.
@@ -315,10 +293,32 @@ impl UserRepository {
     }
 }
 
+impl Repository for UserRepository {
+    type Schema = Schema;
+
+    fn schema() -> Self::Schema {
+        Schema
+    }
+
+    fn oneshot() -> Self {
+        Self { tx: None }
+    }
+
+    fn with_transaction(tx: TransactionId) -> Self {
+        Self { tx: Some(tx) }
+    }
+
+    fn tx(&self) -> Option<TransactionId> {
+        self.tx
+    }
+}
+
 #[cfg(test)]
 mod tests {
 
+    use db_utils::repository::Repository;
     use db_utils::transaction::Transaction;
+    use wasm_dbms::WasmDbmsDatabase;
 
     use super::*;
     use crate::test_utils::{bob, rey_canisteryo, setup};

--- a/crates/canisters/directory/src/domain/users/search_profiles.rs
+++ b/crates/canisters/directory/src/domain/users/search_profiles.rs
@@ -17,6 +17,7 @@
 //! - Empty queries return all Active users, paginated.
 
 use db_utils::handle::HandleSanitizer;
+use db_utils::repository::Repository;
 use did::directory::{SearchProfileEntry, SearchProfilesArgs, SearchProfilesResponse};
 
 use crate::domain::users::repository::UserRepository;

--- a/crates/canisters/directory/src/domain/users/search_profiles.rs
+++ b/crates/canisters/directory/src/domain/users/search_profiles.rs
@@ -36,7 +36,7 @@ pub fn search_profiles(
         "search_profiles called with query: {query}, sanitized handle: {handle}, limit: {limit}, offset: {offset}"
     );
 
-    match UserRepository::search_profiles(&handle, offset as usize, limit as usize) {
+    match UserRepository::oneshot().search_profiles(&handle, offset as usize, limit as usize) {
         Err(err) => {
             ic_utils::log!("Error searching profiles: {err}");
             SearchProfilesResponse::Err(did::directory::SearchProfilesError::Internal(
@@ -172,7 +172,9 @@ mod tests {
     fn test_should_exclude_deletion_pending_user() {
         setup();
         setup_registered_user_with_canister(rey_canisteryo(), "rey_canisteryo", bob());
-        UserRepository::mark_user_for_deletion(rey_canisteryo()).unwrap();
+        UserRepository::oneshot()
+            .mark_user_for_deletion(rey_canisteryo())
+            .unwrap();
 
         let SearchProfilesResponse::Ok(results) = search_profiles(args("rey", 0, 50)) else {
             panic!("expected Ok");

--- a/crates/canisters/directory/src/domain/users/sign_up.rs
+++ b/crates/canisters/directory/src/domain/users/sign_up.rs
@@ -34,7 +34,7 @@ pub fn sign_up(user_id: Principal, SignUpRequest { handle }: SignUpRequest) -> S
     }
 
     // 1. Check whether there is already a user with the given `user_id` in the database, if there is, return [`SignUpError::AlreadyRegistered`].
-    match UserRepository::get_user_by_principal(user_id) {
+    match UserRepository::oneshot().get_user_by_principal(user_id) {
         Err(err) => {
             ic_utils::log!("sign_up: internal error checking principal {user_id}: {err}");
             return SignUpResponse::Err(SignUpError::InternalError(format!(
@@ -78,7 +78,7 @@ pub fn sign_up(user_id: Principal, SignUpRequest { handle }: SignUpRequest) -> S
     }
 
     // 4. Check if the handle is already taken by another user in the database, if it is, return [`SignUpError::HandleTaken`].
-    match UserRepository::get_user_by_handle(&sanitized_handle) {
+    match UserRepository::oneshot().get_user_by_handle(&sanitized_handle) {
         Err(err) => {
             ic_utils::log!("sign_up: internal error checking handle {sanitized_handle}: {err}");
             return SignUpResponse::Err(SignUpError::InternalError(format!(
@@ -93,7 +93,7 @@ pub fn sign_up(user_id: Principal, SignUpRequest { handle }: SignUpRequest) -> S
     };
 
     // 5. Insert the new user in the database with the canister status set to [`did::directory::UserCanisterStatus::CreationPending`].
-    if let Err(err) = UserRepository::sign_up(user_id, sanitized_handle.clone()) {
+    if let Err(err) = UserRepository::oneshot().sign_up(user_id, sanitized_handle.clone()) {
         ic_utils::log!("sign_up: failed to insert user {user_id} in the database: {err}");
         return SignUpResponse::Err(SignUpError::InternalError(format!(
             "Failed to insert new user in the database: {err}"
@@ -130,7 +130,7 @@ pub fn retry_sign_up(user_id: Principal) -> RetrySignUpResponse {
 
     // 1. Check whether there is a user with the given `user_id` in the database, if there isn't, return [`RetrySignUpError::NotRegistered`].
     // 2. Check if the user's canister is in a failed state, if it isn't, return [`RetrySignUpError::CanisterNotInFailedState`].
-    let handle = match UserRepository::get_user_by_principal(user_id) {
+    let handle = match UserRepository::oneshot().get_user_by_principal(user_id) {
         Err(err) => {
             ic_utils::log!("retry_sign_up: internal error checking principal {user_id}: {err}");
             return RetrySignUpResponse::Err(RetrySignUpError::InternalError(format!(
@@ -154,7 +154,7 @@ pub fn retry_sign_up(user_id: Principal) -> RetrySignUpResponse {
     };
 
     // 3. Update the user's canister status in the database to [`did::directory::UserCanisterStatus::CreationPending`]
-    if let Err(err) = UserRepository::retry_user_canister_creation(user_id) {
+    if let Err(err) = UserRepository::oneshot().retry_user_canister_creation(user_id) {
         ic_utils::log!("retry_sign_up: failed to update canister status for user {user_id}: {err}");
         return RetrySignUpResponse::Err(RetrySignUpError::InternalError(format!(
             "Failed to update user canister status in the database: {err}"
@@ -236,7 +236,8 @@ mod tests {
         assert_eq!(response, SignUpResponse::Ok);
 
         // verify it was stored sanitized
-        let user = UserRepository::get_user_by_handle("alice")
+        let user = UserRepository::oneshot()
+            .get_user_by_handle("alice")
             .expect("should query user")
             .expect("user should exist");
         assert_eq!(user.handle.0, "alice");
@@ -372,7 +373,8 @@ mod tests {
         );
 
         // simulate canister creation failure
-        UserRepository::set_failed_user_canister_create(bob())
+        UserRepository::oneshot()
+            .set_failed_user_canister_create(bob())
             .expect("should set canister creation failed");
 
         let response = retry_sign_up(bob());

--- a/crates/canisters/directory/src/domain/users/sign_up.rs
+++ b/crates/canisters/directory/src/domain/users/sign_up.rs
@@ -57,7 +57,7 @@ pub fn sign_up(user_id: Principal, SignUpRequest { handle }: SignUpRequest) -> S
     }
 
     // 3. check whether is tombstoned
-    match TombstoneRepository::is_tombstoned(&sanitized_handle) {
+    match TombstoneRepository::oneshot().is_tombstoned(&sanitized_handle) {
         Ok(true) => {
             ic_utils::log!("sign_up: handle {sanitized_handle} is currently tombstoned");
             return SignUpResponse::Err(SignUpError::HandleTombstoned);

--- a/crates/canisters/directory/src/domain/users/sign_up.rs
+++ b/crates/canisters/directory/src/domain/users/sign_up.rs
@@ -2,6 +2,7 @@
 
 use candid::Principal;
 use db_utils::handle::{HandleSanitizer, HandleValidator};
+use db_utils::repository::Repository;
 use did::directory::{
     RetrySignUpError, RetrySignUpResponse, SignUpError, SignUpRequest, SignUpResponse,
 };

--- a/crates/canisters/directory/src/domain/users/sign_up/state.rs
+++ b/crates/canisters/directory/src/domain/users/sign_up/state.rs
@@ -297,11 +297,11 @@ where
     }
 
     fn commit_sign_up(&self, canister_id: Principal) -> CanisterResult<()> {
-        UserRepository::set_user_canister(self.user_id, canister_id)
+        UserRepository::oneshot().set_user_canister(self.user_id, canister_id)
     }
 
     fn commit_sign_up_failure(&self) -> CanisterResult<()> {
-        UserRepository::set_failed_user_canister_create(self.user_id)
+        UserRepository::oneshot().set_failed_user_canister_create(self.user_id)
     }
 
     /// Finish the sign up process for the user by removing their state from the `USER_SIGN_UP_STATES` thread-local storage.
@@ -734,7 +734,8 @@ mod tests {
             TestFederationClient::ok(),
         );
         // the user must exist in the DB for commit to succeed
-        UserRepository::sign_up(rey_canisteryo(), "alice".to_string())
+        UserRepository::oneshot()
+            .sign_up(rey_canisteryo(), "alice".to_string())
             .expect("sign_up should succeed");
 
         let current = SignUpStateStep {
@@ -756,7 +757,8 @@ mod tests {
             TestManagementClient::ok(user_canister()),
             TestFederationClient::ok(),
         );
-        UserRepository::sign_up(rey_canisteryo(), "alice".to_string())
+        UserRepository::oneshot()
+            .sign_up(rey_canisteryo(), "alice".to_string())
             .expect("sign_up should succeed");
 
         let current = SignUpStateStep {

--- a/crates/canisters/directory/src/domain/users/sign_up/state.rs
+++ b/crates/canisters/directory/src/domain/users/sign_up/state.rs
@@ -3,6 +3,7 @@ use std::collections::HashMap;
 use std::time::Duration;
 
 use candid::Principal;
+use db_utils::repository::Repository;
 use did::user::UserInstallArgs;
 use ic_management_canister_types::CanisterSettings;
 

--- a/crates/canisters/directory/src/domain/users/user_canister.rs
+++ b/crates/canisters/directory/src/domain/users/user_canister.rs
@@ -1,6 +1,7 @@
 //! Flow for getting the `user_canister` by principal.
 
 use candid::Principal;
+use db_utils::repository::Repository;
 use did::directory::{UserCanisterError, UserCanisterResponse};
 
 use crate::domain::users::repository::UserRepository;

--- a/crates/canisters/directory/src/domain/users/user_canister.rs
+++ b/crates/canisters/directory/src/domain/users/user_canister.rs
@@ -14,7 +14,7 @@ use crate::domain::users::repository::UserRepository;
 pub fn user_canister(user: Principal) -> UserCanisterResponse {
     ic_utils::log!("user_canister: looking up user {user}");
 
-    let user_data = match UserRepository::get_user_by_principal(user) {
+    let user_data = match UserRepository::oneshot().get_user_by_principal(user) {
         Ok(Some(user)) => user,
         Ok(None) => {
             ic_utils::log!("whoami: user {user} is not registered");

--- a/crates/canisters/directory/src/domain/users/whoami.rs
+++ b/crates/canisters/directory/src/domain/users/whoami.rs
@@ -13,7 +13,7 @@ use crate::domain::users::repository::UserRepository;
 pub fn whoami(caller: Principal) -> WhoAmIResponse {
     ic_utils::log!("whoami: looking up user {caller}");
 
-    let user = match UserRepository::get_user_by_principal(caller) {
+    let user = match UserRepository::oneshot().get_user_by_principal(caller) {
         Ok(Some(user)) => user,
         Ok(None) => {
             ic_utils::log!("whoami: user {caller} is not registered");

--- a/crates/canisters/directory/src/domain/users/whoami.rs
+++ b/crates/canisters/directory/src/domain/users/whoami.rs
@@ -1,6 +1,7 @@
 //! Whoami flow implementation
 
 use candid::Principal;
+use db_utils::repository::Repository;
 use did::directory::{WhoAmI, WhoAmIError, WhoAmIResponse};
 
 use crate::domain::users::repository::UserRepository;

--- a/crates/canisters/directory/src/error.rs
+++ b/crates/canisters/directory/src/error.rs
@@ -15,4 +15,8 @@ pub enum CanisterError {
     /// Sign up process failed for a user.
     #[error("Sign up failed: {0}")]
     SignUpFailed(String),
+    /// Internal error not caused by misuse.
+    #[error("Internal error: {0}")]
+    #[allow(dead_code)]
+    Internal(String),
 }

--- a/crates/canisters/directory/src/schema.rs
+++ b/crates/canisters/directory/src/schema.rs
@@ -105,7 +105,7 @@ pub struct Report {
     pub resolved_by: Nullable<Principal>,
 }
 
-#[derive(DatabaseSchema, Clone)]
+#[derive(DatabaseSchema, Clone, Copy)]
 #[tables(
     Settings = "settings",
     Moderator = "moderators",

--- a/crates/canisters/directory/src/test_utils.rs
+++ b/crates/canisters/directory/src/test_utils.rs
@@ -1,6 +1,7 @@
 //! Shared test utilities for the directory canister.
 
 use candid::Principal;
+use db_utils::repository::Repository;
 use did::directory::{DirectoryInstallArgs, SignUpRequest, SignUpResponse};
 
 pub fn admin() -> Principal {

--- a/crates/canisters/directory/src/test_utils.rs
+++ b/crates/canisters/directory/src/test_utils.rs
@@ -57,6 +57,7 @@ pub fn setup_registered_user_with_canister(
     canister_id: Principal,
 ) {
     setup_registered_user(principal, handle);
-    crate::domain::users::repository::UserRepository::set_user_canister(principal, canister_id)
+    crate::domain::users::repository::UserRepository::oneshot()
+        .set_user_canister(principal, canister_id)
         .expect("setup_registered_user_with_canister: failed to set user canister");
 }

--- a/crates/canisters/federation/src/adapters/user.rs
+++ b/crates/canisters/federation/src/adapters/user.rs
@@ -8,7 +8,7 @@
 #[cfg(not(target_family = "wasm"))]
 pub mod mock;
 
-use did::user::ReceiveActivityArgs;
+use did::user::{GetLocalStatusArgs, GetLocalStatusResponse, ReceiveActivityArgs};
 
 /// Abstraction over the user canister API used by the Federation Canister.
 ///
@@ -29,6 +29,18 @@ pub trait UserCanister: Send + Sync + Sized {
         &self,
         args: ReceiveActivityArgs,
     ) -> impl Future<Output = Result<(), UserCanisterClientError>>;
+
+    /// Query the User Canister for a single locally-hosted status by id.
+    ///
+    /// Returns the raw [`GetLocalStatusResponse`] — the user-canister-level
+    /// success / error variant is preserved so domain callers can decide
+    /// how to map it. Transport-level problems are reported as
+    /// [`UserCanisterClientError::CallFailed`] or
+    /// [`UserCanisterClientError::DecodeFailed`].
+    fn get_local_status(
+        &self,
+        args: GetLocalStatusArgs,
+    ) -> impl Future<Output = Result<GetLocalStatusResponse, UserCanisterClientError>>;
 }
 
 /// Errors returned by [`UserCanister`] operations.
@@ -110,5 +122,31 @@ impl UserCanister for IcUserCanisterClient {
                 Err(UserCanisterClientError::Rejected(format!("{e:?}")))
             }
         }
+    }
+
+    async fn get_local_status(
+        &self,
+        args: GetLocalStatusArgs,
+    ) -> Result<GetLocalStatusResponse, UserCanisterClientError> {
+        ic_utils::log!(
+            "IcUserCanisterClient::get_local_status: querying status {} on {}",
+            args.id,
+            self.canister_id
+        );
+
+        let raw = ic_cdk::call::Call::bounded_wait(self.canister_id, "get_local_status")
+            .with_arg(args)
+            .await
+            .map_err(|e| {
+                ic_utils::log!("IcUserCanisterClient::get_local_status: call failed: {e:?}");
+                UserCanisterClientError::CallFailed(format!("{e:?}"))
+            })?;
+
+        let response = candid::decode_one::<GetLocalStatusResponse>(&raw).map_err(|e| {
+            ic_utils::log!("IcUserCanisterClient::get_local_status: decode failed: {e}");
+            UserCanisterClientError::DecodeFailed(e.to_string())
+        })?;
+
+        Ok(response)
     }
 }

--- a/crates/canisters/federation/src/adapters/user/mock.rs
+++ b/crates/canisters/federation/src/adapters/user/mock.rs
@@ -30,7 +30,10 @@ thread_local! {
 
 /// Enqueue a canned response to be returned by the next call to
 /// [`MockUserCanisterClient::get_local_status`].
-#[allow(dead_code, reason = "exposed as a test helper; called from cfg(test) sites")]
+#[allow(
+    dead_code,
+    reason = "exposed as a test helper; called from cfg(test) sites"
+)]
 pub fn push_get_local_status_response(resp: GetLocalStatusResponse) {
     GET_LOCAL_STATUS_RESPONSES.with_borrow_mut(|q| q.push_back(resp));
 }
@@ -47,7 +50,10 @@ pub fn captured_get_local_status_calls() -> Vec<GetLocalStatusArgs> {
 
 /// Clear both the canned response queue and the captured-calls log so
 /// tests start from a clean slate.
-#[allow(dead_code, reason = "exposed as a test helper; called from cfg(test) sites")]
+#[allow(
+    dead_code,
+    reason = "exposed as a test helper; called from cfg(test) sites"
+)]
 pub fn reset_get_local_status() {
     GET_LOCAL_STATUS_RESPONSES.with_borrow_mut(|q| q.clear());
     GET_LOCAL_STATUS_CALLS.with_borrow_mut(|v| v.clear());

--- a/crates/canisters/federation/src/adapters/user/mock.rs
+++ b/crates/canisters/federation/src/adapters/user/mock.rs
@@ -6,15 +6,61 @@
 //! additional mock types in this module instead of modifying the default
 //! always-Ok client.
 
-use did::user::ReceiveActivityArgs;
+use std::cell::RefCell;
+use std::collections::VecDeque;
+
+use did::user::{GetLocalStatusArgs, GetLocalStatusResponse, ReceiveActivityArgs};
 
 use super::{UserCanister, UserCanisterClientError};
 
+thread_local! {
+    /// FIFO queue of canned [`GetLocalStatusResponse`] values returned by
+    /// [`MockUserCanisterClient::get_local_status`]. Tests push expected
+    /// responses with [`push_get_local_status_response`] before invoking the
+    /// flow under test.
+    pub static GET_LOCAL_STATUS_RESPONSES: RefCell<VecDeque<GetLocalStatusResponse>> =
+        const { RefCell::new(VecDeque::new()) };
+    /// Captured arguments observed by
+    /// [`MockUserCanisterClient::get_local_status`] in invocation order.
+    /// Tests inspect this with [`captured_get_local_status_calls`] to assert
+    /// on the forwarded args.
+    pub static GET_LOCAL_STATUS_CALLS: RefCell<Vec<GetLocalStatusArgs>> =
+        const { RefCell::new(Vec::new()) };
+}
+
+/// Enqueue a canned response to be returned by the next call to
+/// [`MockUserCanisterClient::get_local_status`].
+#[allow(dead_code, reason = "exposed as a test helper; called from cfg(test) sites")]
+pub fn push_get_local_status_response(resp: GetLocalStatusResponse) {
+    GET_LOCAL_STATUS_RESPONSES.with_borrow_mut(|q| q.push_back(resp));
+}
+
+/// Snapshot of the args captured by past calls to
+/// [`MockUserCanisterClient::get_local_status`], in invocation order.
+#[allow(
+    dead_code,
+    reason = "exposed as a test helper; not all federation tests inspect calls yet"
+)]
+pub fn captured_get_local_status_calls() -> Vec<GetLocalStatusArgs> {
+    GET_LOCAL_STATUS_CALLS.with_borrow(|v| v.clone())
+}
+
+/// Clear both the canned response queue and the captured-calls log so
+/// tests start from a clean slate.
+#[allow(dead_code, reason = "exposed as a test helper; called from cfg(test) sites")]
+pub fn reset_get_local_status() {
+    GET_LOCAL_STATUS_RESPONSES.with_borrow_mut(|q| q.clear());
+    GET_LOCAL_STATUS_CALLS.with_borrow_mut(|v| v.clear());
+}
+
 /// A test-only [`UserCanister`] whose `receive_activity` implementation
-/// always returns `Ok(())`.
+/// always returns `Ok(())`, and whose `get_local_status` implementation
+/// returns the next canned response from the
+/// [`GET_LOCAL_STATUS_RESPONSES`] queue.
 ///
 /// Use this when the behavior under test does not care about the User
-/// Canister response (only that the call was attempted).
+/// Canister response (only that the call was attempted), or when the test
+/// pre-seeds an explicit response via [`push_get_local_status_response`].
 #[derive(Debug)]
 pub struct MockUserCanisterClient;
 
@@ -24,5 +70,20 @@ impl UserCanister for MockUserCanisterClient {
         _args: ReceiveActivityArgs,
     ) -> Result<(), UserCanisterClientError> {
         Ok(())
+    }
+
+    async fn get_local_status(
+        &self,
+        args: GetLocalStatusArgs,
+    ) -> Result<GetLocalStatusResponse, UserCanisterClientError> {
+        GET_LOCAL_STATUS_CALLS.with_borrow_mut(|v| v.push(args.clone()));
+        GET_LOCAL_STATUS_RESPONSES
+            .with_borrow_mut(|q| q.pop_front())
+            .ok_or_else(|| {
+                UserCanisterClientError::CallFailed(
+                    "MockUserCanisterClient::get_local_status: no canned response queued"
+                        .to_string(),
+                )
+            })
     }
 }

--- a/crates/canisters/federation/src/api.rs
+++ b/crates/canisters/federation/src/api.rs
@@ -3,8 +3,8 @@
 pub mod inspect;
 
 use did::federation::{
-    FederationInstallArgs, RegisterUserArgs, RegisterUserResponse, SendActivityArgs,
-    SendActivityResponse,
+    FederationInstallArgs, FetchStatusArgs, FetchStatusResponse, RegisterUserArgs,
+    RegisterUserResponse, SendActivityArgs, SendActivityResponse,
 };
 
 /// Initialize the canister with the given arguments
@@ -68,6 +68,10 @@ pub async fn send_activity(args: SendActivityArgs) -> SendActivityResponse {
     }
 
     crate::domain::activity::send_activity(args).await
+}
+
+pub async fn fetch_status(args: FetchStatusArgs) -> FetchStatusResponse {
+    crate::domain::fetch_status::fetch_status(args).await
 }
 
 #[cfg(test)]

--- a/crates/canisters/federation/src/domain.rs
+++ b/crates/canisters/federation/src/domain.rs
@@ -1,5 +1,4 @@
 //! Federation canister domain logic.
 
 pub mod activity;
-#[allow(dead_code, reason = "wired by api endpoint in Task 9 of WI-1.7")]
 pub mod fetch_status;

--- a/crates/canisters/federation/src/domain.rs
+++ b/crates/canisters/federation/src/domain.rs
@@ -1,3 +1,5 @@
 //! Federation canister domain logic.
 
 pub mod activity;
+#[allow(dead_code, reason = "wired by api endpoint in Task 9 of WI-1.7")]
+pub mod fetch_status;

--- a/crates/canisters/federation/src/domain/fetch_status.rs
+++ b/crates/canisters/federation/src/domain/fetch_status.rs
@@ -1,0 +1,268 @@
+//! `fetch_status` flow — resolve an ActivityPub status URI to a [`Status`].
+//!
+//! - Local URI (host == public_url): directory lookup → user canister
+//!   inter-canister call to `get_local_status`.
+//! - Remote URI: returns [`FetchStatusError::Unsupported`]. M3 will replace
+//!   this branch with an HTTPS outcall.
+
+use did::common::Status;
+use did::federation::{FetchStatusArgs, FetchStatusError, FetchStatusResponse};
+use did::user::{GetLocalStatusArgs, GetLocalStatusResponse};
+use url::Url;
+
+use crate::adapters::user::UserCanisterClientError;
+
+/// Entry point for the `fetch_status` canister method.
+///
+/// Resolves `args.uri` to a [`Status`] via the local directory + user
+/// canister. Remote URIs return [`FetchStatusError::Unsupported`] until
+/// HTTPS outcalls land in M3.
+pub async fn fetch_status(args: FetchStatusArgs) -> FetchStatusResponse {
+    match fetch_status_inner(args).await {
+        Ok(status) => FetchStatusResponse::Ok(status),
+        Err(failure) => failure.into(),
+    }
+}
+
+async fn fetch_status_inner(
+    FetchStatusArgs {
+        uri,
+        requester_actor_uri,
+    }: FetchStatusArgs,
+) -> Result<Status, FetchStatusFailure> {
+    let target = Url::parse(&uri).map_err(|err| {
+        ic_utils::log!("fetch_status: invalid uri {uri:?}: {err}");
+        FetchStatusFailure::InvalidUri
+    })?;
+
+    let public_url_raw = crate::settings::get_public_url();
+    let public_url = Url::parse(&public_url_raw).map_err(|err| {
+        ic_utils::log!("fetch_status: public_url {public_url_raw:?} invalid: {err}");
+        FetchStatusFailure::Internal(format!("public_url misconfigured: {err}"))
+    })?;
+
+    if !is_local(&target, &public_url) {
+        ic_utils::log!("fetch_status: remote uri {target} unsupported (M3)");
+        return Err(FetchStatusFailure::Unsupported);
+    }
+
+    let (handle, id) = parse_local_path(&target).ok_or_else(|| {
+        ic_utils::log!(
+            "fetch_status: unexpected local path shape: {}",
+            target.path()
+        );
+        FetchStatusFailure::InvalidUri
+    })?;
+
+    let Some(user) = crate::directory::get_user_by_handle(&handle) else {
+        ic_utils::log!("fetch_status: unknown local handle {handle}");
+        return Err(FetchStatusFailure::NotFound);
+    };
+
+    let response = call_get_local_status(
+        user.user_canister_id,
+        GetLocalStatusArgs {
+            id,
+            requester_actor_uri,
+        },
+    )
+    .await
+    .map_err(|err| {
+        ic_utils::log!("fetch_status: get_local_status call failed: {err}");
+        FetchStatusFailure::Internal(err.to_string())
+    })?;
+
+    match response {
+        GetLocalStatusResponse::Ok(status) => Ok(status),
+        GetLocalStatusResponse::Err(_) => Err(FetchStatusFailure::NotFound),
+    }
+}
+
+/// Native (test) build: route through the mock client so unit tests can
+/// drive the canned-response queue.
+#[cfg(not(target_family = "wasm"))]
+async fn call_get_local_status(
+    _canister_id: candid::Principal,
+    args: GetLocalStatusArgs,
+) -> Result<GetLocalStatusResponse, UserCanisterClientError> {
+    use crate::adapters::user::UserCanister;
+    use crate::adapters::user::mock::MockUserCanisterClient;
+    MockUserCanisterClient.get_local_status(args).await
+}
+
+/// Wasm build: perform the real inter-canister query via
+/// [`crate::adapters::user::IcUserCanisterClient`].
+#[cfg(target_family = "wasm")]
+async fn call_get_local_status(
+    canister_id: candid::Principal,
+    args: GetLocalStatusArgs,
+) -> Result<GetLocalStatusResponse, UserCanisterClientError> {
+    use crate::adapters::user::{IcUserCanisterClient, UserCanister};
+    IcUserCanisterClient::from(canister_id)
+        .get_local_status(args)
+        .await
+}
+
+/// Returns `true` when `target` resolves to this Mastic instance.
+fn is_local(target: &Url, public_url: &Url) -> bool {
+    target.host_str() == public_url.host_str()
+        && target.port_or_known_default() == public_url.port_or_known_default()
+}
+
+/// Parse a local status URL of shape `<public_url>/users/<handle>/statuses/<id>`.
+fn parse_local_path(target: &Url) -> Option<(String, u64)> {
+    let mut segments = target.path_segments()?;
+    let users = segments.next()?;
+    let handle = segments.next()?;
+    let statuses = segments.next()?;
+    let id = segments.next()?;
+    if segments.next().is_some() || users != "users" || statuses != "statuses" || handle.is_empty()
+    {
+        return None;
+    }
+    let id = id.parse::<u64>().ok()?;
+    Some((handle.to_string(), id))
+}
+
+#[derive(Debug, thiserror::Error)]
+enum FetchStatusFailure {
+    #[error("unsupported (remote URI)")]
+    Unsupported,
+    #[error("invalid uri")]
+    InvalidUri,
+    #[error("not found")]
+    NotFound,
+    #[error("internal: {0}")]
+    Internal(String),
+}
+
+impl From<FetchStatusFailure> for FetchStatusResponse {
+    fn from(value: FetchStatusFailure) -> Self {
+        FetchStatusResponse::Err(match value {
+            FetchStatusFailure::Unsupported => FetchStatusError::Unsupported,
+            FetchStatusFailure::InvalidUri => FetchStatusError::InvalidUri,
+            FetchStatusFailure::NotFound => FetchStatusError::NotFound,
+            FetchStatusFailure::Internal(s) => FetchStatusError::Internal(s),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use candid::Principal;
+    use did::common::{Status, Visibility};
+    use did::federation::{FetchStatusArgs, FetchStatusError, FetchStatusResponse};
+    use did::user::{GetLocalStatusError, GetLocalStatusResponse};
+
+    use super::fetch_status;
+    use crate::adapters::user::mock::push_get_local_status_response;
+    use crate::test_utils::{alice, public_url, setup};
+
+    fn fixture_status() -> Status {
+        Status {
+            id: 42,
+            content: "hi".into(),
+            author: format!("{}/users/alice", public_url()),
+            created_at: 0,
+            visibility: Visibility::Public,
+            like_count: 0,
+            boost_count: 0,
+            spoiler_text: None,
+            sensitive: false,
+        }
+    }
+
+    fn register_alice() {
+        crate::directory::insert_user(
+            Principal::from_text("mfufu-x6j4c-gomzb-geilq").unwrap(),
+            "alice".to_string(),
+            alice(),
+        );
+    }
+
+    // M-UNIT-TEST: a local URI is resolved through the directory and forwarded
+    // to the target user canister.
+    #[tokio::test]
+    async fn test_local_uri_resolves_via_directory() {
+        setup();
+        register_alice();
+        push_get_local_status_response(GetLocalStatusResponse::Ok(fixture_status()));
+
+        let resp = fetch_status(FetchStatusArgs {
+            uri: format!("{}/users/alice/statuses/42", public_url()),
+            requester_actor_uri: None,
+        })
+        .await;
+
+        assert!(matches!(resp, FetchStatusResponse::Ok(_)));
+    }
+
+    // M-UNIT-TEST: a remote URI is reported as Unsupported until HTTPS outcalls
+    // are wired up in M3.
+    #[tokio::test]
+    async fn test_remote_uri_returns_unsupported() {
+        setup();
+        let resp = fetch_status(FetchStatusArgs {
+            uri: "https://other.example/users/bob/statuses/9".to_string(),
+            requester_actor_uri: None,
+        })
+        .await;
+        assert_eq!(
+            resp,
+            FetchStatusResponse::Err(FetchStatusError::Unsupported)
+        );
+    }
+
+    // M-UNIT-TEST: an unparseable URI yields InvalidUri.
+    #[tokio::test]
+    async fn test_invalid_uri_returns_invalid() {
+        setup();
+        let resp = fetch_status(FetchStatusArgs {
+            uri: "not-a-url".to_string(),
+            requester_actor_uri: None,
+        })
+        .await;
+        assert_eq!(resp, FetchStatusResponse::Err(FetchStatusError::InvalidUri));
+    }
+
+    // M-UNIT-TEST: a local URI for an unknown handle yields NotFound.
+    #[tokio::test]
+    async fn test_unknown_handle_returns_not_found() {
+        setup();
+        let resp = fetch_status(FetchStatusArgs {
+            uri: format!("{}/users/unknown/statuses/1", public_url()),
+            requester_actor_uri: None,
+        })
+        .await;
+        assert_eq!(resp, FetchStatusResponse::Err(FetchStatusError::NotFound));
+    }
+
+    // M-UNIT-TEST: a NotFound response from the target user canister bubbles
+    // up unchanged.
+    #[tokio::test]
+    async fn test_target_user_canister_returns_not_found() {
+        setup();
+        register_alice();
+        push_get_local_status_response(GetLocalStatusResponse::Err(GetLocalStatusError::NotFound));
+
+        let resp = fetch_status(FetchStatusArgs {
+            uri: format!("{}/users/alice/statuses/42", public_url()),
+            requester_actor_uri: None,
+        })
+        .await;
+        assert_eq!(resp, FetchStatusResponse::Err(FetchStatusError::NotFound));
+    }
+
+    // M-UNIT-TEST: a local URL whose path is not /users/{handle}/statuses/{id}
+    // is rejected as InvalidUri.
+    #[tokio::test]
+    async fn test_unexpected_path_shape_returns_invalid_uri() {
+        setup();
+        let resp = fetch_status(FetchStatusArgs {
+            uri: format!("{}/users/alice/foo", public_url()),
+            requester_actor_uri: None,
+        })
+        .await;
+        assert_eq!(resp, FetchStatusResponse::Err(FetchStatusError::InvalidUri));
+    }
+}

--- a/crates/canisters/federation/src/lib.rs
+++ b/crates/canisters/federation/src/lib.rs
@@ -1,6 +1,6 @@
 use did::federation::{
-    FederationInstallArgs, RegisterUserArgs, RegisterUserResponse, SendActivityArgs,
-    SendActivityResponse,
+    FederationInstallArgs, FetchStatusArgs, FetchStatusResponse, RegisterUserArgs,
+    RegisterUserResponse, SendActivityArgs, SendActivityResponse,
 };
 
 mod adapters;
@@ -39,6 +39,11 @@ fn register_user(args: RegisterUserArgs) -> RegisterUserResponse {
 #[ic_cdk::update]
 async fn send_activity(args: SendActivityArgs) -> SendActivityResponse {
     api::send_activity(args).await
+}
+
+#[ic_cdk::update]
+async fn fetch_status(args: FetchStatusArgs) -> FetchStatusResponse {
+    api::fetch_status(args).await
 }
 
 ic_cdk::export_candid!();

--- a/crates/canisters/federation/src/lib.rs
+++ b/crates/canisters/federation/src/lib.rs
@@ -32,6 +32,11 @@ fn inspect_message() {
 }
 
 #[ic_cdk::update]
+async fn fetch_status(args: FetchStatusArgs) -> FetchStatusResponse {
+    api::fetch_status(args).await
+}
+
+#[ic_cdk::update]
 fn register_user(args: RegisterUserArgs) -> RegisterUserResponse {
     api::register_user(args)
 }
@@ -39,11 +44,6 @@ fn register_user(args: RegisterUserArgs) -> RegisterUserResponse {
 #[ic_cdk::update]
 async fn send_activity(args: SendActivityArgs) -> SendActivityResponse {
     api::send_activity(args).await
-}
-
-#[ic_cdk::update]
-async fn fetch_status(args: FetchStatusArgs) -> FetchStatusResponse {
-    api::fetch_status(args).await
 }
 
 ic_cdk::export_candid!();

--- a/crates/canisters/federation/src/test_utils.rs
+++ b/crates/canisters/federation/src/test_utils.rs
@@ -20,4 +20,5 @@ pub fn setup() {
         directory_canister: directory(),
         public_url: public_url(),
     });
+    crate::adapters::user::mock::reset_get_local_status();
 }

--- a/crates/canisters/user/src/adapters/federation.rs
+++ b/crates/canisters/user/src/adapters/federation.rs
@@ -3,7 +3,7 @@
 #[cfg(test)]
 pub mod mock;
 
-use did::federation::SendActivityArgs;
+use did::federation::{FetchStatusArgs, FetchStatusResponse, SendActivityArgs};
 
 use crate::error::CanisterResult;
 
@@ -33,6 +33,32 @@ pub async fn send_activity(_args: SendActivityArgs) -> CanisterResult<()> {
     }
 }
 
+/// Fetch a status from the Federation Canister.
+///
+/// Dispatches to the mock client in tests and to the real
+/// inter-canister client on wasm targets.
+pub async fn fetch_status(_args: FetchStatusArgs) -> CanisterResult<FetchStatusResponse> {
+    #[cfg(test)]
+    {
+        mock::FederationCanisterMockClient
+            .fetch_status(_args)
+            .await
+            .map_err(crate::error::CanisterError::from)
+    }
+    #[cfg(target_family = "wasm")]
+    {
+        let federation_canister = crate::settings::get_federation_canister()?;
+        IcFederationCanisterClient::from(federation_canister)
+            .fetch_status(_args)
+            .await
+            .map_err(crate::error::CanisterError::from)
+    }
+    #[cfg(not(any(target_family = "wasm", test)))]
+    {
+        panic!("fetch_status is not implemented for non-wasm, non-test targets");
+    }
+}
+
 /// Abstraction over the federation canister API.
 #[cfg(any(target_family = "wasm", test))]
 pub trait FederationCanister: Send + Sync + Sized {
@@ -41,6 +67,12 @@ pub trait FederationCanister: Send + Sync + Sized {
         &self,
         args: SendActivityArgs,
     ) -> impl Future<Output = Result<(), FederationCanisterClientError>>;
+
+    /// call the `fetch_status` method of the federation canister with the given arguments.
+    fn fetch_status(
+        &self,
+        args: FetchStatusArgs,
+    ) -> impl Future<Output = Result<FetchStatusResponse, FederationCanisterClientError>>;
 }
 
 /// Errors returned by [`FederationCanister`] operations.
@@ -109,5 +141,66 @@ impl FederationCanister for IcFederationCanisterClient {
 
         ic_utils::log!("IcFederationCanisterClient::send_activity: sent activity successfully");
         Ok(())
+    }
+
+    async fn fetch_status(
+        &self,
+        args: FetchStatusArgs,
+    ) -> Result<FetchStatusResponse, FederationCanisterClientError> {
+        ic_utils::log!("IcFederationCanisterClient::fetch_status: sending fetch_status request");
+
+        let raw = ic_cdk::call::Call::bounded_wait(self.canister_id, "fetch_status")
+            .with_arg(args)
+            .await
+            .map_err(|e| {
+                ic_utils::log!("IcFederationCanisterClient::fetch_status: call failed: {e:?}");
+                FederationCanisterClientError::CallFailed(format!("{e:?}"))
+            })?;
+
+        let response = candid::decode_one::<FetchStatusResponse>(&raw).map_err(|e| {
+            ic_utils::log!("IcFederationCanisterClient::fetch_status: decode failed: {e}");
+            FederationCanisterClientError::DecodeFailed(e.to_string())
+        })?;
+
+        Ok(response)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use did::common::{Status, Visibility};
+    use did::federation::{FetchStatusArgs, FetchStatusResponse};
+
+    use super::fetch_status;
+    use crate::adapters::federation::mock::push_fetch_status_response;
+    use crate::test_utils::setup;
+
+    fn fixture_status() -> Status {
+        Status {
+            id: 1,
+            content: "hi".into(),
+            author: "https://x/users/a".into(),
+            created_at: 0,
+            visibility: Visibility::Public,
+            like_count: 0,
+            boost_count: 0,
+            spoiler_text: None,
+            sensitive: false,
+        }
+    }
+
+    #[tokio::test]
+    async fn test_fetch_status_returns_mocked_response() {
+        setup();
+        push_fetch_status_response(FetchStatusResponse::Ok(fixture_status()));
+
+        let resp = fetch_status(FetchStatusArgs {
+            uri: "https://x/users/a/statuses/1".into(),
+            requester_actor_uri: None,
+        })
+        .await
+        .expect("should call");
+
+        assert!(matches!(resp, FetchStatusResponse::Ok(_)));
     }
 }

--- a/crates/canisters/user/src/adapters/federation/mock.rs
+++ b/crates/canisters/user/src/adapters/federation/mock.rs
@@ -7,7 +7,7 @@ use crate::adapters::federation::FederationCanister;
 
 thread_local! {
     static CAPTURED: RefCell<Vec<SendActivityArgs>> = const { RefCell::new(Vec::new()) };
-    static FETCH_STATUS_RESPONSES: RefCell<VecDeque<FetchStatusResponse>> = RefCell::new(VecDeque::new());
+    static FETCH_STATUS_RESPONSES: RefCell<VecDeque<FetchStatusResponse>> = const { RefCell::new(VecDeque::new()) };
     static FETCH_STATUS_CALLS: RefCell<Vec<FetchStatusArgs>> = const { RefCell::new(Vec::new()) };
 }
 

--- a/crates/canisters/user/src/adapters/federation/mock.rs
+++ b/crates/canisters/user/src/adapters/federation/mock.rs
@@ -1,11 +1,14 @@
 use std::cell::RefCell;
+use std::collections::VecDeque;
 
-use did::federation::SendActivityArgs;
+use did::federation::{FetchStatusArgs, FetchStatusResponse, SendActivityArgs};
 
 use crate::adapters::federation::FederationCanister;
 
 thread_local! {
     static CAPTURED: RefCell<Vec<SendActivityArgs>> = const { RefCell::new(Vec::new()) };
+    static FETCH_STATUS_RESPONSES: RefCell<VecDeque<FetchStatusResponse>> = RefCell::new(VecDeque::new());
+    static FETCH_STATUS_CALLS: RefCell<Vec<FetchStatusArgs>> = const { RefCell::new(Vec::new()) };
 }
 
 #[derive(Debug)]
@@ -18,6 +21,21 @@ impl FederationCanister for FederationCanisterMockClient {
     ) -> Result<(), crate::adapters::federation::FederationCanisterClientError> {
         CAPTURED.with(|c| c.borrow_mut().push(args));
         Ok(())
+    }
+
+    async fn fetch_status(
+        &self,
+        args: FetchStatusArgs,
+    ) -> Result<FetchStatusResponse, crate::adapters::federation::FederationCanisterClientError>
+    {
+        FETCH_STATUS_CALLS.with_borrow_mut(|v| v.push(args.clone()));
+        Ok(FETCH_STATUS_RESPONSES
+            .with_borrow_mut(|q| q.pop_front())
+            .unwrap_or_else(|| {
+                panic!(
+                    "FederationCanisterMockClient::fetch_status: no canned response queued for {args:?}"
+                )
+            }))
     }
 }
 
@@ -32,4 +50,24 @@ pub fn reset_captured() {
 #[allow(dead_code, reason = "used by domain-level unit tests")]
 pub fn captured() -> Vec<SendActivityArgs> {
     CAPTURED.with(|c| c.borrow().clone())
+}
+
+/// Queue a canned [`FetchStatusResponse`] to be returned by the next
+/// [`FederationCanisterMockClient::fetch_status`] call.
+pub fn push_fetch_status_response(resp: FetchStatusResponse) {
+    FETCH_STATUS_RESPONSES.with_borrow_mut(|q| q.push_back(resp));
+}
+
+/// Return a clone of every [`FetchStatusArgs`] passed to
+/// [`FederationCanisterMockClient::fetch_status`] since the last
+/// [`reset_fetch_status`].
+#[allow(dead_code, reason = "used by domain-level unit tests")]
+pub fn captured_fetch_status_calls() -> Vec<FetchStatusArgs> {
+    FETCH_STATUS_CALLS.with_borrow(|v| v.clone())
+}
+
+/// Reset the fetch-status response queue and call log. Call from `test_utils::setup`.
+pub fn reset_fetch_status() {
+    FETCH_STATUS_RESPONSES.with_borrow_mut(|q| q.clear());
+    FETCH_STATUS_CALLS.with_borrow_mut(|v| v.clear());
 }

--- a/crates/canisters/user/src/api.rs
+++ b/crates/canisters/user/src/api.rs
@@ -137,6 +137,11 @@ pub fn get_following(args: GetFollowingArgs) -> GetFollowingResponse {
     crate::domain::following::get_following(args)
 }
 
+/// Gets a single status by id, applying caller-scoped visibility rules.
+pub fn get_local_status(args: GetLocalStatusArgs) -> GetLocalStatusResponse {
+    crate::domain::status::get_local_status(args)
+}
+
 /// Likes a status.
 pub fn get_liked(args: GetLikedArgs) -> GetLikedResponse {
     crate::domain::liked::get_liked(args)

--- a/crates/canisters/user/src/api.rs
+++ b/crates/canisters/user/src/api.rs
@@ -87,6 +87,15 @@ pub async fn accept_follow(args: AcceptFollowArgs) -> AcceptFollowResponse {
     crate::domain::follower::accept_follow(args).await
 }
 
+/// Boost of a status.
+pub async fn boost_status(args: BoostStatusArgs) -> BoostStatusResponse {
+    if !inspect::is_owner(ic_utils::caller()) {
+        ic_utils::trap!("Only the owner can boost statuses");
+    }
+
+    crate::domain::boost::boost_status(args).await
+}
+
 /// Emit a `Delete(Person)` activity to followers on profile deletion.
 ///
 /// This function can only be called by the directory canister.
@@ -193,6 +202,15 @@ pub async fn reject_follow(args: RejectFollowArgs) -> RejectFollowResponse {
     }
 
     crate::domain::follower::reject_follow(args).await
+}
+
+/// Undoes a boost of a status.
+pub async fn undo_boost(args: UndoBoostArgs) -> UndoBoostResponse {
+    if !inspect::is_owner(ic_utils::caller()) {
+        ic_utils::trap!("Only the owner can undo boosts");
+    }
+
+    crate::domain::boost::undo_boost(args).await
 }
 
 /// Unfollows a user.

--- a/crates/canisters/user/src/api.rs
+++ b/crates/canisters/user/src/api.rs
@@ -137,14 +137,14 @@ pub fn get_following(args: GetFollowingArgs) -> GetFollowingResponse {
     crate::domain::following::get_following(args)
 }
 
-/// Gets a single status by id, applying caller-scoped visibility rules.
-pub fn get_local_status(args: GetLocalStatusArgs) -> GetLocalStatusResponse {
-    crate::domain::status::get_local_status(args)
-}
-
 /// Likes a status.
 pub fn get_liked(args: GetLikedArgs) -> GetLikedResponse {
     crate::domain::liked::get_liked(args)
+}
+
+/// Gets a single status by id, applying caller-scoped visibility rules.
+pub fn get_local_status(args: GetLocalStatusArgs) -> GetLocalStatusResponse {
+    crate::domain::status::get_local_status(args)
 }
 
 /// Gets the user profile.

--- a/crates/canisters/user/src/domain.rs
+++ b/crates/canisters/user/src/domain.rs
@@ -5,6 +5,7 @@ pub const MAX_PAGE_LIMIT: u64 = 50;
 
 pub mod activity;
 pub mod block;
+pub mod boost;
 pub mod ed25519;
 pub mod feed;
 pub mod follow_request;

--- a/crates/canisters/user/src/domain/activity/handle_incoming.rs
+++ b/crates/canisters/user/src/domain/activity/handle_incoming.rs
@@ -2,6 +2,7 @@
 
 use activitypub::Activity;
 use activitypub::activity::{ActivityObject, ActivityType};
+use db_utils::transaction::Transaction;
 use did::user::{ReceiveActivityArgs, ReceiveActivityError, ReceiveActivityResponse};
 use wasm_dbms_api::prelude::{Database, Nullable};
 
@@ -170,7 +171,11 @@ fn handle_accept(activity: &Activity) -> Result<(), ReceiveActivityError> {
 
     ic_utils::log!("handle_incoming: accepting following for {remote_actor_uri}");
 
-    FollowingRepository::update_status(remote_actor_uri, FollowStatus::Accepted).map_err(|e| {
+    Transaction::run::<_, _, _, CanisterError>(Schema, |tx| {
+        FollowingRepository::with_transaction(tx)
+            .update_status(remote_actor_uri, FollowStatus::Accepted)
+    })
+    .map_err(|e| {
         ic_utils::log!("handle_incoming: failed to update following status: {e}");
         match e {
             CanisterError::Database(_) => ReceiveActivityError::ProcessingFailed,
@@ -188,7 +193,8 @@ fn handle_reject(activity: &Activity) -> Result<(), ReceiveActivityError> {
 
     ic_utils::log!("handle_incoming: rejecting following for {remote_actor_uri}, removing entry");
 
-    FollowingRepository::delete_by_actor_uri(remote_actor_uri)
+    FollowingRepository::oneshot()
+        .delete_by_actor_uri(remote_actor_uri)
         .map_err(|e| {
             ic_utils::log!("handle_incoming: failed to delete following entry: {e}");
             match e {
@@ -594,7 +600,8 @@ mod tests {
         setup();
 
         // first, create a pending following entry (simulates follow_user having run)
-        FollowingRepository::insert_pending("https://mastic.social/users/bob")
+        FollowingRepository::oneshot()
+            .insert_pending("https://mastic.social/users/bob")
             .expect("should insert pending");
 
         let json = make_accept_follow_json(
@@ -608,7 +615,8 @@ mod tests {
 
         assert_eq!(response, ReceiveActivityResponse::Ok);
 
-        let entry = FollowingRepository::find_by_actor_uri("https://mastic.social/users/bob")
+        let entry = FollowingRepository::oneshot()
+            .find_by_actor_uri("https://mastic.social/users/bob")
             .expect("should query")
             .expect("should find following entry");
         assert_eq!(entry.status, FollowStatus::Accepted);
@@ -619,7 +627,8 @@ mod tests {
         setup();
 
         // first, create a pending following entry
-        FollowingRepository::insert_pending("https://mastic.social/users/bob")
+        FollowingRepository::oneshot()
+            .insert_pending("https://mastic.social/users/bob")
             .expect("should insert pending");
 
         let json = make_reject_follow_json(
@@ -634,7 +643,8 @@ mod tests {
         assert_eq!(response, ReceiveActivityResponse::Ok);
 
         // entry should be deleted, not updated to rejected
-        let entry = FollowingRepository::find_by_actor_uri("https://mastic.social/users/bob")
+        let entry = FollowingRepository::oneshot()
+            .find_by_actor_uri("https://mastic.social/users/bob")
             .expect("should query");
         assert!(
             entry.is_none(),

--- a/crates/canisters/user/src/domain/activity/handle_incoming.rs
+++ b/crates/canisters/user/src/domain/activity/handle_incoming.rs
@@ -34,6 +34,7 @@ pub fn handle_incoming(
         ActivityType::Accept => handle_accept(&activity),
         ActivityType::Reject => handle_reject(&activity),
         ActivityType::Like => handle_like(&activity),
+        ActivityType::Announce => handle_announce(&activity, &activity_json),
         ActivityType::Undo => handle_undo(&activity),
         other => {
             // Unknown / not-yet-implemented activity types are silently accepted.
@@ -229,6 +230,7 @@ fn handle_undo(activity: &Activity) -> Result<(), ReceiveActivityError> {
             Ok(())
         }
         ActivityType::Like => handle_undo_like(inner, sender_uri),
+        ActivityType::Announce => handle_undo_announce(inner, sender_uri),
         other => {
             ic_utils::log!("handle_incoming: ignoring Undo of unsupported inner type: {other:?}");
             Ok(())
@@ -236,9 +238,8 @@ fn handle_undo(activity: &Activity) -> Result<(), ReceiveActivityError> {
     }
 }
 
-/// Extract the status URI targeted by a `Like` activity, accepting either
-/// `object` as a bare id string or a wrapped object whose `id` is the URI.
-fn extract_like_target_uri(activity: &Activity) -> Option<String> {
+/// Extract the object URI from an `Id`-form or `Object`-form `ActivityObject`.
+fn extract_object_uri(activity: &Activity) -> Option<String> {
     match activity.object.as_ref()? {
         ActivityObject::Id(uri) => Some(uri.clone()),
         ActivityObject::Object(obj) => obj.id.clone(),
@@ -264,7 +265,7 @@ fn handle_like(activity: &Activity) -> Result<(), ReceiveActivityError> {
         .actor
         .as_deref()
         .ok_or(ReceiveActivityError::ProcessingFailed)?;
-    let Some(status_uri) = extract_like_target_uri(activity) else {
+    let Some(status_uri) = extract_object_uri(activity) else {
         ic_utils::log!("handle_incoming: Like missing object URI");
         return Err(ReceiveActivityError::ProcessingFailed);
     };
@@ -287,7 +288,7 @@ fn handle_like(activity: &Activity) -> Result<(), ReceiveActivityError> {
 /// Handle an `Undo(Like)` body: decrement the cached `like_count` if the
 /// inner activity refers to a local status. Ignored otherwise.
 fn handle_undo_like(inner: &Activity, sender_uri: &str) -> Result<(), ReceiveActivityError> {
-    let Some(status_uri) = extract_like_target_uri(inner) else {
+    let Some(status_uri) = extract_object_uri(inner) else {
         ic_utils::log!("handle_incoming: Undo(Like) missing object URI");
         return Err(ReceiveActivityError::ProcessingFailed);
     };
@@ -303,6 +304,134 @@ fn handle_undo_like(inner: &Activity, sender_uri: &str) -> Result<(), ReceiveAct
         ReceiveActivityError::Internal(e.to_string())
     })? {
         ic_utils::log!("handle_incoming: Undo(Like) target status {id} not found, ignoring");
+    }
+    Ok(())
+}
+
+/// Handle an incoming `Announce` (boost) activity.
+///
+/// Stores the announce in the inbox with `is_boost = true`, indexes it in
+/// the `feed` table so the boost shows up in the recipient's timeline, and
+/// — if the boosted status is hosted locally — increments the cached
+/// `statuses.boost_count` of the original.
+fn handle_announce(activity: &Activity, activity_json: &str) -> Result<(), ReceiveActivityError> {
+    let actor_uri = activity
+        .actor
+        .as_deref()
+        .ok_or(ReceiveActivityError::ProcessingFailed)?;
+    let Some(target_uri) = extract_object_uri(activity) else {
+        ic_utils::log!("handle_incoming: Announce missing object URI");
+        return Err(ReceiveActivityError::ProcessingFailed);
+    };
+
+    ic_utils::log!("handle_incoming: Announce from {actor_uri} on {target_uri}");
+
+    let snowflake_id = Snowflake::new();
+    let created_at = ic_utils::now();
+    let object_data: serde_json::Value = serde_json::from_str(activity_json).map_err(|e| {
+        ic_utils::log!("handle_incoming: failed to parse activity JSON: {e}");
+        ReceiveActivityError::Internal(e.to_string())
+    })?;
+
+    ic_dbms_canister::prelude::DBMS_CONTEXT
+        .with(|ctx| {
+            let tx_id =
+                ctx.begin_transaction(db_utils::transaction::transaction_caller(ic_utils::now()));
+            let mut db = wasm_dbms::WasmDbmsDatabase::from_transaction(ctx, Schema, tx_id);
+
+            db.insert::<InboxActivity>(InboxActivityInsertRequest {
+                id: snowflake_id.into(),
+                activity_type: DbActivityType::from(ActivityType::Announce),
+                actor_uri: actor_uri.into(),
+                object_data: object_data.into(),
+                is_boost: true.into(),
+                original_status_uri: Nullable::Value(target_uri.clone().into()),
+                created_at: created_at.into(),
+            })?;
+
+            db.insert::<FeedEntry>(FeedEntryInsertRequest {
+                id: snowflake_id.into(),
+                source: FeedSource::Inbox,
+                created_at: created_at.into(),
+            })?;
+
+            db.commit()?;
+            Ok(())
+        })
+        .map_err(|e: CanisterError| {
+            ic_utils::log!("handle_incoming: failed to insert announce inbox row: {e}");
+            ReceiveActivityError::Internal(e.to_string())
+        })?;
+
+    if let Some((_handle, id)) = parse_local_status(&target_uri)?
+        && !StatusRepository::increment_boost_count(id).map_err(|e| {
+            ic_utils::log!("handle_incoming: failed to increment boost_count: {e}");
+            ReceiveActivityError::Internal(e.to_string())
+        })?
+    {
+        ic_utils::log!("handle_incoming: Announce target status {id} not found, ignoring");
+    }
+    Ok(())
+}
+
+/// Handle an `Undo(Announce)` body.
+///
+/// Deletes the matching `(actor_uri, original_status_uri, is_boost = true)`
+/// inbox row and its `feed` entry, and — if the original is local —
+/// decrements the cached `statuses.boost_count` (saturating at 0).
+fn handle_undo_announce(inner: &Activity, sender_uri: &str) -> Result<(), ReceiveActivityError> {
+    let Some(target_uri) = extract_object_uri(inner) else {
+        ic_utils::log!("handle_incoming: Undo(Announce) missing object URI");
+        return Err(ReceiveActivityError::ProcessingFailed);
+    };
+    ic_utils::log!("handle_incoming: Undo(Announce) from {sender_uri} on {target_uri}");
+
+    use wasm_dbms_api::prelude::{DeleteBehavior, Filter, Query, Value};
+
+    ic_dbms_canister::prelude::DBMS_CONTEXT
+        .with(|ctx| {
+            let tx_id =
+                ctx.begin_transaction(db_utils::transaction::transaction_caller(ic_utils::now()));
+            let mut db = wasm_dbms::WasmDbmsDatabase::from_transaction(ctx, Schema, tx_id);
+
+            let rows = db.select::<InboxActivity>(
+                Query::builder()
+                    .all()
+                    .and_where(Filter::eq("actor_uri", Value::from(sender_uri)))
+                    .and_where(Filter::eq("is_boost", Value::from(true)))
+                    .and_where(Filter::eq(
+                        "original_status_uri",
+                        Value::from(target_uri.as_str()),
+                    ))
+                    .limit(1)
+                    .build(),
+            )?;
+            if let Some(row) = rows.into_iter().next() {
+                let id = row.id.expect("id").0;
+                db.delete::<FeedEntry>(
+                    DeleteBehavior::Restrict,
+                    Some(Filter::eq("id", Value::from(id))),
+                )?;
+                db.delete::<InboxActivity>(
+                    DeleteBehavior::Restrict,
+                    Some(Filter::eq("id", Value::from(id))),
+                )?;
+            }
+            db.commit()?;
+            Ok(())
+        })
+        .map_err(|e: CanisterError| {
+            ic_utils::log!("handle_incoming: failed to delete announce inbox row: {e}");
+            ReceiveActivityError::Internal(e.to_string())
+        })?;
+
+    if let Some((_handle, id)) = parse_local_status(&target_uri)?
+        && !StatusRepository::decrement_boost_count(id).map_err(|e| {
+            ic_utils::log!("handle_incoming: failed to decrement boost_count: {e}");
+            ReceiveActivityError::Internal(e.to_string())
+        })?
+    {
+        ic_utils::log!("handle_incoming: Undo(Announce) target status {id} not found, ignoring");
     }
     Ok(())
 }
@@ -925,6 +1054,158 @@ mod tests {
             .expect("should query")
             .expect("should find");
         assert_eq!(status.like_count.0, 0);
+    }
+
+    const REMOTE_BOOSTER: &str = "https://remote.example/users/alice";
+    const LOCAL_STATUS_URI: &str = "https://mastic.social/users/rey_canisteryo/statuses/42";
+
+    fn make_announce_json(actor: &str, target_uri: &str) -> String {
+        let activity = Activity {
+            base: BaseObject {
+                kind: ActivityType::Announce,
+                ..Default::default()
+            },
+            actor: Some(actor.into()),
+            object: Some(ActivityObject::Id(target_uri.into())),
+            target: None,
+            result: None,
+            origin: None,
+            instrument: None,
+        };
+        serde_json::to_string(&activity).unwrap()
+    }
+
+    fn make_undo_announce_json(actor: &str, target_uri: &str) -> String {
+        let activity = Activity {
+            base: BaseObject {
+                kind: ActivityType::Undo,
+                ..Default::default()
+            },
+            actor: Some(actor.into()),
+            object: Some(ActivityObject::Activity(Box::new(Activity {
+                base: BaseObject {
+                    kind: ActivityType::Announce,
+                    ..Default::default()
+                },
+                actor: Some(actor.into()),
+                object: Some(ActivityObject::Id(target_uri.into())),
+                target: None,
+                result: None,
+                origin: None,
+                instrument: None,
+            }))),
+            target: None,
+            result: None,
+            origin: None,
+            instrument: None,
+        };
+        serde_json::to_string(&activity).unwrap()
+    }
+
+    #[test]
+    fn test_should_store_inbox_row_on_announce() {
+        setup();
+        crate::test_utils::insert_status(42, "hi", did::common::Visibility::Public, 1_000);
+
+        let resp = handle_incoming(ReceiveActivityArgs {
+            activity_json: make_announce_json(REMOTE_BOOSTER, LOCAL_STATUS_URI),
+        });
+        assert_eq!(resp, ReceiveActivityResponse::Ok);
+
+        // boost_count incremented
+        let s = StatusRepository::find_by_id(42).unwrap().unwrap();
+        assert_eq!(s.boost_count.0, 1);
+
+        // inbox row + feed entry exist with is_boost=true
+        use ic_dbms_canister::prelude::DBMS_CONTEXT;
+        use wasm_dbms::WasmDbmsDatabase;
+        use wasm_dbms_api::prelude::{Database, Filter, Query, Value};
+        DBMS_CONTEXT.with(|ctx| {
+            let db = WasmDbmsDatabase::oneshot(ctx, crate::schema::Schema);
+            let inbox = db
+                .select::<crate::schema::InboxActivity>(
+                    Query::builder()
+                        .all()
+                        .and_where(Filter::eq("is_boost", Value::from(true)))
+                        .build(),
+                )
+                .unwrap();
+            assert_eq!(inbox.len(), 1);
+            let row = &inbox[0];
+            assert_eq!(row.actor_uri.as_ref().unwrap().0, REMOTE_BOOSTER);
+            assert_eq!(
+                row.original_status_uri
+                    .as_ref()
+                    .unwrap()
+                    .clone()
+                    .into_opt()
+                    .unwrap()
+                    .0,
+                LOCAL_STATUS_URI
+            );
+        });
+    }
+
+    #[test]
+    fn test_should_decrement_boost_count_and_delete_inbox_on_undo_announce() {
+        setup();
+        crate::test_utils::insert_status(42, "hi", did::common::Visibility::Public, 1_000);
+
+        handle_incoming(ReceiveActivityArgs {
+            activity_json: make_announce_json(REMOTE_BOOSTER, LOCAL_STATUS_URI),
+        });
+        let resp = handle_incoming(ReceiveActivityArgs {
+            activity_json: make_undo_announce_json(REMOTE_BOOSTER, LOCAL_STATUS_URI),
+        });
+        assert_eq!(resp, ReceiveActivityResponse::Ok);
+
+        let s = StatusRepository::find_by_id(42).unwrap().unwrap();
+        assert_eq!(s.boost_count.0, 0);
+
+        // Inbox boost row removed
+        use ic_dbms_canister::prelude::DBMS_CONTEXT;
+        use wasm_dbms::WasmDbmsDatabase;
+        use wasm_dbms_api::prelude::{Database, Filter, Query, Value};
+        DBMS_CONTEXT.with(|ctx| {
+            let db = WasmDbmsDatabase::oneshot(ctx, crate::schema::Schema);
+            let inbox = db
+                .select::<crate::schema::InboxActivity>(
+                    Query::builder()
+                        .all()
+                        .and_where(Filter::eq("is_boost", Value::from(true)))
+                        .build(),
+                )
+                .unwrap();
+            assert!(inbox.is_empty(), "inbox boost row removed");
+        });
+    }
+
+    #[test]
+    fn test_announce_on_remote_status_does_not_panic_or_affect_counts() {
+        setup();
+        let resp = handle_incoming(ReceiveActivityArgs {
+            activity_json: make_announce_json(
+                REMOTE_BOOSTER,
+                "https://other.example/users/bob/statuses/9",
+            ),
+        });
+        assert_eq!(resp, ReceiveActivityResponse::Ok);
+        // No local status to update; no panic.
+    }
+
+    #[test]
+    fn test_undo_announce_saturates_at_zero() {
+        setup();
+        crate::test_utils::insert_status(42, "hi", did::common::Visibility::Public, 1_000);
+
+        // Undo without prior Announce — boost_count stays at 0.
+        let resp = handle_incoming(ReceiveActivityArgs {
+            activity_json: make_undo_announce_json(REMOTE_BOOSTER, LOCAL_STATUS_URI),
+        });
+        assert_eq!(resp, ReceiveActivityResponse::Ok);
+
+        let s = StatusRepository::find_by_id(42).unwrap().unwrap();
+        assert_eq!(s.boost_count.0, 0);
     }
 
     #[test]

--- a/crates/canisters/user/src/domain/activity/handle_incoming.rs
+++ b/crates/canisters/user/src/domain/activity/handle_incoming.rs
@@ -447,10 +447,12 @@ fn parse_local_status(status_uri: &str) -> Result<Option<(String, u64)>, Receive
         return Ok(None);
     };
 
-    let own = crate::domain::profile::ProfileRepository::get_profile().map_err(|e| {
-        ic_utils::log!("handle_incoming: failed to load own profile: {e}");
-        ReceiveActivityError::Internal(e.to_string())
-    })?;
+    let own = crate::domain::profile::ProfileRepository::oneshot()
+        .get_profile()
+        .map_err(|e| {
+            ic_utils::log!("handle_incoming: failed to load own profile: {e}");
+            ReceiveActivityError::Internal(e.to_string())
+        })?;
     if handle != own.handle.0 {
         return Ok(None);
     }

--- a/crates/canisters/user/src/domain/activity/handle_incoming.rs
+++ b/crates/canisters/user/src/domain/activity/handle_incoming.rs
@@ -118,20 +118,24 @@ fn handle_follow(activity: &Activity) -> Result<(), ReceiveActivityError> {
     ic_utils::log!("handle_incoming: Follow from {actor_uri}");
 
     // Check for existing follow request to ensure idempotency (AP retries)
-    let existing = FollowRequestRepository::find_by_actor_uri(actor_uri).map_err(|e| {
-        ic_utils::log!("handle_incoming: failed to look up follow request: {e}");
-        ReceiveActivityError::Internal(e.to_string())
-    })?;
+    let existing = FollowRequestRepository::oneshot()
+        .find_by_actor_uri(actor_uri)
+        .map_err(|e| {
+            ic_utils::log!("handle_incoming: failed to look up follow request: {e}");
+            ReceiveActivityError::Internal(e.to_string())
+        })?;
 
     if existing.is_some() {
         ic_utils::log!("handle_incoming: follow request from {actor_uri} already exists, skipping");
         return Ok(());
     }
 
-    FollowRequestRepository::insert(actor_uri).map_err(|e| {
-        ic_utils::log!("handle_incoming: failed to insert follow request: {e}");
-        ReceiveActivityError::Internal(e.to_string())
-    })
+    FollowRequestRepository::oneshot()
+        .insert(actor_uri)
+        .map_err(|e| {
+            ic_utils::log!("handle_incoming: failed to insert follow request: {e}");
+            ReceiveActivityError::Internal(e.to_string())
+        })
 }
 
 /// Validate that the activity wraps an inner `Follow` activity and extract
@@ -225,10 +229,12 @@ fn handle_undo(activity: &Activity) -> Result<(), ReceiveActivityError> {
                     ic_utils::log!("handle_incoming: failed to delete follower: {e}");
                     ReceiveActivityError::Internal(e.to_string())
                 })?;
-            FollowRequestRepository::delete_by_actor_uri(sender_uri).map_err(|e| {
-                ic_utils::log!("handle_incoming: failed to delete follow request: {e}");
-                ReceiveActivityError::Internal(e.to_string())
-            })?;
+            FollowRequestRepository::oneshot()
+                .delete_by_actor_uri(sender_uri)
+                .map_err(|e| {
+                    ic_utils::log!("handle_incoming: failed to delete follow request: {e}");
+                    ReceiveActivityError::Internal(e.to_string())
+                })?;
             Ok(())
         }
         ActivityType::Like => handle_undo_like(inner, sender_uri),
@@ -576,10 +582,10 @@ mod tests {
 
         assert_eq!(response, ReceiveActivityResponse::Ok);
 
-        let request =
-            FollowRequestRepository::find_by_actor_uri("https://mastic.social/users/alice")
-                .expect("should query")
-                .expect("should find follow request");
+        let request = FollowRequestRepository::oneshot()
+            .find_by_actor_uri("https://mastic.social/users/alice")
+            .expect("should query")
+            .expect("should find follow request");
         assert_eq!(request.actor_uri.0, "https://mastic.social/users/alice");
     }
 
@@ -693,10 +699,10 @@ mod tests {
         assert_eq!(second, ReceiveActivityResponse::Ok);
 
         // only one follow request should exist
-        let request =
-            FollowRequestRepository::find_by_actor_uri("https://mastic.social/users/alice")
-                .expect("should query")
-                .expect("should find follow request");
+        let request = FollowRequestRepository::oneshot()
+            .find_by_actor_uri("https://mastic.social/users/alice")
+            .expect("should query")
+            .expect("should find follow request");
         assert_eq!(request.actor_uri.0, "https://mastic.social/users/alice");
     }
 
@@ -786,7 +792,8 @@ mod tests {
     fn test_should_remove_pending_follow_request_on_undo_follow() {
         setup();
 
-        FollowRequestRepository::insert("https://mastic.social/users/alice")
+        FollowRequestRepository::oneshot()
+            .insert("https://mastic.social/users/alice")
             .expect("should insert");
 
         let json = make_undo_follow_json(
@@ -799,9 +806,9 @@ mod tests {
         });
         assert_eq!(response, ReceiveActivityResponse::Ok);
 
-        let request =
-            FollowRequestRepository::find_by_actor_uri("https://mastic.social/users/alice")
-                .expect("should query");
+        let request = FollowRequestRepository::oneshot()
+            .find_by_actor_uri("https://mastic.social/users/alice")
+            .expect("should query");
         assert!(request.is_none(), "follow request should be deleted");
     }
 

--- a/crates/canisters/user/src/domain/activity/handle_incoming.rs
+++ b/crates/canisters/user/src/domain/activity/handle_incoming.rs
@@ -219,10 +219,12 @@ fn handle_undo(activity: &Activity) -> Result<(), ReceiveActivityError> {
         ActivityType::Follow => {
             ic_utils::log!("handle_incoming: Undo(Follow) from {sender_uri}");
 
-            FollowerRepository::delete_by_actor_uri(sender_uri).map_err(|e| {
-                ic_utils::log!("handle_incoming: failed to delete follower: {e}");
-                ReceiveActivityError::Internal(e.to_string())
-            })?;
+            FollowerRepository::oneshot()
+                .delete_by_actor_uri(sender_uri)
+                .map_err(|e| {
+                    ic_utils::log!("handle_incoming: failed to delete follower: {e}");
+                    ReceiveActivityError::Internal(e.to_string())
+                })?;
             FollowRequestRepository::delete_by_actor_uri(sender_uri).map_err(|e| {
                 ic_utils::log!("handle_incoming: failed to delete follow request: {e}");
                 ReceiveActivityError::Internal(e.to_string())
@@ -760,7 +762,9 @@ mod tests {
     fn test_should_remove_follower_on_undo_follow() {
         setup();
 
-        FollowerRepository::insert("https://mastic.social/users/alice").expect("should insert");
+        FollowerRepository::oneshot()
+            .insert("https://mastic.social/users/alice")
+            .expect("should insert");
 
         let json = make_undo_follow_json(
             "https://mastic.social/users/alice",
@@ -772,7 +776,9 @@ mod tests {
         });
         assert_eq!(response, ReceiveActivityResponse::Ok);
 
-        let followers = FollowerRepository::get_followers().expect("should query");
+        let followers = FollowerRepository::oneshot()
+            .get_followers()
+            .expect("should query");
         assert!(followers.is_empty(), "follower entry should be deleted");
     }
 

--- a/crates/canisters/user/src/domain/activity/handle_incoming.rs
+++ b/crates/canisters/user/src/domain/activity/handle_incoming.rs
@@ -2,6 +2,7 @@
 
 use activitypub::Activity;
 use activitypub::activity::{ActivityObject, ActivityType};
+use db_utils::repository::Repository;
 use db_utils::transaction::Transaction;
 use did::user::{ReceiveActivityArgs, ReceiveActivityError, ReceiveActivityResponse};
 use wasm_dbms_api::prelude::{Database, Nullable};
@@ -489,6 +490,7 @@ mod tests {
 
     use activitypub::activity::{Activity, ActivityObject, ActivityType};
     use activitypub::object::BaseObject;
+    use db_utils::repository::Repository;
     use did::user::{ReceiveActivityArgs, ReceiveActivityError, ReceiveActivityResponse};
 
     use super::handle_incoming;

--- a/crates/canisters/user/src/domain/activity/handle_incoming.rs
+++ b/crates/canisters/user/src/domain/activity/handle_incoming.rs
@@ -290,10 +290,13 @@ fn handle_like(activity: &Activity) -> Result<(), ReceiveActivityError> {
         return Ok(());
     };
 
-    if !StatusRepository::increment_like_count(id).map_err(|e| {
-        ic_utils::log!("handle_incoming: failed to increment like_count: {e}");
-        ReceiveActivityError::Internal(e.to_string())
-    })? {
+    if !StatusRepository::oneshot()
+        .increment_like_count(id)
+        .map_err(|e| {
+            ic_utils::log!("handle_incoming: failed to increment like_count: {e}");
+            ReceiveActivityError::Internal(e.to_string())
+        })?
+    {
         ic_utils::log!("handle_incoming: Like target status {id} not found, ignoring");
     }
     Ok(())
@@ -313,10 +316,13 @@ fn handle_undo_like(inner: &Activity, sender_uri: &str) -> Result<(), ReceiveAct
         return Ok(());
     };
 
-    if !StatusRepository::decrement_like_count(id).map_err(|e| {
-        ic_utils::log!("handle_incoming: failed to decrement like_count: {e}");
-        ReceiveActivityError::Internal(e.to_string())
-    })? {
+    if !StatusRepository::oneshot()
+        .decrement_like_count(id)
+        .map_err(|e| {
+            ic_utils::log!("handle_incoming: failed to decrement like_count: {e}");
+            ReceiveActivityError::Internal(e.to_string())
+        })?
+    {
         ic_utils::log!("handle_incoming: Undo(Like) target status {id} not found, ignoring");
     }
     Ok(())
@@ -378,10 +384,12 @@ fn handle_announce(activity: &Activity, activity_json: &str) -> Result<(), Recei
         })?;
 
     if let Some((_handle, id)) = parse_local_status(&target_uri)?
-        && !StatusRepository::increment_boost_count(id).map_err(|e| {
-            ic_utils::log!("handle_incoming: failed to increment boost_count: {e}");
-            ReceiveActivityError::Internal(e.to_string())
-        })?
+        && !StatusRepository::oneshot()
+            .increment_boost_count(id)
+            .map_err(|e| {
+                ic_utils::log!("handle_incoming: failed to increment boost_count: {e}");
+                ReceiveActivityError::Internal(e.to_string())
+            })?
     {
         ic_utils::log!("handle_incoming: Announce target status {id} not found, ignoring");
     }
@@ -440,10 +448,12 @@ fn handle_undo_announce(inner: &Activity, sender_uri: &str) -> Result<(), Receiv
         })?;
 
     if let Some((_handle, id)) = parse_local_status(&target_uri)?
-        && !StatusRepository::decrement_boost_count(id).map_err(|e| {
-            ic_utils::log!("handle_incoming: failed to decrement boost_count: {e}");
-            ReceiveActivityError::Internal(e.to_string())
-        })?
+        && !StatusRepository::oneshot()
+            .decrement_boost_count(id)
+            .map_err(|e| {
+                ic_utils::log!("handle_incoming: failed to decrement boost_count: {e}");
+                ReceiveActivityError::Internal(e.to_string())
+            })?
     {
         ic_utils::log!("handle_incoming: Undo(Announce) target status {id} not found, ignoring");
     }
@@ -963,7 +973,8 @@ mod tests {
         });
         assert_eq!(response, ReceiveActivityResponse::Ok);
 
-        let status = StatusRepository::find_by_id(42)
+        let status = StatusRepository::oneshot()
+            .find_by_id(42)
             .expect("should query")
             .expect("should find");
         assert_eq!(status.like_count.0, 1);
@@ -997,7 +1008,8 @@ mod tests {
             ReceiveActivityResponse::Ok
         );
 
-        let status = StatusRepository::find_by_id(42)
+        let status = StatusRepository::oneshot()
+            .find_by_id(42)
             .expect("should query")
             .expect("should find");
         assert_eq!(status.like_count.0, 0);
@@ -1034,7 +1046,8 @@ mod tests {
             ReceiveActivityResponse::Ok
         );
 
-        let status = StatusRepository::find_by_id(42)
+        let status = StatusRepository::oneshot()
+            .find_by_id(42)
             .expect("should query")
             .expect("should find");
         assert_eq!(
@@ -1075,7 +1088,8 @@ mod tests {
             ReceiveActivityResponse::Ok
         );
 
-        let status = StatusRepository::find_by_id(42)
+        let status = StatusRepository::oneshot()
+            .find_by_id(42)
             .expect("should query")
             .expect("should find");
         assert_eq!(status.like_count.0, 0);
@@ -1138,7 +1152,7 @@ mod tests {
         assert_eq!(resp, ReceiveActivityResponse::Ok);
 
         // boost_count incremented
-        let s = StatusRepository::find_by_id(42).unwrap().unwrap();
+        let s = StatusRepository::oneshot().find_by_id(42).unwrap().unwrap();
         assert_eq!(s.boost_count.0, 1);
 
         // inbox row + feed entry exist with is_boost=true
@@ -1184,7 +1198,7 @@ mod tests {
         });
         assert_eq!(resp, ReceiveActivityResponse::Ok);
 
-        let s = StatusRepository::find_by_id(42).unwrap().unwrap();
+        let s = StatusRepository::oneshot().find_by_id(42).unwrap().unwrap();
         assert_eq!(s.boost_count.0, 0);
 
         // Inbox boost row removed
@@ -1229,7 +1243,7 @@ mod tests {
         });
         assert_eq!(resp, ReceiveActivityResponse::Ok);
 
-        let s = StatusRepository::find_by_id(42).unwrap().unwrap();
+        let s = StatusRepository::oneshot().find_by_id(42).unwrap().unwrap();
         assert_eq!(s.boost_count.0, 0);
     }
 

--- a/crates/canisters/user/src/domain/block/repository.rs
+++ b/crates/canisters/user/src/domain/block/repository.rs
@@ -2,9 +2,8 @@
 
 use std::collections::HashSet;
 
-use ic_dbms_canister::prelude::{DBMS_CONTEXT, IcAccessControlList, IcMemoryProvider};
-use wasm_dbms::WasmDbmsDatabase;
-use wasm_dbms::prelude::DbmsContext;
+use db_utils::repository::Repository;
+use ic_dbms_canister::prelude::DBMS_CONTEXT;
 use wasm_dbms_api::prelude::{Database, Query, TransactionId};
 
 use crate::error::{CanisterError, CanisterResult};
@@ -15,27 +14,6 @@ pub struct BlockRepository {
 }
 
 impl BlockRepository {
-    pub const fn oneshot() -> Self {
-        Self { tx: None }
-    }
-
-    // Reserved for future cross-repo atomic flows that need to splice block
-    // reads/writes into an externally-driven transaction. Not yet wired up.
-    #[allow(dead_code)]
-    pub const fn with_transaction(tx: TransactionId) -> Self {
-        Self { tx: Some(tx) }
-    }
-
-    fn db<'a>(
-        &self,
-        ctx: &'a DbmsContext<IcMemoryProvider, IcAccessControlList>,
-    ) -> WasmDbmsDatabase<'a, IcMemoryProvider, IcAccessControlList> {
-        match self.tx {
-            Some(id) => WasmDbmsDatabase::from_transaction(ctx, Schema, id),
-            None => WasmDbmsDatabase::oneshot(ctx, Schema),
-        }
-    }
-
     /// Return the set of actor URIs blocked by the owner.
     pub fn list_blocked_uris(&self) -> CanisterResult<HashSet<String>> {
         DBMS_CONTEXT.with(|ctx| {
@@ -56,8 +34,30 @@ impl BlockRepository {
     }
 }
 
+impl Repository for BlockRepository {
+    type Schema = Schema;
+
+    fn schema() -> Self::Schema {
+        Schema
+    }
+
+    fn oneshot() -> Self {
+        Self { tx: None }
+    }
+
+    fn with_transaction(tx: TransactionId) -> Self {
+        Self { tx: Some(tx) }
+    }
+
+    fn tx(&self) -> Option<TransactionId> {
+        self.tx
+    }
+}
+
 #[cfg(test)]
 mod tests {
+    use wasm_dbms::WasmDbmsDatabase;
+
     use super::*;
     use crate::schema::BlockInsertRequest;
     use crate::test_utils::setup;

--- a/crates/canisters/user/src/domain/block/repository.rs
+++ b/crates/canisters/user/src/domain/block/repository.rs
@@ -2,22 +2,45 @@
 
 use std::collections::HashSet;
 
-use ic_dbms_canister::prelude::DBMS_CONTEXT;
+use ic_dbms_canister::prelude::{DBMS_CONTEXT, IcAccessControlList, IcMemoryProvider};
 use wasm_dbms::WasmDbmsDatabase;
-use wasm_dbms_api::prelude::*;
+use wasm_dbms::prelude::DbmsContext;
+use wasm_dbms_api::prelude::{Database, Query, TransactionId};
 
 use crate::error::{CanisterError, CanisterResult};
 use crate::schema::{Block, BlockRecord, Schema};
 
-pub struct BlockRepository;
+pub struct BlockRepository {
+    tx: Option<TransactionId>,
+}
 
 impl BlockRepository {
-    /// Return the set of actor URIs blocked by the owner.
-    pub fn list_blocked_uris() -> CanisterResult<HashSet<String>> {
-        DBMS_CONTEXT.with(|ctx| {
-            let db = WasmDbmsDatabase::oneshot(ctx, Schema);
+    pub const fn oneshot() -> Self {
+        Self { tx: None }
+    }
 
-            db.select::<Block>(Query::builder().all().build())
+    // Reserved for future cross-repo atomic flows that need to splice block
+    // reads/writes into an externally-driven transaction. Not yet wired up.
+    #[allow(dead_code)]
+    pub const fn with_transaction(tx: TransactionId) -> Self {
+        Self { tx: Some(tx) }
+    }
+
+    fn db<'a>(
+        &self,
+        ctx: &'a DbmsContext<IcMemoryProvider, IcAccessControlList>,
+    ) -> WasmDbmsDatabase<'a, IcMemoryProvider, IcAccessControlList> {
+        match self.tx {
+            Some(id) => WasmDbmsDatabase::from_transaction(ctx, Schema, id),
+            None => WasmDbmsDatabase::oneshot(ctx, Schema),
+        }
+    }
+
+    /// Return the set of actor URIs blocked by the owner.
+    pub fn list_blocked_uris(&self) -> CanisterResult<HashSet<String>> {
+        DBMS_CONTEXT.with(|ctx| {
+            self.db(ctx)
+                .select::<Block>(Query::builder().all().build())
                 .map(|records| {
                     records
                         .into_iter()
@@ -53,7 +76,9 @@ mod tests {
     #[test]
     fn test_list_blocked_uris_empty() {
         setup();
-        let blocked = BlockRepository::list_blocked_uris().expect("should query");
+        let blocked = BlockRepository::oneshot()
+            .list_blocked_uris()
+            .expect("should query");
         assert!(blocked.is_empty());
     }
 
@@ -63,7 +88,9 @@ mod tests {
         insert_block("https://remote.example/users/eve");
         insert_block("https://remote.example/users/mallory");
 
-        let blocked = BlockRepository::list_blocked_uris().expect("should query");
+        let blocked = BlockRepository::oneshot()
+            .list_blocked_uris()
+            .expect("should query");
         assert_eq!(blocked.len(), 2);
         assert!(blocked.contains("https://remote.example/users/eve"));
         assert!(blocked.contains("https://remote.example/users/mallory"));

--- a/crates/canisters/user/src/domain/boost.rs
+++ b/crates/canisters/user/src/domain/boost.rs
@@ -1,0 +1,8 @@
+//! Boost status domain
+
+mod boost_status;
+mod repository;
+mod undo_boost;
+
+pub use self::boost_status::boost_status;
+pub use self::undo_boost::undo_boost;

--- a/crates/canisters/user/src/domain/boost.rs
+++ b/crates/canisters/user/src/domain/boost.rs
@@ -5,4 +5,5 @@ mod repository;
 mod undo_boost;
 
 pub use self::boost_status::boost_status;
+pub use self::repository::BoostRepository;
 pub use self::undo_boost::undo_boost;

--- a/crates/canisters/user/src/domain/boost/boost_status.rs
+++ b/crates/canisters/user/src/domain/boost/boost_status.rs
@@ -28,7 +28,9 @@ async fn boost_status_impl(status_uri: String) -> CanisterResult<()> {
     // Insert the boost into the database first; if federation dispatch
     // later fails, the user can re-trigger and the row already exists,
     // making the second call a no-op.
-    BoostRepository::boost_status(&status_uri)?;
+    // TODO(Task 11): provide real `id` and `status_id` values.
+    #[allow(unreachable_code)]
+    BoostRepository::boost_status(todo!(), todo!(), &status_uri)?;
 
     Ok(())
 }

--- a/crates/canisters/user/src/domain/boost/boost_status.rs
+++ b/crates/canisters/user/src/domain/boost/boost_status.rs
@@ -110,7 +110,8 @@ async fn boost_status_inner(status_url: String) -> CanisterResult<()> {
 /// - For a third-party boost, include the author unconditionally
 ///   (deduplication via sort + dedup handles overlap with followers).
 fn compute_recipients(fetched: &Status, own_actor_uri: &str) -> CanisterResult<Vec<String>> {
-    let mut recipients: Vec<String> = FollowerRepository::get_followers()?
+    let mut recipients: Vec<String> = FollowerRepository::oneshot()
+        .get_followers()?
         .into_iter()
         .map(|f| f.actor_uri.0)
         .collect();
@@ -189,7 +190,9 @@ mod tests {
     }
 
     fn insert_follower(uri: &str) {
-        FollowerRepository::insert(uri).expect("insert follower");
+        FollowerRepository::oneshot()
+            .insert(uri)
+            .expect("insert follower");
     }
 
     #[tokio::test]

--- a/crates/canisters/user/src/domain/boost/boost_status.rs
+++ b/crates/canisters/user/src/domain/boost/boost_status.rs
@@ -1,36 +1,9 @@
 //! Flow for boosting a status.
+//!
+//! Implementation lands in WI-1.7 Task 11.
 
-use did::user::{BoostStatusArgs, BoostStatusError, BoostStatusResponse};
+use did::user::{BoostStatusArgs, BoostStatusResponse};
 
-use crate::domain::boost::repository::BoostRepository;
-use crate::error::CanisterResult;
-
-/// Boost of a status.
-pub async fn boost_status(BoostStatusArgs { status_url }: BoostStatusArgs) -> BoostStatusResponse {
-    match boost_status_impl(status_url).await {
-        Ok(()) => BoostStatusResponse::Ok,
-        Err(err) => {
-            ic_utils::log!("Failed to boost status: {err}");
-            BoostStatusResponse::Err(BoostStatusError::Internal(err.to_string()))
-        }
-    }
-}
-
-async fn boost_status_impl(status_uri: String) -> CanisterResult<()> {
-    ic_utils::log!("Boosting status with URI: {status_uri}");
-
-    // Idempotent: if already boosted, do not duplicate or re-emit.
-    if BoostRepository::is_boosted(&status_uri)? {
-        ic_utils::log!("Status already boosted: {status_uri}");
-        return Ok(());
-    }
-
-    // Insert the boost into the database first; if federation dispatch
-    // later fails, the user can re-trigger and the row already exists,
-    // making the second call a no-op.
-    // TODO(Task 11): provide real `id` and `status_id` values.
-    #[allow(unreachable_code)]
-    BoostRepository::boost_status(todo!(), todo!(), &status_uri)?;
-
-    Ok(())
+pub async fn boost_status(_args: BoostStatusArgs) -> BoostStatusResponse {
+    todo!()
 }

--- a/crates/canisters/user/src/domain/boost/boost_status.rs
+++ b/crates/canisters/user/src/domain/boost/boost_status.rs
@@ -1,9 +1,292 @@
 //! Flow for boosting a status.
 //!
-//! Implementation lands in WI-1.7 Task 11.
+//! See `.claude/specs/2026-05-02-wi-1-7-boost-status-design.md` for the
+//! full design.
+//!
+//! Pipeline:
+//! 1. Idempotency: if a boost row for `status_url` already exists → `Ok`.
+//! 2. Fetch the original status via `Federation.fetch_status` so the
+//!    wrapper's denormalized content is verified, not caller-supplied.
+//! 3. Mint a single Snowflake reused as `boosts.id`, `boosts.status_id`,
+//!    wrapper `statuses.id`, and `feed.id`. The wrapper status URL
+//!    `<own_actor_uri>/statuses/<snowflake>` doubles as the `Announce`
+//!    activity id.
+//! 4. Insert the wrapper Status, Boost, and FeedEntry in one transaction.
+//! 5. Build an `Announce` activity addressed to followers ∪ {original
+//!    author} (deduplicated; self-boost addresses self) and dispatch
+//!    a per-recipient batch via the federation adapter.
 
-use did::user::{BoostStatusArgs, BoostStatusResponse};
+use activitypub::Activity;
+use activitypub::activity::{ActivityObject, ActivityType};
+use activitypub::context::ACTIVITY_STREAMS_CONTEXT;
+use activitypub::object::{BaseObject, OneOrMany};
+use did::common::Status;
+use did::federation::{
+    FetchStatusArgs, FetchStatusResponse, SendActivityArgs, SendActivityArgsObject,
+};
+use did::user::{BoostStatusArgs, BoostStatusError, BoostStatusResponse};
 
-pub async fn boost_status(_args: BoostStatusArgs) -> BoostStatusResponse {
-    todo!()
+use crate::domain::boost::repository::BoostRepository;
+use crate::domain::follower::FollowerRepository;
+use crate::domain::profile::ProfileRepository;
+use crate::domain::snowflake::Snowflake;
+use crate::domain::urls;
+use crate::error::{CanisterError, CanisterResult};
+
+const AS_PUBLIC: &str = "https://www.w3.org/ns/activitystreams#Public";
+
+pub async fn boost_status(BoostStatusArgs { status_url }: BoostStatusArgs) -> BoostStatusResponse {
+    match boost_status_inner(status_url).await {
+        Ok(()) => BoostStatusResponse::Ok,
+        Err(err) => {
+            ic_utils::log!("Failed to boost status: {err}");
+            BoostStatusResponse::Err(BoostStatusError::Internal(err.to_string()))
+        }
+    }
+}
+
+async fn boost_status_inner(status_url: String) -> CanisterResult<()> {
+    ic_utils::log!("Boosting status {status_url}");
+
+    if BoostRepository::is_boosted(&status_url)? {
+        ic_utils::log!("Status already boosted: {status_url}");
+        return Ok(());
+    }
+
+    let own_profile = ProfileRepository::get_profile()?;
+    let own_actor_uri = urls::actor_uri(&own_profile.handle.0)?;
+
+    let fetched = match crate::adapters::federation::fetch_status(FetchStatusArgs {
+        uri: status_url.clone(),
+        requester_actor_uri: Some(own_actor_uri.clone()),
+    })
+    .await?
+    {
+        FetchStatusResponse::Ok(status) => status,
+        FetchStatusResponse::Err(err) => {
+            return Err(CanisterError::Internal(format!(
+                "fetch_status failed: {err:?}"
+            )));
+        }
+    };
+
+    let snowflake: u64 = Snowflake::new().into();
+    let now = ic_utils::now();
+
+    BoostRepository::insert_boost_with_wrapper(
+        snowflake,
+        &status_url,
+        &fetched.content,
+        fetched.visibility.into(),
+        fetched.spoiler_text.as_deref(),
+        fetched.sensitive,
+        now,
+    )?;
+
+    let recipients = compute_recipients(&fetched, &own_actor_uri)?;
+    if recipients.is_empty() {
+        ic_utils::log!("Boost: no recipients to dispatch");
+        return Ok(());
+    }
+    let activity = make_announce_activity(&own_actor_uri, snowflake, &status_url, &recipients);
+    let activity_json =
+        serde_json::to_string(&activity).expect("Activity serialization must not fail");
+    let batch: Vec<SendActivityArgsObject> = recipients
+        .iter()
+        .map(|recipient| SendActivityArgsObject {
+            activity_json: activity_json.clone(),
+            target_inbox: format!("{recipient}/inbox"),
+        })
+        .collect();
+
+    crate::adapters::federation::send_activity(SendActivityArgs::Batch(batch)).await?;
+    Ok(())
+}
+
+/// Compute the dedup'd recipient list for an Announce: followers ∪ author.
+///
+/// - For a self-boost (author == self), include self only if it isn't
+///   already in the followers set.
+/// - For a third-party boost, include the author unconditionally
+///   (deduplication via sort + dedup handles overlap with followers).
+fn compute_recipients(fetched: &Status, own_actor_uri: &str) -> CanisterResult<Vec<String>> {
+    let mut recipients: Vec<String> = FollowerRepository::get_followers()?
+        .into_iter()
+        .map(|f| f.actor_uri.0)
+        .collect();
+    if fetched.author == own_actor_uri {
+        if !recipients.iter().any(|r| r == own_actor_uri) {
+            recipients.push(own_actor_uri.to_string());
+        }
+    } else if !fetched.author.is_empty() {
+        recipients.push(fetched.author.clone());
+    }
+    recipients.sort();
+    recipients.dedup();
+    Ok(recipients)
+}
+
+fn make_announce_activity(
+    own_actor_uri: &str,
+    wrapper_id: u64,
+    status_url: &str,
+    recipients: &[String],
+) -> Activity {
+    let cc = if recipients.is_empty() {
+        None
+    } else {
+        Some(OneOrMany::Many(recipients.to_vec()))
+    };
+    Activity {
+        base: BaseObject {
+            id: Some(format!("{own_actor_uri}/statuses/{wrapper_id}")),
+            context: Some(activitypub::context::Context::Uri(
+                ACTIVITY_STREAMS_CONTEXT.to_string(),
+            )),
+            kind: ActivityType::Announce,
+            to: Some(OneOrMany::One(AS_PUBLIC.to_string())),
+            cc,
+            ..Default::default()
+        },
+        actor: Some(own_actor_uri.to_string()),
+        object: Some(ActivityObject::Id(status_url.to_string())),
+        target: None,
+        result: None,
+        origin: None,
+        instrument: None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use activitypub::activity::ActivityType;
+    use did::common::{Status, Visibility};
+    use did::federation::{FetchStatusError, FetchStatusResponse, SendActivityArgs};
+    use did::user::{BoostStatusArgs, BoostStatusError, BoostStatusResponse};
+
+    use super::*;
+    use crate::adapters::federation::mock::{captured, push_fetch_status_response};
+    use crate::domain::boost::repository::BoostRepository;
+    use crate::domain::follower::FollowerRepository;
+    use crate::test_utils::setup;
+
+    const STATUS_URI: &str = "https://remote.example/users/bob/statuses/42";
+    const OWN_URI: &str = "https://mastic.social/users/rey_canisteryo";
+    const FOLLOWER_URI: &str = "https://remote.example/users/charlie";
+
+    fn fixture_status() -> Status {
+        Status {
+            id: 42,
+            content: "hello".into(),
+            author: "https://remote.example/users/bob".into(),
+            created_at: 1_000,
+            visibility: Visibility::Public,
+            like_count: 0,
+            boost_count: 0,
+            spoiler_text: Some("cw".into()),
+            sensitive: true,
+        }
+    }
+
+    fn insert_follower(uri: &str) {
+        FollowerRepository::insert(uri).expect("insert follower");
+    }
+
+    #[tokio::test]
+    async fn test_should_boost_status() {
+        setup();
+        insert_follower(FOLLOWER_URI);
+        push_fetch_status_response(FetchStatusResponse::Ok(fixture_status()));
+
+        let resp = boost_status(BoostStatusArgs {
+            status_url: STATUS_URI.to_string(),
+        })
+        .await;
+        assert_eq!(resp, BoostStatusResponse::Ok);
+        assert!(BoostRepository::is_boosted(STATUS_URI).expect("query"));
+
+        let captured = captured();
+        assert_eq!(captured.len(), 1);
+        let SendActivityArgs::Batch(batch) = &captured[0] else {
+            panic!("expected batch");
+        };
+        // recipients: follower + bob (author), deduplicated
+        assert_eq!(batch.len(), 2);
+        for entry in batch {
+            let activity: activitypub::Activity =
+                serde_json::from_str(&entry.activity_json).unwrap();
+            assert_eq!(activity.base.kind, ActivityType::Announce);
+            assert_eq!(activity.actor.as_deref(), Some(OWN_URI));
+        }
+    }
+
+    #[tokio::test]
+    async fn test_should_be_idempotent_when_already_boosted() {
+        setup();
+        insert_follower(FOLLOWER_URI);
+        push_fetch_status_response(FetchStatusResponse::Ok(fixture_status()));
+
+        assert_eq!(
+            boost_status(BoostStatusArgs {
+                status_url: STATUS_URI.into()
+            })
+            .await,
+            BoostStatusResponse::Ok
+        );
+        assert_eq!(
+            boost_status(BoostStatusArgs {
+                status_url: STATUS_URI.into()
+            })
+            .await,
+            BoostStatusResponse::Ok
+        );
+        assert_eq!(captured().len(), 1, "only one dispatch");
+    }
+
+    #[tokio::test]
+    async fn test_should_propagate_fetch_error_as_internal() {
+        setup();
+        push_fetch_status_response(FetchStatusResponse::Err(FetchStatusError::NotFound));
+
+        let resp = boost_status(BoostStatusArgs {
+            status_url: STATUS_URI.into(),
+        })
+        .await;
+        assert!(matches!(
+            resp,
+            BoostStatusResponse::Err(BoostStatusError::Internal(_))
+        ));
+        assert!(!BoostRepository::is_boosted(STATUS_URI).expect("query"));
+    }
+
+    #[tokio::test]
+    async fn test_self_boost_allowed() {
+        setup();
+        let mut status = fixture_status();
+        status.author = OWN_URI.into();
+        push_fetch_status_response(FetchStatusResponse::Ok(status));
+
+        let resp = boost_status(BoostStatusArgs {
+            status_url: format!("{OWN_URI}/statuses/9"),
+        })
+        .await;
+        assert_eq!(resp, BoostStatusResponse::Ok);
+    }
+
+    #[tokio::test]
+    async fn test_dispatch_dedups_when_follower_is_author() {
+        setup();
+        insert_follower("https://remote.example/users/bob");
+        push_fetch_status_response(FetchStatusResponse::Ok(fixture_status()));
+
+        let _ = boost_status(BoostStatusArgs {
+            status_url: STATUS_URI.into(),
+        })
+        .await;
+        let captured = captured();
+        let SendActivityArgs::Batch(batch) = &captured[0] else {
+            unreachable!()
+        };
+        assert_eq!(batch.len(), 1, "follower == author should dedup to 1");
+    }
 }

--- a/crates/canisters/user/src/domain/boost/boost_status.rs
+++ b/crates/canisters/user/src/domain/boost/boost_status.rs
@@ -1,0 +1,34 @@
+//! Flow for boosting a status.
+
+use did::user::{BoostStatusArgs, BoostStatusError, BoostStatusResponse};
+
+use crate::domain::boost::repository::BoostRepository;
+use crate::error::CanisterResult;
+
+/// Boost of a status.
+pub async fn boost_status(BoostStatusArgs { status_url }: BoostStatusArgs) -> BoostStatusResponse {
+    match boost_status_impl(status_url).await {
+        Ok(()) => BoostStatusResponse::Ok,
+        Err(err) => {
+            ic_utils::log!("Failed to boost status: {err}");
+            BoostStatusResponse::Err(BoostStatusError::Internal(err.to_string()))
+        }
+    }
+}
+
+async fn boost_status_impl(status_uri: String) -> CanisterResult<()> {
+    ic_utils::log!("Boosting status with URI: {status_uri}");
+
+    // Idempotent: if already boosted, do not duplicate or re-emit.
+    if BoostRepository::is_boosted(&status_uri)? {
+        ic_utils::log!("Status already boosted: {status_uri}");
+        return Ok(());
+    }
+
+    // Insert the boost into the database first; if federation dispatch
+    // later fails, the user can re-trigger and the row already exists,
+    // making the second call a no-op.
+    BoostRepository::boost_status(&status_uri)?;
+
+    Ok(())
+}

--- a/crates/canisters/user/src/domain/boost/boost_status.rs
+++ b/crates/canisters/user/src/domain/boost/boost_status.rs
@@ -20,17 +20,21 @@ use activitypub::Activity;
 use activitypub::activity::{ActivityObject, ActivityType};
 use activitypub::context::ACTIVITY_STREAMS_CONTEXT;
 use activitypub::object::{BaseObject, OneOrMany};
+use db_utils::repository::Repository;
 use db_utils::transaction::Transaction;
-use did::common::Status;
+use did::common::{Status, Visibility};
 use did::federation::{
     FetchStatusArgs, FetchStatusResponse, SendActivityArgs, SendActivityArgsObject,
 };
 use did::user::{BoostStatusArgs, BoostStatusError, BoostStatusResponse};
+use wasm_dbms_api::prelude::TransactionId;
 
 use crate::domain::boost::repository::BoostRepository;
+use crate::domain::feed::FeedRepository;
 use crate::domain::follower::FollowerRepository;
 use crate::domain::profile::ProfileRepository;
 use crate::domain::snowflake::Snowflake;
+use crate::domain::status::StatusRepository;
 use crate::domain::urls;
 use crate::error::{CanisterError, CanisterResult};
 use crate::schema::Schema;
@@ -76,11 +80,12 @@ async fn boost_status_inner(status_url: String) -> CanisterResult<()> {
     let now = ic_utils::now();
 
     Transaction::run::<_, _, _, CanisterError>(Schema, |tx| {
-        BoostRepository::with_transaction(tx).insert_boost_with_wrapper(
+        insert_boost_with_wrapper(
+            tx,
             snowflake,
             &status_url,
             &fetched.content,
-            fetched.visibility.into(),
+            fetched.visibility,
             fetched.spoiler_text.as_deref(),
             fetched.sensitive,
             now,
@@ -131,6 +136,36 @@ fn compute_recipients(fetched: &Status, own_actor_uri: &str) -> CanisterResult<V
     Ok(recipients)
 }
 
+/// Insert a boost wrapper status, the boost row, and the outbox feed entry
+/// inside the given transaction. Caller drives lifecycle via
+/// [`db_utils::transaction::Transaction::run`].
+#[expect(
+    clippy::too_many_arguments,
+    reason = "wrapper status fields collapse here"
+)]
+fn insert_boost_with_wrapper(
+    tx: TransactionId,
+    snowflake_id: u64,
+    original_status_uri: &str,
+    content: &str,
+    visibility: Visibility,
+    spoiler_text: Option<&str>,
+    sensitive: bool,
+    created_at: u64,
+) -> CanisterResult<()> {
+    StatusRepository::with_transaction(tx).insert_wrapper(
+        snowflake_id,
+        content,
+        visibility,
+        spoiler_text,
+        sensitive,
+        created_at,
+    )?;
+    BoostRepository::with_transaction(tx).insert(snowflake_id, original_status_uri, created_at)?;
+    FeedRepository::with_transaction(tx).insert_outbox(snowflake_id, created_at)?;
+    Ok(())
+}
+
 fn make_announce_activity(
     own_actor_uri: &str,
     wrapper_id: u64,
@@ -173,6 +208,8 @@ mod tests {
     use crate::adapters::federation::mock::{captured, push_fetch_status_response};
     use crate::domain::boost::repository::BoostRepository;
     use crate::domain::follower::FollowerRepository;
+    use crate::domain::status::StatusRepository;
+    use crate::error::CanisterError;
     use crate::test_utils::setup;
 
     const STATUS_URI: &str = "https://remote.example/users/bob/statuses/42";
@@ -303,5 +340,89 @@ mod tests {
             unreachable!()
         };
         assert_eq!(batch.len(), 1, "follower == author should dedup to 1");
+    }
+
+    #[test]
+    fn test_should_insert_boost_with_wrapper_in_one_tx() {
+        setup();
+
+        Transaction::run::<_, _, _, CanisterError>(Schema, |tx| {
+            insert_boost_with_wrapper(
+                tx,
+                42,
+                STATUS_URI,
+                "boosted text",
+                Visibility::Public,
+                Some("cw"),
+                true,
+                1_000_000,
+            )
+        })
+        .expect("insert");
+
+        let wrapper = StatusRepository::oneshot()
+            .find_by_id(42)
+            .expect("query")
+            .expect("wrapper exists");
+        assert_eq!(wrapper.content.0, "boosted text");
+        assert_eq!(
+            wrapper
+                .spoiler_text
+                .clone()
+                .into_opt()
+                .expect("spoiler value")
+                .0,
+            "cw"
+        );
+        assert!(wrapper.sensitive.0);
+
+        let boost = BoostRepository::oneshot()
+            .find_by_original_uri(STATUS_URI)
+            .expect("query")
+            .expect("boost exists");
+        assert_eq!(boost.id.expect("id").0, 42);
+        assert_eq!(
+            boost.original_status_uri.expect("uri").0,
+            STATUS_URI.to_string()
+        );
+
+        assert!(
+            BoostRepository::oneshot()
+                .is_boosted(STATUS_URI)
+                .expect("query")
+        );
+    }
+
+    #[test]
+    fn test_insert_boost_with_wrapper_rolls_back_on_error() {
+        setup();
+
+        let result: Result<(), CanisterError> = Transaction::run(Schema, |tx| {
+            insert_boost_with_wrapper(
+                tx,
+                55,
+                STATUS_URI,
+                "rolled back",
+                Visibility::Public,
+                None,
+                false,
+                500,
+            )?;
+            Err(CanisterError::Internal("boom".to_string()))
+        });
+        assert!(result.is_err());
+
+        assert!(
+            !BoostRepository::oneshot()
+                .is_boosted(STATUS_URI)
+                .expect("query")
+        );
+        assert!(
+            StatusRepository::oneshot()
+                .find_by_id(55)
+                .expect("query")
+                .is_none(),
+            "wrapper status must not persist on rollback"
+        );
     }
 }

--- a/crates/canisters/user/src/domain/boost/boost_status.rs
+++ b/crates/canisters/user/src/domain/boost/boost_status.rs
@@ -20,6 +20,7 @@ use activitypub::Activity;
 use activitypub::activity::{ActivityObject, ActivityType};
 use activitypub::context::ACTIVITY_STREAMS_CONTEXT;
 use activitypub::object::{BaseObject, OneOrMany};
+use db_utils::transaction::Transaction;
 use did::common::Status;
 use did::federation::{
     FetchStatusArgs, FetchStatusResponse, SendActivityArgs, SendActivityArgsObject,
@@ -32,6 +33,7 @@ use crate::domain::profile::ProfileRepository;
 use crate::domain::snowflake::Snowflake;
 use crate::domain::urls;
 use crate::error::{CanisterError, CanisterResult};
+use crate::schema::Schema;
 
 const AS_PUBLIC: &str = "https://www.w3.org/ns/activitystreams#Public";
 
@@ -48,7 +50,7 @@ pub async fn boost_status(BoostStatusArgs { status_url }: BoostStatusArgs) -> Bo
 async fn boost_status_inner(status_url: String) -> CanisterResult<()> {
     ic_utils::log!("Boosting status {status_url}");
 
-    if BoostRepository::is_boosted(&status_url)? {
+    if BoostRepository::oneshot().is_boosted(&status_url)? {
         ic_utils::log!("Status already boosted: {status_url}");
         return Ok(());
     }
@@ -73,15 +75,17 @@ async fn boost_status_inner(status_url: String) -> CanisterResult<()> {
     let snowflake: u64 = Snowflake::new().into();
     let now = ic_utils::now();
 
-    BoostRepository::insert_boost_with_wrapper(
-        snowflake,
-        &status_url,
-        &fetched.content,
-        fetched.visibility.into(),
-        fetched.spoiler_text.as_deref(),
-        fetched.sensitive,
-        now,
-    )?;
+    Transaction::run::<_, _, _, CanisterError>(Schema, |tx| {
+        BoostRepository::with_transaction(tx).insert_boost_with_wrapper(
+            snowflake,
+            &status_url,
+            &fetched.content,
+            fetched.visibility.into(),
+            fetched.spoiler_text.as_deref(),
+            fetched.sensitive,
+            now,
+        )
+    })?;
 
     let recipients = compute_recipients(&fetched, &own_actor_uri)?;
     if recipients.is_empty() {
@@ -206,7 +210,11 @@ mod tests {
         })
         .await;
         assert_eq!(resp, BoostStatusResponse::Ok);
-        assert!(BoostRepository::is_boosted(STATUS_URI).expect("query"));
+        assert!(
+            BoostRepository::oneshot()
+                .is_boosted(STATUS_URI)
+                .expect("query")
+        );
 
         let captured = captured();
         assert_eq!(captured.len(), 1);
@@ -259,7 +267,11 @@ mod tests {
             resp,
             BoostStatusResponse::Err(BoostStatusError::Internal(_))
         ));
-        assert!(!BoostRepository::is_boosted(STATUS_URI).expect("query"));
+        assert!(
+            !BoostRepository::oneshot()
+                .is_boosted(STATUS_URI)
+                .expect("query")
+        );
     }
 
     #[tokio::test]

--- a/crates/canisters/user/src/domain/boost/boost_status.rs
+++ b/crates/canisters/user/src/domain/boost/boost_status.rs
@@ -53,7 +53,7 @@ async fn boost_status_inner(status_url: String) -> CanisterResult<()> {
         return Ok(());
     }
 
-    let own_profile = ProfileRepository::get_profile()?;
+    let own_profile = ProfileRepository::oneshot().get_profile()?;
     let own_actor_uri = urls::actor_uri(&own_profile.handle.0)?;
 
     let fetched = match crate::adapters::federation::fetch_status(FetchStatusArgs {

--- a/crates/canisters/user/src/domain/boost/repository.rs
+++ b/crates/canisters/user/src/domain/boost/repository.rs
@@ -3,7 +3,7 @@ use wasm_dbms::WasmDbmsDatabase;
 use wasm_dbms_api::prelude::{Database, DeleteBehavior, Filter, Query};
 
 use crate::error::{CanisterError, CanisterResult};
-use crate::schema::{Boost, BoostInsertRequest, Schema};
+use crate::schema::{Boost, BoostInsertRequest, BoostRecord, Schema};
 
 /// Repository for managing [`Boost`] records in the database.
 pub struct BoostRepository;
@@ -26,6 +26,7 @@ impl BoostRepository {
     }
 
     /// Deletes a boost from the database, identified by the boosted status URI.
+    #[allow(dead_code)] // wired up in Task 12 (undo_boost flow)
     pub fn unboost_status(original_status_uri: &str) -> CanisterResult<()> {
         DBMS_CONTEXT
             .with(|ctx| {
@@ -63,7 +64,29 @@ impl BoostRepository {
             .map_err(CanisterError::from)
     }
 
+    /// Looks up a boost record by the URI of the original (boosted) status.
+    ///
+    /// Returns `Ok(None)` when no matching row exists.
+    #[allow(dead_code)] // wired up in Task 11 (boost_status flow rewrite)
+    pub fn find_by_original_uri(uri: &str) -> CanisterResult<Option<BoostRecord>> {
+        DBMS_CONTEXT
+            .with(|ctx| {
+                let db = WasmDbmsDatabase::oneshot(ctx, Schema);
+
+                db.select::<Boost>(
+                    Query::builder()
+                        .all()
+                        .and_where(Filter::eq("original_status_uri", uri.into()))
+                        .limit(1)
+                        .build(),
+                )
+            })
+            .map(|rows| rows.into_iter().next())
+            .map_err(CanisterError::from)
+    }
+
     /// Returns the URIs of statuses boosted by the user.
+    #[allow(dead_code)] // wired up in a later task (get_boosts API endpoint)
     pub fn get_boosts(offset: usize, limit: usize) -> CanisterResult<Vec<String>> {
         DBMS_CONTEXT
             .with(|ctx| {
@@ -162,5 +185,28 @@ mod tests {
 
         let boosts = BoostRepository::get_boosts(0, 10).expect("should query");
         assert!(boosts.is_empty());
+    }
+
+    #[test]
+    fn test_should_find_by_original_uri() {
+        setup();
+        seed_status(10);
+        BoostRepository::boost_status(100, 10, STATUS_URI_A).expect("should insert boost");
+
+        let found = BoostRepository::find_by_original_uri(STATUS_URI_A)
+            .expect("should query")
+            .expect("should find row");
+        assert_eq!(found.id.expect("id").0, 100);
+        assert_eq!(
+            found.original_status_uri.expect("uri").0,
+            STATUS_URI_A.to_string()
+        );
+    }
+
+    #[test]
+    fn test_find_by_original_uri_returns_none_when_missing() {
+        setup();
+        let found = BoostRepository::find_by_original_uri(STATUS_URI_A).expect("should query");
+        assert!(found.is_none());
     }
 }

--- a/crates/canisters/user/src/domain/boost/repository.rs
+++ b/crates/canisters/user/src/domain/boost/repository.rs
@@ -26,7 +26,6 @@ impl BoostRepository {
     }
 
     /// Deletes a boost from the database, identified by the boosted status URI.
-    #[allow(dead_code)] // wired up in Task 12 (undo_boost flow)
     pub fn unboost_status(original_status_uri: &str) -> CanisterResult<()> {
         DBMS_CONTEXT
             .with(|ctx| {
@@ -67,7 +66,6 @@ impl BoostRepository {
     /// Looks up a boost record by the URI of the original (boosted) status.
     ///
     /// Returns `Ok(None)` when no matching row exists.
-    #[allow(dead_code)] // wired up in Task 11 (boost_status flow rewrite)
     pub fn find_by_original_uri(uri: &str) -> CanisterResult<Option<BoostRecord>> {
         DBMS_CONTEXT
             .with(|ctx| {
@@ -86,7 +84,6 @@ impl BoostRepository {
     }
 
     /// Returns the URIs of statuses boosted by the user.
-    #[allow(dead_code)] // wired up in a later task (get_boosts API endpoint)
     pub fn get_boosts(offset: usize, limit: usize) -> CanisterResult<Vec<String>> {
         DBMS_CONTEXT
             .with(|ctx| {

--- a/crates/canisters/user/src/domain/boost/repository.rs
+++ b/crates/canisters/user/src/domain/boost/repository.rs
@@ -12,22 +12,6 @@ use crate::schema::{
 pub struct BoostRepository;
 
 impl BoostRepository {
-    /// Inserts a boost into the database.
-    pub fn boost_status(id: u64, status_id: u64, original_status_uri: &str) -> CanisterResult<()> {
-        DBMS_CONTEXT
-            .with(|ctx| {
-                let db = WasmDbmsDatabase::oneshot(ctx, Schema);
-
-                db.insert::<Boost>(BoostInsertRequest {
-                    id: id.into(),
-                    status_id: status_id.into(),
-                    original_status_uri: original_status_uri.into(),
-                    created_at: ic_utils::now().into(),
-                })
-            })
-            .map_err(CanisterError::from)
-    }
-
     /// Transactionally insert a wrapper [`Status`] row, the corresponding
     /// [`Boost`] row, and a `feed` entry with `source = Outbox`. The same
     /// `snowflake_id` is used as the primary key in all three tables — this
@@ -109,24 +93,6 @@ impl BoostRepository {
             .map_err(CanisterError::from)
     }
 
-    /// Deletes a boost from the database, identified by the boosted status URI.
-    pub fn unboost_status(original_status_uri: &str) -> CanisterResult<()> {
-        DBMS_CONTEXT
-            .with(|ctx| {
-                let db = WasmDbmsDatabase::oneshot(ctx, Schema);
-
-                db.delete::<Boost>(
-                    DeleteBehavior::Cascade,
-                    Some(Filter::eq(
-                        "original_status_uri",
-                        original_status_uri.into(),
-                    )),
-                )
-            })
-            .map(|_| ())
-            .map_err(CanisterError::from)
-    }
-
     /// Checks whether the user has boosted the given status.
     pub fn is_boosted(original_status_uri: &str) -> CanisterResult<bool> {
         DBMS_CONTEXT
@@ -166,45 +132,33 @@ impl BoostRepository {
             .map(|rows| rows.into_iter().next())
             .map_err(CanisterError::from)
     }
-
-    /// Returns the URIs of statuses boosted by the user.
-    pub fn get_boosts(offset: usize, limit: usize) -> CanisterResult<Vec<String>> {
-        DBMS_CONTEXT
-            .with(|ctx| {
-                let db = WasmDbmsDatabase::oneshot(ctx, Schema);
-
-                db.select::<Boost>(Query::builder().all().offset(offset).limit(limit).build())
-            })
-            .map(|records| {
-                records
-                    .into_iter()
-                    .map(|record| record.original_status_uri.unwrap_or_default().0)
-                    .collect()
-            })
-            .map_err(CanisterError::from)
-    }
 }
 
 #[cfg(test)]
 mod tests {
 
     use super::*;
-    use crate::test_utils::{insert_status, setup};
+    use crate::test_utils::setup;
 
     const STATUS_URI_A: &str = "https://example.com/users/alice/statuses/1";
-    const STATUS_URI_B: &str = "https://example.com/users/alice/statuses/2";
-    const STATUS_URI_C: &str = "https://example.com/users/alice/statuses/3";
 
-    fn seed_status(id: u64) {
-        insert_status(id, "Hello", did::common::Visibility::Public, 1_000_000);
+    fn insert_boost(snowflake_id: u64, original_status_uri: &str) {
+        BoostRepository::insert_boost_with_wrapper(
+            snowflake_id,
+            original_status_uri,
+            "boosted",
+            crate::schema::Visibility::from(did::common::Visibility::Public),
+            None,
+            false,
+            1_000_000,
+        )
+        .expect("insert boost");
     }
 
     #[test]
     fn test_should_insert_and_check_boost() {
         setup();
-        seed_status(10);
-
-        BoostRepository::boost_status(100, 10, STATUS_URI_A).expect("should insert boost");
+        insert_boost(10, STATUS_URI_A);
 
         assert!(BoostRepository::is_boosted(STATUS_URI_A).expect("should query"));
     }
@@ -217,62 +171,9 @@ mod tests {
     }
 
     #[test]
-    fn test_should_unboost_status() {
-        setup();
-        seed_status(10);
-
-        BoostRepository::boost_status(100, 10, STATUS_URI_A).expect("should insert boost");
-        assert!(BoostRepository::is_boosted(STATUS_URI_A).expect("should query"));
-
-        BoostRepository::unboost_status(STATUS_URI_A).expect("should delete boost");
-
-        assert!(!BoostRepository::is_boosted(STATUS_URI_A).expect("should query"));
-    }
-
-    #[test]
-    fn test_should_unboost_missing_without_error() {
-        setup();
-
-        BoostRepository::unboost_status(STATUS_URI_A).expect("should delete missing boost");
-    }
-
-    #[test]
-    fn test_should_get_boosts_paginated() {
-        setup();
-        seed_status(10);
-        seed_status(20);
-        seed_status(30);
-
-        BoostRepository::boost_status(100, 10, STATUS_URI_A).expect("should insert boost");
-        BoostRepository::boost_status(200, 20, STATUS_URI_B).expect("should insert boost");
-        BoostRepository::boost_status(300, 30, STATUS_URI_C).expect("should insert boost");
-
-        let all = BoostRepository::get_boosts(0, 10).expect("should query");
-        assert_eq!(all.len(), 3);
-        assert!(all.contains(&STATUS_URI_A.to_string()));
-        assert!(all.contains(&STATUS_URI_B.to_string()));
-        assert!(all.contains(&STATUS_URI_C.to_string()));
-
-        let first = BoostRepository::get_boosts(0, 2).expect("should query");
-        assert_eq!(first.len(), 2);
-
-        let second = BoostRepository::get_boosts(2, 2).expect("should query");
-        assert_eq!(second.len(), 1);
-    }
-
-    #[test]
-    fn test_should_return_empty_when_no_boosts() {
-        setup();
-
-        let boosts = BoostRepository::get_boosts(0, 10).expect("should query");
-        assert!(boosts.is_empty());
-    }
-
-    #[test]
     fn test_should_find_by_original_uri() {
         setup();
-        seed_status(10);
-        BoostRepository::boost_status(100, 10, STATUS_URI_A).expect("should insert boost");
+        insert_boost(100, STATUS_URI_A);
 
         let found = BoostRepository::find_by_original_uri(STATUS_URI_A)
             .expect("should query")

--- a/crates/canisters/user/src/domain/boost/repository.rs
+++ b/crates/canisters/user/src/domain/boost/repository.rs
@@ -1,6 +1,9 @@
-use ic_dbms_canister::prelude::DBMS_CONTEXT;
+use ic_dbms_canister::prelude::{DBMS_CONTEXT, IcAccessControlList, IcMemoryProvider};
 use wasm_dbms::WasmDbmsDatabase;
-use wasm_dbms_api::prelude::{Database, DeleteBehavior, Filter, Nullable, Query, Value};
+use wasm_dbms::prelude::DbmsContext;
+use wasm_dbms_api::prelude::{
+    Database, DeleteBehavior, Filter, Nullable, Query, TransactionId, Value,
+};
 
 use crate::error::{CanisterError, CanisterResult};
 use crate::schema::{
@@ -9,15 +12,39 @@ use crate::schema::{
 };
 
 /// Repository for managing [`Boost`] records in the database.
-pub struct BoostRepository;
+pub struct BoostRepository {
+    tx: Option<TransactionId>,
+}
 
 impl BoostRepository {
-    /// Transactionally insert a wrapper [`Status`] row, the corresponding
-    /// [`Boost`] row, and a `feed` entry with `source = Outbox`. The same
-    /// `snowflake_id` is used as the primary key in all three tables — this
-    /// makes the wrapper status URL `<actor>/statuses/<snowflake>` also serve
-    /// as the `Announce` activity id.
+    pub const fn oneshot() -> Self {
+        Self { tx: None }
+    }
+
+    pub const fn with_transaction(tx: TransactionId) -> Self {
+        Self { tx: Some(tx) }
+    }
+
+    fn db<'a>(
+        &self,
+        ctx: &'a DbmsContext<IcMemoryProvider, IcAccessControlList>,
+    ) -> WasmDbmsDatabase<'a, IcMemoryProvider, IcAccessControlList> {
+        match self.tx {
+            Some(id) => WasmDbmsDatabase::from_transaction(ctx, Schema, id),
+            None => WasmDbmsDatabase::oneshot(ctx, Schema),
+        }
+    }
+
+    /// Insert a wrapper [`Status`] row, the corresponding [`Boost`] row, and a
+    /// `feed` entry with `source = Outbox`. The same `snowflake_id` is used as
+    /// the primary key in all three tables — this makes the wrapper status URL
+    /// `<actor>/statuses/<snowflake>` also serve as the `Announce` activity id.
+    ///
+    /// Transaction lifecycle is owned by the caller — typically via
+    /// `Transaction::run` — so the three writes are atomic.
+    #[allow(clippy::too_many_arguments)]
     pub fn insert_boost_with_wrapper(
+        &self,
         snowflake_id: u64,
         original_status_uri: &str,
         content: &str,
@@ -26,80 +53,73 @@ impl BoostRepository {
         sensitive: bool,
         created_at: u64,
     ) -> CanisterResult<()> {
-        DBMS_CONTEXT
-            .with(|ctx| {
-                let tx_id = ctx
-                    .begin_transaction(db_utils::transaction::transaction_caller(ic_utils::now()));
-                let mut db = WasmDbmsDatabase::from_transaction(ctx, Schema, tx_id);
+        DBMS_CONTEXT.with(|ctx| {
+            let db = self.db(ctx);
 
-                db.insert::<Status>(StatusInsertRequest {
-                    id: snowflake_id.into(),
-                    content: content.into(),
-                    visibility,
-                    like_count: 0u64.into(),
-                    boost_count: 0u64.into(),
-                    in_reply_to_uri: Nullable::Null,
-                    spoiler_text: spoiler_text
-                        .map_or(Nullable::Null, |s| Nullable::Value(s.into())),
-                    sensitive: sensitive.into(),
-                    edited_at: Nullable::Null,
-                    created_at: created_at.into(),
-                })?;
+            db.insert::<Status>(StatusInsertRequest {
+                id: snowflake_id.into(),
+                content: content.into(),
+                visibility,
+                like_count: 0u64.into(),
+                boost_count: 0u64.into(),
+                in_reply_to_uri: Nullable::Null,
+                spoiler_text: spoiler_text.map_or(Nullable::Null, |s| Nullable::Value(s.into())),
+                sensitive: sensitive.into(),
+                edited_at: Nullable::Null,
+                created_at: created_at.into(),
+            })?;
 
-                db.insert::<Boost>(BoostInsertRequest {
-                    id: snowflake_id.into(),
-                    status_id: snowflake_id.into(),
-                    original_status_uri: original_status_uri.into(),
-                    created_at: created_at.into(),
-                })?;
+            db.insert::<Boost>(BoostInsertRequest {
+                id: snowflake_id.into(),
+                status_id: snowflake_id.into(),
+                original_status_uri: original_status_uri.into(),
+                created_at: created_at.into(),
+            })?;
 
-                db.insert::<FeedEntry>(FeedEntryInsertRequest {
-                    id: snowflake_id.into(),
-                    source: FeedSource::Outbox,
-                    created_at: created_at.into(),
-                })?;
+            db.insert::<FeedEntry>(FeedEntryInsertRequest {
+                id: snowflake_id.into(),
+                source: FeedSource::Outbox,
+                created_at: created_at.into(),
+            })?;
 
-                db.commit()
-            })
-            .map_err(CanisterError::from)
+            Ok::<(), CanisterError>(())
+        })
     }
 
-    /// Transactionally delete the [`Boost`] row, the wrapper [`Status`] row,
-    /// and the corresponding `feed` entry sharing the same `snowflake_id`.
+    /// Delete the [`Boost`] row, the wrapper [`Status`] row, and the
+    /// corresponding `feed` entry sharing the same `snowflake_id`.
     ///
     /// Order: child (`boosts`) → `feed` → parent (`statuses`) so the FK
     /// `boosts.status_id → statuses.id` (Restrict) is satisfied.
-    pub fn delete_boost_with_wrapper(snowflake_id: u64) -> CanisterResult<()> {
-        DBMS_CONTEXT
-            .with(|ctx| {
-                let tx_id = ctx
-                    .begin_transaction(db_utils::transaction::transaction_caller(ic_utils::now()));
-                let mut db = WasmDbmsDatabase::from_transaction(ctx, Schema, tx_id);
+    ///
+    /// Transaction lifecycle is owned by the caller — typically via
+    /// `Transaction::run` — so the three deletes are atomic.
+    pub fn delete_boost_with_wrapper(&self, snowflake_id: u64) -> CanisterResult<()> {
+        DBMS_CONTEXT.with(|ctx| {
+            let db = self.db(ctx);
 
-                db.delete::<Boost>(
-                    DeleteBehavior::Restrict,
-                    Some(Filter::eq("id", Value::from(snowflake_id))),
-                )?;
-                db.delete::<FeedEntry>(
-                    DeleteBehavior::Restrict,
-                    Some(Filter::eq("id", Value::from(snowflake_id))),
-                )?;
-                db.delete::<Status>(
-                    DeleteBehavior::Restrict,
-                    Some(Filter::eq("id", Value::from(snowflake_id))),
-                )?;
-                db.commit()
-            })
-            .map_err(CanisterError::from)
+            db.delete::<Boost>(
+                DeleteBehavior::Restrict,
+                Some(Filter::eq("id", Value::from(snowflake_id))),
+            )?;
+            db.delete::<FeedEntry>(
+                DeleteBehavior::Restrict,
+                Some(Filter::eq("id", Value::from(snowflake_id))),
+            )?;
+            db.delete::<Status>(
+                DeleteBehavior::Restrict,
+                Some(Filter::eq("id", Value::from(snowflake_id))),
+            )?;
+
+            Ok::<(), CanisterError>(())
+        })
     }
 
     /// Checks whether the user has boosted the given status.
-    pub fn is_boosted(original_status_uri: &str) -> CanisterResult<bool> {
+    pub fn is_boosted(&self, original_status_uri: &str) -> CanisterResult<bool> {
         DBMS_CONTEXT
             .with(|ctx| {
-                let db = WasmDbmsDatabase::oneshot(ctx, Schema);
-
-                db.select::<Boost>(
+                self.db(ctx).select::<Boost>(
                     Query::builder()
                         .and_where(Filter::eq(
                             "original_status_uri",
@@ -116,12 +136,10 @@ impl BoostRepository {
     /// Looks up a boost record by the URI of the original (boosted) status.
     ///
     /// Returns `Ok(None)` when no matching row exists.
-    pub fn find_by_original_uri(uri: &str) -> CanisterResult<Option<BoostRecord>> {
+    pub fn find_by_original_uri(&self, uri: &str) -> CanisterResult<Option<BoostRecord>> {
         DBMS_CONTEXT
             .with(|ctx| {
-                let db = WasmDbmsDatabase::oneshot(ctx, Schema);
-
-                db.select::<Boost>(
+                self.db(ctx).select::<Boost>(
                     Query::builder()
                         .all()
                         .and_where(Filter::eq("original_status_uri", uri.into()))
@@ -137,21 +155,25 @@ impl BoostRepository {
 #[cfg(test)]
 mod tests {
 
+    use db_utils::transaction::Transaction;
+
     use super::*;
     use crate::test_utils::setup;
 
     const STATUS_URI_A: &str = "https://example.com/users/alice/statuses/1";
 
     fn insert_boost(snowflake_id: u64, original_status_uri: &str) {
-        BoostRepository::insert_boost_with_wrapper(
-            snowflake_id,
-            original_status_uri,
-            "boosted",
-            crate::schema::Visibility::from(did::common::Visibility::Public),
-            None,
-            false,
-            1_000_000,
-        )
+        Transaction::run::<_, _, _, CanisterError>(Schema, |tx| {
+            BoostRepository::with_transaction(tx).insert_boost_with_wrapper(
+                snowflake_id,
+                original_status_uri,
+                "boosted",
+                crate::schema::Visibility::from(did::common::Visibility::Public),
+                None,
+                false,
+                1_000_000,
+            )
+        })
         .expect("insert boost");
     }
 
@@ -160,14 +182,22 @@ mod tests {
         setup();
         insert_boost(10, STATUS_URI_A);
 
-        assert!(BoostRepository::is_boosted(STATUS_URI_A).expect("should query"));
+        assert!(
+            BoostRepository::oneshot()
+                .is_boosted(STATUS_URI_A)
+                .expect("should query")
+        );
     }
 
     #[test]
     fn test_should_return_false_for_missing_boost() {
         setup();
 
-        assert!(!BoostRepository::is_boosted(STATUS_URI_A).expect("should query"));
+        assert!(
+            !BoostRepository::oneshot()
+                .is_boosted(STATUS_URI_A)
+                .expect("should query")
+        );
     }
 
     #[test]
@@ -175,7 +205,8 @@ mod tests {
         setup();
         insert_boost(100, STATUS_URI_A);
 
-        let found = BoostRepository::find_by_original_uri(STATUS_URI_A)
+        let found = BoostRepository::oneshot()
+            .find_by_original_uri(STATUS_URI_A)
             .expect("should query")
             .expect("should find row");
         assert_eq!(found.id.expect("id").0, 100);
@@ -188,7 +219,9 @@ mod tests {
     #[test]
     fn test_find_by_original_uri_returns_none_when_missing() {
         setup();
-        let found = BoostRepository::find_by_original_uri(STATUS_URI_A).expect("should query");
+        let found = BoostRepository::oneshot()
+            .find_by_original_uri(STATUS_URI_A)
+            .expect("should query");
         assert!(found.is_none());
     }
 
@@ -196,20 +229,29 @@ mod tests {
     fn test_should_delete_boost_with_wrapper_in_one_tx() {
         setup();
 
-        BoostRepository::insert_boost_with_wrapper(
-            77,
-            STATUS_URI_A,
-            "boosted",
-            crate::schema::Visibility::from(did::common::Visibility::Public),
-            None,
-            false,
-            1_000,
-        )
+        Transaction::run::<_, _, _, CanisterError>(Schema, |tx| {
+            BoostRepository::with_transaction(tx).insert_boost_with_wrapper(
+                77,
+                STATUS_URI_A,
+                "boosted",
+                crate::schema::Visibility::from(did::common::Visibility::Public),
+                None,
+                false,
+                1_000,
+            )
+        })
         .expect("insert");
 
-        BoostRepository::delete_boost_with_wrapper(77).expect("delete");
+        Transaction::run::<_, _, _, CanisterError>(Schema, |tx| {
+            BoostRepository::with_transaction(tx).delete_boost_with_wrapper(77)
+        })
+        .expect("delete");
 
-        assert!(!BoostRepository::is_boosted(STATUS_URI_A).expect("query"));
+        assert!(
+            !BoostRepository::oneshot()
+                .is_boosted(STATUS_URI_A)
+                .expect("query")
+        );
         assert!(
             crate::domain::status::StatusRepository::oneshot()
                 .find_by_id(77)
@@ -223,15 +265,17 @@ mod tests {
     fn test_should_insert_boost_with_wrapper_in_one_tx() {
         setup();
 
-        BoostRepository::insert_boost_with_wrapper(
-            42,
-            STATUS_URI_A,
-            "boosted text",
-            crate::schema::Visibility::from(did::common::Visibility::Public),
-            Some("cw"),
-            true,
-            1_000_000,
-        )
+        Transaction::run::<_, _, _, CanisterError>(Schema, |tx| {
+            BoostRepository::with_transaction(tx).insert_boost_with_wrapper(
+                42,
+                STATUS_URI_A,
+                "boosted text",
+                crate::schema::Visibility::from(did::common::Visibility::Public),
+                Some("cw"),
+                true,
+                1_000_000,
+            )
+        })
         .expect("insert");
 
         // Wrapper Status row
@@ -252,7 +296,8 @@ mod tests {
         assert!(wrapper.sensitive.0);
 
         // Boost row
-        let boost = BoostRepository::find_by_original_uri(STATUS_URI_A)
+        let boost = BoostRepository::oneshot()
+            .find_by_original_uri(STATUS_URI_A)
             .expect("query")
             .expect("boost exists");
         assert_eq!(boost.id.expect("id").0, 42);
@@ -262,6 +307,42 @@ mod tests {
         );
 
         // Idempotency check picks it up
-        assert!(BoostRepository::is_boosted(STATUS_URI_A).expect("query"));
+        assert!(
+            BoostRepository::oneshot()
+                .is_boosted(STATUS_URI_A)
+                .expect("query")
+        );
+    }
+
+    #[test]
+    fn test_insert_boost_with_wrapper_rolls_back_on_error() {
+        setup();
+
+        let result: Result<(), CanisterError> = Transaction::run(Schema, |tx| {
+            BoostRepository::with_transaction(tx).insert_boost_with_wrapper(
+                55,
+                STATUS_URI_A,
+                "rolled back",
+                crate::schema::Visibility::from(did::common::Visibility::Public),
+                None,
+                false,
+                500,
+            )?;
+            Err(CanisterError::Internal("boom".to_string()))
+        });
+        assert!(result.is_err());
+
+        assert!(
+            !BoostRepository::oneshot()
+                .is_boosted(STATUS_URI_A)
+                .expect("query")
+        );
+        assert!(
+            crate::domain::status::StatusRepository::oneshot()
+                .find_by_id(55)
+                .expect("query")
+                .is_none(),
+            "wrapper status must not persist on rollback"
+        );
     }
 }

--- a/crates/canisters/user/src/domain/boost/repository.rs
+++ b/crates/canisters/user/src/domain/boost/repository.rs
@@ -1,6 +1,6 @@
 use ic_dbms_canister::prelude::DBMS_CONTEXT;
 use wasm_dbms::WasmDbmsDatabase;
-use wasm_dbms_api::prelude::{Database, DeleteBehavior, Filter, Nullable, Query};
+use wasm_dbms_api::prelude::{Database, DeleteBehavior, Filter, Nullable, Query, Value};
 
 use crate::error::{CanisterError, CanisterResult};
 use crate::schema::{
@@ -75,6 +75,35 @@ impl BoostRepository {
                     created_at: created_at.into(),
                 })?;
 
+                db.commit()
+            })
+            .map_err(CanisterError::from)
+    }
+
+    /// Transactionally delete the [`Boost`] row, the wrapper [`Status`] row,
+    /// and the corresponding `feed` entry sharing the same `snowflake_id`.
+    ///
+    /// Order: child (`boosts`) → `feed` → parent (`statuses`) so the FK
+    /// `boosts.status_id → statuses.id` (Restrict) is satisfied.
+    pub fn delete_boost_with_wrapper(snowflake_id: u64) -> CanisterResult<()> {
+        DBMS_CONTEXT
+            .with(|ctx| {
+                let tx_id = ctx
+                    .begin_transaction(db_utils::transaction::transaction_caller(ic_utils::now()));
+                let mut db = WasmDbmsDatabase::from_transaction(ctx, Schema, tx_id);
+
+                db.delete::<Boost>(
+                    DeleteBehavior::Restrict,
+                    Some(Filter::eq("id", Value::from(snowflake_id))),
+                )?;
+                db.delete::<FeedEntry>(
+                    DeleteBehavior::Restrict,
+                    Some(Filter::eq("id", Value::from(snowflake_id))),
+                )?;
+                db.delete::<Status>(
+                    DeleteBehavior::Restrict,
+                    Some(Filter::eq("id", Value::from(snowflake_id))),
+                )?;
                 db.commit()
             })
             .map_err(CanisterError::from)
@@ -260,6 +289,32 @@ mod tests {
         setup();
         let found = BoostRepository::find_by_original_uri(STATUS_URI_A).expect("should query");
         assert!(found.is_none());
+    }
+
+    #[test]
+    fn test_should_delete_boost_with_wrapper_in_one_tx() {
+        setup();
+
+        BoostRepository::insert_boost_with_wrapper(
+            77,
+            STATUS_URI_A,
+            "boosted",
+            crate::schema::Visibility::from(did::common::Visibility::Public),
+            None,
+            false,
+            1_000,
+        )
+        .expect("insert");
+
+        BoostRepository::delete_boost_with_wrapper(77).expect("delete");
+
+        assert!(!BoostRepository::is_boosted(STATUS_URI_A).expect("query"));
+        assert!(
+            crate::domain::status::StatusRepository::find_by_id(77)
+                .expect("query")
+                .is_none(),
+            "wrapper status row removed"
+        );
     }
 
     #[test]

--- a/crates/canisters/user/src/domain/boost/repository.rs
+++ b/crates/canisters/user/src/domain/boost/repository.rs
@@ -1,0 +1,166 @@
+use ic_dbms_canister::prelude::DBMS_CONTEXT;
+use wasm_dbms::WasmDbmsDatabase;
+use wasm_dbms_api::prelude::{Database, DeleteBehavior, Filter, Query};
+
+use crate::error::{CanisterError, CanisterResult};
+use crate::schema::{Boost, BoostInsertRequest, Schema};
+
+/// Repository for managing [`Boost`] records in the database.
+pub struct BoostRepository;
+
+impl BoostRepository {
+    /// Inserts a boost into the database.
+    pub fn boost_status(id: u64, status_id: u64, original_status_uri: &str) -> CanisterResult<()> {
+        DBMS_CONTEXT
+            .with(|ctx| {
+                let db = WasmDbmsDatabase::oneshot(ctx, Schema);
+
+                db.insert::<Boost>(BoostInsertRequest {
+                    id: id.into(),
+                    status_id: status_id.into(),
+                    original_status_uri: original_status_uri.into(),
+                    created_at: ic_utils::now().into(),
+                })
+            })
+            .map_err(CanisterError::from)
+    }
+
+    /// Deletes a boost from the database, identified by the boosted status URI.
+    pub fn unboost_status(original_status_uri: &str) -> CanisterResult<()> {
+        DBMS_CONTEXT
+            .with(|ctx| {
+                let db = WasmDbmsDatabase::oneshot(ctx, Schema);
+
+                db.delete::<Boost>(
+                    DeleteBehavior::Cascade,
+                    Some(Filter::eq(
+                        "original_status_uri",
+                        original_status_uri.into(),
+                    )),
+                )
+            })
+            .map(|_| ())
+            .map_err(CanisterError::from)
+    }
+
+    /// Checks whether the user has boosted the given status.
+    pub fn is_boosted(original_status_uri: &str) -> CanisterResult<bool> {
+        DBMS_CONTEXT
+            .with(|ctx| {
+                let db = WasmDbmsDatabase::oneshot(ctx, Schema);
+
+                db.select::<Boost>(
+                    Query::builder()
+                        .and_where(Filter::eq(
+                            "original_status_uri",
+                            original_status_uri.into(),
+                        ))
+                        .limit(1)
+                        .build(),
+                )
+            })
+            .map(|rows| !rows.is_empty())
+            .map_err(CanisterError::from)
+    }
+
+    /// Returns the URIs of statuses boosted by the user.
+    pub fn get_boosts(offset: usize, limit: usize) -> CanisterResult<Vec<String>> {
+        DBMS_CONTEXT
+            .with(|ctx| {
+                let db = WasmDbmsDatabase::oneshot(ctx, Schema);
+
+                db.select::<Boost>(Query::builder().all().offset(offset).limit(limit).build())
+            })
+            .map(|records| {
+                records
+                    .into_iter()
+                    .map(|record| record.original_status_uri.unwrap_or_default().0)
+                    .collect()
+            })
+            .map_err(CanisterError::from)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+    use crate::test_utils::{insert_status, setup};
+
+    const STATUS_URI_A: &str = "https://example.com/users/alice/statuses/1";
+    const STATUS_URI_B: &str = "https://example.com/users/alice/statuses/2";
+    const STATUS_URI_C: &str = "https://example.com/users/alice/statuses/3";
+
+    fn seed_status(id: u64) {
+        insert_status(id, "Hello", did::common::Visibility::Public, 1_000_000);
+    }
+
+    #[test]
+    fn test_should_insert_and_check_boost() {
+        setup();
+        seed_status(10);
+
+        BoostRepository::boost_status(100, 10, STATUS_URI_A).expect("should insert boost");
+
+        assert!(BoostRepository::is_boosted(STATUS_URI_A).expect("should query"));
+    }
+
+    #[test]
+    fn test_should_return_false_for_missing_boost() {
+        setup();
+
+        assert!(!BoostRepository::is_boosted(STATUS_URI_A).expect("should query"));
+    }
+
+    #[test]
+    fn test_should_unboost_status() {
+        setup();
+        seed_status(10);
+
+        BoostRepository::boost_status(100, 10, STATUS_URI_A).expect("should insert boost");
+        assert!(BoostRepository::is_boosted(STATUS_URI_A).expect("should query"));
+
+        BoostRepository::unboost_status(STATUS_URI_A).expect("should delete boost");
+
+        assert!(!BoostRepository::is_boosted(STATUS_URI_A).expect("should query"));
+    }
+
+    #[test]
+    fn test_should_unboost_missing_without_error() {
+        setup();
+
+        BoostRepository::unboost_status(STATUS_URI_A).expect("should delete missing boost");
+    }
+
+    #[test]
+    fn test_should_get_boosts_paginated() {
+        setup();
+        seed_status(10);
+        seed_status(20);
+        seed_status(30);
+
+        BoostRepository::boost_status(100, 10, STATUS_URI_A).expect("should insert boost");
+        BoostRepository::boost_status(200, 20, STATUS_URI_B).expect("should insert boost");
+        BoostRepository::boost_status(300, 30, STATUS_URI_C).expect("should insert boost");
+
+        let all = BoostRepository::get_boosts(0, 10).expect("should query");
+        assert_eq!(all.len(), 3);
+        assert!(all.contains(&STATUS_URI_A.to_string()));
+        assert!(all.contains(&STATUS_URI_B.to_string()));
+        assert!(all.contains(&STATUS_URI_C.to_string()));
+
+        let first = BoostRepository::get_boosts(0, 2).expect("should query");
+        assert_eq!(first.len(), 2);
+
+        let second = BoostRepository::get_boosts(2, 2).expect("should query");
+        assert_eq!(second.len(), 1);
+    }
+
+    #[test]
+    fn test_should_return_empty_when_no_boosts() {
+        setup();
+
+        let boosts = BoostRepository::get_boosts(0, 10).expect("should query");
+        assert!(boosts.is_empty());
+    }
+}

--- a/crates/canisters/user/src/domain/boost/repository.rs
+++ b/crates/canisters/user/src/domain/boost/repository.rs
@@ -211,7 +211,8 @@ mod tests {
 
         assert!(!BoostRepository::is_boosted(STATUS_URI_A).expect("query"));
         assert!(
-            crate::domain::status::StatusRepository::find_by_id(77)
+            crate::domain::status::StatusRepository::oneshot()
+                .find_by_id(77)
                 .expect("query")
                 .is_none(),
             "wrapper status row removed"
@@ -234,7 +235,8 @@ mod tests {
         .expect("insert");
 
         // Wrapper Status row
-        let wrapper = crate::domain::status::StatusRepository::find_by_id(42)
+        let wrapper = crate::domain::status::StatusRepository::oneshot()
+            .find_by_id(42)
             .expect("query")
             .expect("wrapper exists");
         assert_eq!(wrapper.content.0, "boosted text");

--- a/crates/canisters/user/src/domain/boost/repository.rs
+++ b/crates/canisters/user/src/domain/boost/repository.rs
@@ -1,15 +1,9 @@
-use ic_dbms_canister::prelude::{DBMS_CONTEXT, IcAccessControlList, IcMemoryProvider};
-use wasm_dbms::WasmDbmsDatabase;
-use wasm_dbms::prelude::DbmsContext;
-use wasm_dbms_api::prelude::{
-    Database, DeleteBehavior, Filter, Nullable, Query, TransactionId, Value,
-};
+use db_utils::repository::Repository;
+use ic_dbms_canister::prelude::DBMS_CONTEXT;
+use wasm_dbms_api::prelude::{Database, DeleteBehavior, Filter, Query, TransactionId, Value};
 
-use crate::error::{CanisterError, CanisterResult};
-use crate::schema::{
-    Boost, BoostInsertRequest, BoostRecord, FeedEntry, FeedEntryInsertRequest, FeedSource, Schema,
-    Status, StatusInsertRequest, Visibility,
-};
+use crate::error::CanisterResult;
+use crate::schema::{Boost, BoostInsertRequest, BoostRecord, Schema};
 
 /// Repository for managing [`Boost`] records in the database.
 pub struct BoostRepository {
@@ -17,101 +11,38 @@ pub struct BoostRepository {
 }
 
 impl BoostRepository {
-    pub const fn oneshot() -> Self {
-        Self { tx: None }
-    }
-
-    pub const fn with_transaction(tx: TransactionId) -> Self {
-        Self { tx: Some(tx) }
-    }
-
-    fn db<'a>(
-        &self,
-        ctx: &'a DbmsContext<IcMemoryProvider, IcAccessControlList>,
-    ) -> WasmDbmsDatabase<'a, IcMemoryProvider, IcAccessControlList> {
-        match self.tx {
-            Some(id) => WasmDbmsDatabase::from_transaction(ctx, Schema, id),
-            None => WasmDbmsDatabase::oneshot(ctx, Schema),
-        }
-    }
-
-    /// Insert a wrapper [`Status`] row, the corresponding [`Boost`] row, and a
-    /// `feed` entry with `source = Outbox`. The same `snowflake_id` is used as
-    /// the primary key in all three tables — this makes the wrapper status URL
-    /// `<actor>/statuses/<snowflake>` also serve as the `Announce` activity id.
-    ///
-    /// Transaction lifecycle is owned by the caller — typically via
-    /// `Transaction::run` — so the three writes are atomic.
-    #[allow(clippy::too_many_arguments)]
-    pub fn insert_boost_with_wrapper(
+    /// Insert a [`Boost`] row. The same `snowflake_id` is reused as the
+    /// primary key in the wrapper `statuses` and `feed` tables — that
+    /// orchestration is owned by the boost domain helper, not this repo.
+    pub fn insert(
         &self,
         snowflake_id: u64,
         original_status_uri: &str,
-        content: &str,
-        visibility: Visibility,
-        spoiler_text: Option<&str>,
-        sensitive: bool,
         created_at: u64,
     ) -> CanisterResult<()> {
         DBMS_CONTEXT.with(|ctx| {
-            let db = self.db(ctx);
-
-            db.insert::<Status>(StatusInsertRequest {
-                id: snowflake_id.into(),
-                content: content.into(),
-                visibility,
-                like_count: 0u64.into(),
-                boost_count: 0u64.into(),
-                in_reply_to_uri: Nullable::Null,
-                spoiler_text: spoiler_text.map_or(Nullable::Null, |s| Nullable::Value(s.into())),
-                sensitive: sensitive.into(),
-                edited_at: Nullable::Null,
-                created_at: created_at.into(),
-            })?;
-
-            db.insert::<Boost>(BoostInsertRequest {
+            self.db(ctx).insert::<Boost>(BoostInsertRequest {
                 id: snowflake_id.into(),
                 status_id: snowflake_id.into(),
                 original_status_uri: original_status_uri.into(),
                 created_at: created_at.into(),
             })?;
-
-            db.insert::<FeedEntry>(FeedEntryInsertRequest {
-                id: snowflake_id.into(),
-                source: FeedSource::Outbox,
-                created_at: created_at.into(),
-            })?;
-
-            Ok::<(), CanisterError>(())
+            Ok(())
         })
     }
 
-    /// Delete the [`Boost`] row, the wrapper [`Status`] row, and the
-    /// corresponding `feed` entry sharing the same `snowflake_id`.
+    /// Delete the [`Boost`] row whose primary key matches `snowflake_id`.
     ///
-    /// Order: child (`boosts`) → `feed` → parent (`statuses`) so the FK
-    /// `boosts.status_id → statuses.id` (Restrict) is satisfied.
-    ///
-    /// Transaction lifecycle is owned by the caller — typically via
-    /// `Transaction::run` — so the three deletes are atomic.
-    pub fn delete_boost_with_wrapper(&self, snowflake_id: u64) -> CanisterResult<()> {
+    /// Uses [`DeleteBehavior::Restrict`] — callers must drop the wrapper
+    /// `statuses` and `feed` rows in the right order so referential integrity
+    /// is preserved.
+    pub fn delete_by_id(&self, snowflake_id: u64) -> CanisterResult<()> {
         DBMS_CONTEXT.with(|ctx| {
-            let db = self.db(ctx);
-
-            db.delete::<Boost>(
+            self.db(ctx).delete::<Boost>(
                 DeleteBehavior::Restrict,
                 Some(Filter::eq("id", Value::from(snowflake_id))),
             )?;
-            db.delete::<FeedEntry>(
-                DeleteBehavior::Restrict,
-                Some(Filter::eq("id", Value::from(snowflake_id))),
-            )?;
-            db.delete::<Status>(
-                DeleteBehavior::Restrict,
-                Some(Filter::eq("id", Value::from(snowflake_id))),
-            )?;
-
-            Ok::<(), CanisterError>(())
+            Ok(())
         })
     }
 
@@ -130,7 +61,7 @@ impl BoostRepository {
                 )
             })
             .map(|rows| !rows.is_empty())
-            .map_err(CanisterError::from)
+            .map_err(crate::error::CanisterError::from)
     }
 
     /// Looks up a boost record by the URI of the original (boosted) status.
@@ -148,45 +79,61 @@ impl BoostRepository {
                 )
             })
             .map(|rows| rows.into_iter().next())
-            .map_err(CanisterError::from)
+            .map_err(crate::error::CanisterError::from)
+    }
+}
+
+impl Repository for BoostRepository {
+    type Schema = Schema;
+
+    fn schema() -> Self::Schema {
+        Schema
+    }
+
+    fn oneshot() -> Self {
+        Self { tx: None }
+    }
+
+    fn with_transaction(tx: TransactionId) -> Self {
+        Self { tx: Some(tx) }
+    }
+
+    fn tx(&self) -> Option<TransactionId> {
+        self.tx
     }
 }
 
 #[cfg(test)]
 mod tests {
 
-    use db_utils::transaction::Transaction;
+    use did::common::Visibility;
 
     use super::*;
-    use crate::test_utils::setup;
+    use crate::test_utils::{insert_status, setup};
 
     const STATUS_URI_A: &str = "https://example.com/users/alice/statuses/1";
 
-    fn insert_boost(snowflake_id: u64, original_status_uri: &str) {
-        Transaction::run::<_, _, _, CanisterError>(Schema, |tx| {
-            BoostRepository::with_transaction(tx).insert_boost_with_wrapper(
-                snowflake_id,
-                original_status_uri,
-                "boosted",
-                crate::schema::Visibility::from(did::common::Visibility::Public),
-                None,
-                false,
-                1_000_000,
-            )
-        })
-        .expect("insert boost");
-    }
-
     #[test]
-    fn test_should_insert_and_check_boost() {
+    fn test_insert_should_persist_boost_row() {
         setup();
-        insert_boost(10, STATUS_URI_A);
+        // The boost row has a FK to a wrapper `statuses` row sharing the same
+        // primary key — insert it first so the FK constraint holds.
+        insert_status(10, "wrapper", Visibility::Public, 1_000_000);
 
-        assert!(
-            BoostRepository::oneshot()
-                .is_boosted(STATUS_URI_A)
-                .expect("should query")
+        BoostRepository::oneshot()
+            .insert(10, STATUS_URI_A, 1_000_000)
+            .expect("insert");
+
+        let row = BoostRepository::oneshot()
+            .find_by_original_uri(STATUS_URI_A)
+            .expect("query")
+            .expect("row exists");
+        assert_eq!(row.id.expect("id").0, 10);
+        assert_eq!(
+            row.original_status_uri.expect("uri").0,
+            STATUS_URI_A.to_string()
         );
+        assert_eq!(row.created_at.expect("created_at").0, 1_000_000);
     }
 
     #[test]
@@ -203,7 +150,10 @@ mod tests {
     #[test]
     fn test_should_find_by_original_uri() {
         setup();
-        insert_boost(100, STATUS_URI_A);
+        insert_status(100, "wrapper", Visibility::Public, 1_000_000);
+        BoostRepository::oneshot()
+            .insert(100, STATUS_URI_A, 1_000_000)
+            .expect("insert");
 
         let found = BoostRepository::oneshot()
             .find_by_original_uri(STATUS_URI_A)
@@ -226,123 +176,30 @@ mod tests {
     }
 
     #[test]
-    fn test_should_delete_boost_with_wrapper_in_one_tx() {
+    fn test_delete_by_id_should_remove_boost_row() {
         setup();
+        insert_status(11, "wrapper", Visibility::Public, 1_000);
+        BoostRepository::oneshot()
+            .insert(11, STATUS_URI_A, 1_000)
+            .expect("insert");
 
-        Transaction::run::<_, _, _, CanisterError>(Schema, |tx| {
-            BoostRepository::with_transaction(tx).insert_boost_with_wrapper(
-                77,
-                STATUS_URI_A,
-                "boosted",
-                crate::schema::Visibility::from(did::common::Visibility::Public),
-                None,
-                false,
-                1_000,
-            )
-        })
-        .expect("insert");
-
-        Transaction::run::<_, _, _, CanisterError>(Schema, |tx| {
-            BoostRepository::with_transaction(tx).delete_boost_with_wrapper(77)
-        })
-        .expect("delete");
+        BoostRepository::oneshot()
+            .delete_by_id(11)
+            .expect("should delete");
 
         assert!(
             !BoostRepository::oneshot()
                 .is_boosted(STATUS_URI_A)
                 .expect("query")
         );
-        assert!(
-            crate::domain::status::StatusRepository::oneshot()
-                .find_by_id(77)
-                .expect("query")
-                .is_none(),
-            "wrapper status row removed"
-        );
     }
 
     #[test]
-    fn test_should_insert_boost_with_wrapper_in_one_tx() {
+    fn test_delete_by_id_should_be_noop_when_missing() {
         setup();
 
-        Transaction::run::<_, _, _, CanisterError>(Schema, |tx| {
-            BoostRepository::with_transaction(tx).insert_boost_with_wrapper(
-                42,
-                STATUS_URI_A,
-                "boosted text",
-                crate::schema::Visibility::from(did::common::Visibility::Public),
-                Some("cw"),
-                true,
-                1_000_000,
-            )
-        })
-        .expect("insert");
-
-        // Wrapper Status row
-        let wrapper = crate::domain::status::StatusRepository::oneshot()
-            .find_by_id(42)
-            .expect("query")
-            .expect("wrapper exists");
-        assert_eq!(wrapper.content.0, "boosted text");
-        assert_eq!(
-            wrapper
-                .spoiler_text
-                .clone()
-                .into_opt()
-                .expect("spoiler value")
-                .0,
-            "cw"
-        );
-        assert!(wrapper.sensitive.0);
-
-        // Boost row
-        let boost = BoostRepository::oneshot()
-            .find_by_original_uri(STATUS_URI_A)
-            .expect("query")
-            .expect("boost exists");
-        assert_eq!(boost.id.expect("id").0, 42);
-        assert_eq!(
-            boost.original_status_uri.expect("uri").0,
-            STATUS_URI_A.to_string()
-        );
-
-        // Idempotency check picks it up
-        assert!(
-            BoostRepository::oneshot()
-                .is_boosted(STATUS_URI_A)
-                .expect("query")
-        );
-    }
-
-    #[test]
-    fn test_insert_boost_with_wrapper_rolls_back_on_error() {
-        setup();
-
-        let result: Result<(), CanisterError> = Transaction::run(Schema, |tx| {
-            BoostRepository::with_transaction(tx).insert_boost_with_wrapper(
-                55,
-                STATUS_URI_A,
-                "rolled back",
-                crate::schema::Visibility::from(did::common::Visibility::Public),
-                None,
-                false,
-                500,
-            )?;
-            Err(CanisterError::Internal("boom".to_string()))
-        });
-        assert!(result.is_err());
-
-        assert!(
-            !BoostRepository::oneshot()
-                .is_boosted(STATUS_URI_A)
-                .expect("query")
-        );
-        assert!(
-            crate::domain::status::StatusRepository::oneshot()
-                .find_by_id(55)
-                .expect("query")
-                .is_none(),
-            "wrapper status must not persist on rollback"
-        );
+        BoostRepository::oneshot()
+            .delete_by_id(999)
+            .expect("delete missing must succeed");
     }
 }

--- a/crates/canisters/user/src/domain/boost/repository.rs
+++ b/crates/canisters/user/src/domain/boost/repository.rs
@@ -1,9 +1,12 @@
 use ic_dbms_canister::prelude::DBMS_CONTEXT;
 use wasm_dbms::WasmDbmsDatabase;
-use wasm_dbms_api::prelude::{Database, DeleteBehavior, Filter, Query};
+use wasm_dbms_api::prelude::{Database, DeleteBehavior, Filter, Nullable, Query};
 
 use crate::error::{CanisterError, CanisterResult};
-use crate::schema::{Boost, BoostInsertRequest, BoostRecord, Schema};
+use crate::schema::{
+    Boost, BoostInsertRequest, BoostRecord, FeedEntry, FeedEntryInsertRequest, FeedSource, Schema,
+    Status, StatusInsertRequest, Visibility,
+};
 
 /// Repository for managing [`Boost`] records in the database.
 pub struct BoostRepository;
@@ -21,6 +24,58 @@ impl BoostRepository {
                     original_status_uri: original_status_uri.into(),
                     created_at: ic_utils::now().into(),
                 })
+            })
+            .map_err(CanisterError::from)
+    }
+
+    /// Transactionally insert a wrapper [`Status`] row, the corresponding
+    /// [`Boost`] row, and a `feed` entry with `source = Outbox`. The same
+    /// `snowflake_id` is used as the primary key in all three tables — this
+    /// makes the wrapper status URL `<actor>/statuses/<snowflake>` also serve
+    /// as the `Announce` activity id.
+    pub fn insert_boost_with_wrapper(
+        snowflake_id: u64,
+        original_status_uri: &str,
+        content: &str,
+        visibility: Visibility,
+        spoiler_text: Option<&str>,
+        sensitive: bool,
+        created_at: u64,
+    ) -> CanisterResult<()> {
+        DBMS_CONTEXT
+            .with(|ctx| {
+                let tx_id = ctx
+                    .begin_transaction(db_utils::transaction::transaction_caller(ic_utils::now()));
+                let mut db = WasmDbmsDatabase::from_transaction(ctx, Schema, tx_id);
+
+                db.insert::<Status>(StatusInsertRequest {
+                    id: snowflake_id.into(),
+                    content: content.into(),
+                    visibility,
+                    like_count: 0u64.into(),
+                    boost_count: 0u64.into(),
+                    in_reply_to_uri: Nullable::Null,
+                    spoiler_text: spoiler_text
+                        .map_or(Nullable::Null, |s| Nullable::Value(s.into())),
+                    sensitive: sensitive.into(),
+                    edited_at: Nullable::Null,
+                    created_at: created_at.into(),
+                })?;
+
+                db.insert::<Boost>(BoostInsertRequest {
+                    id: snowflake_id.into(),
+                    status_id: snowflake_id.into(),
+                    original_status_uri: original_status_uri.into(),
+                    created_at: created_at.into(),
+                })?;
+
+                db.insert::<FeedEntry>(FeedEntryInsertRequest {
+                    id: snowflake_id.into(),
+                    source: FeedSource::Outbox,
+                    created_at: created_at.into(),
+                })?;
+
+                db.commit()
             })
             .map_err(CanisterError::from)
     }
@@ -205,5 +260,50 @@ mod tests {
         setup();
         let found = BoostRepository::find_by_original_uri(STATUS_URI_A).expect("should query");
         assert!(found.is_none());
+    }
+
+    #[test]
+    fn test_should_insert_boost_with_wrapper_in_one_tx() {
+        setup();
+
+        BoostRepository::insert_boost_with_wrapper(
+            42,
+            STATUS_URI_A,
+            "boosted text",
+            crate::schema::Visibility::from(did::common::Visibility::Public),
+            Some("cw"),
+            true,
+            1_000_000,
+        )
+        .expect("insert");
+
+        // Wrapper Status row
+        let wrapper = crate::domain::status::StatusRepository::find_by_id(42)
+            .expect("query")
+            .expect("wrapper exists");
+        assert_eq!(wrapper.content.0, "boosted text");
+        assert_eq!(
+            wrapper
+                .spoiler_text
+                .clone()
+                .into_opt()
+                .expect("spoiler value")
+                .0,
+            "cw"
+        );
+        assert!(wrapper.sensitive.0);
+
+        // Boost row
+        let boost = BoostRepository::find_by_original_uri(STATUS_URI_A)
+            .expect("query")
+            .expect("boost exists");
+        assert_eq!(boost.id.expect("id").0, 42);
+        assert_eq!(
+            boost.original_status_uri.expect("uri").0,
+            STATUS_URI_A.to_string()
+        );
+
+        // Idempotency check picks it up
+        assert!(BoostRepository::is_boosted(STATUS_URI_A).expect("query"));
     }
 }

--- a/crates/canisters/user/src/domain/boost/undo_boost.rs
+++ b/crates/canisters/user/src/domain/boost/undo_boost.rs
@@ -1,7 +1,232 @@
 //! Flow for undoing a boost of a status.
+//!
+//! See `.claude/specs/2026-05-02-wi-1-7-boost-status-design.md` ("Undo Flow").
+//!
+//! Pipeline:
+//! 1. Idempotency: if no boost row for `status_url` exists → `Ok` without
+//!    dispatching anything.
+//! 2. Resolve the wrapper id from the boost row (== `boost.status_id` ==
+//!    `boost.id` with the shared-snowflake design).
+//! 3. Compute recipients (followers ∪ original author, deduplicated;
+//!    excluding self when self == author).
+//! 4. In one transaction: delete Boost, FeedEntry, then wrapper Status.
+//! 5. Dispatch `Undo(Announce)` to the recipients via the federation
+//!    adapter. The inner `Announce` activity reuses
+//!    `<own_actor>/statuses/<wrapper_id>` as its id, matching what the
+//!    original boost emitted.
 
-use did::user::{UndoBoostArgs, UndoBoostResponse};
+use activitypub::Activity;
+use activitypub::activity::{ActivityObject, ActivityType};
+use activitypub::context::ACTIVITY_STREAMS_CONTEXT;
+use activitypub::object::{BaseObject, OneOrMany};
+use did::federation::{SendActivityArgs, SendActivityArgsObject};
+use did::user::{UndoBoostArgs, UndoBoostError, UndoBoostResponse};
 
-pub async fn undo_boost(_args: UndoBoostArgs) -> UndoBoostResponse {
-    todo!()
+use crate::domain::boost::repository::BoostRepository;
+use crate::domain::follower::FollowerRepository;
+use crate::domain::profile::ProfileRepository;
+use crate::domain::urls;
+use crate::error::CanisterResult;
+
+const AS_PUBLIC: &str = "https://www.w3.org/ns/activitystreams#Public";
+
+pub async fn undo_boost(UndoBoostArgs { status_url }: UndoBoostArgs) -> UndoBoostResponse {
+    match undo_boost_inner(status_url).await {
+        Ok(()) => UndoBoostResponse::Ok,
+        Err(err) => {
+            ic_utils::log!("Failed to undo boost: {err}");
+            UndoBoostResponse::Err(UndoBoostError::Internal(err.to_string()))
+        }
+    }
+}
+
+async fn undo_boost_inner(status_url: String) -> CanisterResult<()> {
+    ic_utils::log!("Undoing boost on {status_url}");
+
+    let Some(boost) = BoostRepository::find_by_original_uri(&status_url)? else {
+        ic_utils::log!("No boost row for {status_url}; idempotent ok");
+        return Ok(());
+    };
+
+    let wrapper_id = boost.id.expect("id").0;
+    let own_profile = ProfileRepository::get_profile()?;
+    let own_actor_uri = urls::actor_uri(&own_profile.handle.0)?;
+
+    let mut recipients: Vec<String> = FollowerRepository::get_followers()?
+        .into_iter()
+        .map(|f| f.actor_uri.0)
+        .collect();
+    if let Some(author) = urls::actor_uri_from_status_uri(&status_url)
+        && author != own_actor_uri
+    {
+        recipients.push(author);
+    }
+    recipients.sort();
+    recipients.dedup();
+
+    BoostRepository::delete_boost_with_wrapper(wrapper_id)?;
+
+    if recipients.is_empty() {
+        return Ok(());
+    }
+
+    let undo_activity = make_undo_announce(&own_actor_uri, wrapper_id, &status_url, &recipients);
+    let undo_json =
+        serde_json::to_string(&undo_activity).expect("Activity serialization must not fail");
+    let batch: Vec<SendActivityArgsObject> = recipients
+        .iter()
+        .map(|recipient| SendActivityArgsObject {
+            activity_json: undo_json.clone(),
+            target_inbox: format!("{recipient}/inbox"),
+        })
+        .collect();
+    crate::adapters::federation::send_activity(SendActivityArgs::Batch(batch)).await?;
+
+    Ok(())
+}
+
+fn make_undo_announce(
+    own_actor_uri: &str,
+    wrapper_id: u64,
+    status_url: &str,
+    recipients: &[String],
+) -> Activity {
+    let inner_announce = Activity {
+        base: BaseObject {
+            id: Some(format!("{own_actor_uri}/statuses/{wrapper_id}")),
+            kind: ActivityType::Announce,
+            ..Default::default()
+        },
+        actor: Some(own_actor_uri.to_string()),
+        object: Some(ActivityObject::Id(status_url.to_string())),
+        target: None,
+        result: None,
+        origin: None,
+        instrument: None,
+    };
+    let cc = if recipients.is_empty() {
+        None
+    } else {
+        Some(OneOrMany::Many(recipients.to_vec()))
+    };
+    Activity {
+        base: BaseObject {
+            context: Some(activitypub::context::Context::Uri(
+                ACTIVITY_STREAMS_CONTEXT.to_string(),
+            )),
+            kind: ActivityType::Undo,
+            to: Some(OneOrMany::One(AS_PUBLIC.to_string())),
+            cc,
+            ..Default::default()
+        },
+        actor: Some(own_actor_uri.to_string()),
+        object: Some(ActivityObject::Activity(Box::new(inner_announce))),
+        target: None,
+        result: None,
+        origin: None,
+        instrument: None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use activitypub::activity::{ActivityObject, ActivityType};
+    use did::common::{Status, Visibility};
+    use did::federation::{FetchStatusResponse, SendActivityArgs};
+    use did::user::{BoostStatusArgs, BoostStatusResponse, UndoBoostArgs, UndoBoostResponse};
+
+    use super::undo_boost;
+    use crate::adapters::federation::mock::{captured, push_fetch_status_response, reset_captured};
+    use crate::domain::boost::boost_status::boost_status;
+    use crate::domain::boost::repository::BoostRepository;
+    use crate::domain::follower::FollowerRepository;
+    use crate::test_utils::setup;
+
+    const STATUS_URI: &str = "https://remote.example/users/bob/statuses/42";
+    const FOLLOWER_URI: &str = "https://remote.example/users/charlie";
+
+    fn fixture_status() -> Status {
+        Status {
+            id: 42,
+            content: "hi".into(),
+            author: "https://remote.example/users/bob".into(),
+            created_at: 1_000,
+            visibility: Visibility::Public,
+            like_count: 0,
+            boost_count: 0,
+            spoiler_text: None,
+            sensitive: false,
+        }
+    }
+
+    async fn boost_first() {
+        FollowerRepository::insert(FOLLOWER_URI).expect("insert follower");
+        push_fetch_status_response(FetchStatusResponse::Ok(fixture_status()));
+        assert_eq!(
+            boost_status(BoostStatusArgs {
+                status_url: STATUS_URI.into()
+            })
+            .await,
+            BoostStatusResponse::Ok
+        );
+    }
+
+    #[tokio::test]
+    async fn test_should_undo_boost() {
+        setup();
+        boost_first().await;
+        reset_captured();
+
+        let resp = undo_boost(UndoBoostArgs {
+            status_url: STATUS_URI.into(),
+        })
+        .await;
+        assert_eq!(resp, UndoBoostResponse::Ok);
+        assert!(!BoostRepository::is_boosted(STATUS_URI).expect("query"));
+
+        let captured = captured();
+        let SendActivityArgs::Batch(batch) = &captured[0] else {
+            panic!("expected batch");
+        };
+        assert!(!batch.is_empty());
+        let activity: activitypub::Activity =
+            serde_json::from_str(&batch[0].activity_json).unwrap();
+        assert_eq!(activity.base.kind, ActivityType::Undo);
+        let ActivityObject::Activity(inner) = activity.object.expect("inner") else {
+            panic!("expected nested Activity");
+        };
+        assert_eq!(inner.base.kind, ActivityType::Announce);
+    }
+
+    #[tokio::test]
+    async fn test_idempotent_when_no_boost_exists() {
+        setup();
+
+        let resp = undo_boost(UndoBoostArgs {
+            status_url: STATUS_URI.into(),
+        })
+        .await;
+        assert_eq!(resp, UndoBoostResponse::Ok);
+        assert!(captured().is_empty(), "no dispatch when no boost row");
+    }
+
+    #[tokio::test]
+    async fn test_double_undo_dispatches_only_once() {
+        setup();
+        boost_first().await;
+        reset_captured();
+
+        let _ = undo_boost(UndoBoostArgs {
+            status_url: STATUS_URI.into(),
+        })
+        .await;
+        let after_first = captured().len();
+        let _ = undo_boost(UndoBoostArgs {
+            status_url: STATUS_URI.into(),
+        })
+        .await;
+        let after_second = captured().len();
+
+        assert_eq!(after_first, after_second);
+    }
 }

--- a/crates/canisters/user/src/domain/boost/undo_boost.rs
+++ b/crates/canisters/user/src/domain/boost/undo_boost.rs
@@ -52,7 +52,8 @@ async fn undo_boost_inner(status_url: String) -> CanisterResult<()> {
     let own_profile = ProfileRepository::oneshot().get_profile()?;
     let own_actor_uri = urls::actor_uri(&own_profile.handle.0)?;
 
-    let mut recipients: Vec<String> = FollowerRepository::get_followers()?
+    let mut recipients: Vec<String> = FollowerRepository::oneshot()
+        .get_followers()?
         .into_iter()
         .map(|f| f.actor_uri.0)
         .collect();
@@ -160,7 +161,9 @@ mod tests {
     }
 
     async fn boost_first() {
-        FollowerRepository::insert(FOLLOWER_URI).expect("insert follower");
+        FollowerRepository::oneshot()
+            .insert(FOLLOWER_URI)
+            .expect("insert follower");
         push_fetch_status_response(FetchStatusResponse::Ok(fixture_status()));
         assert_eq!(
             boost_status(BoostStatusArgs {

--- a/crates/canisters/user/src/domain/boost/undo_boost.rs
+++ b/crates/canisters/user/src/domain/boost/undo_boost.rs
@@ -1,0 +1,7 @@
+//! Flow for undoing a boost of a status.
+
+use did::user::{UndoBoostArgs, UndoBoostResponse};
+
+pub async fn undo_boost(args: UndoBoostArgs) -> UndoBoostResponse {
+    todo!()
+}

--- a/crates/canisters/user/src/domain/boost/undo_boost.rs
+++ b/crates/canisters/user/src/domain/boost/undo_boost.rs
@@ -2,6 +2,6 @@
 
 use did::user::{UndoBoostArgs, UndoBoostResponse};
 
-pub async fn undo_boost(args: UndoBoostArgs) -> UndoBoostResponse {
+pub async fn undo_boost(_args: UndoBoostArgs) -> UndoBoostResponse {
     todo!()
 }

--- a/crates/canisters/user/src/domain/boost/undo_boost.rs
+++ b/crates/canisters/user/src/domain/boost/undo_boost.rs
@@ -19,13 +19,17 @@ use activitypub::Activity;
 use activitypub::activity::{ActivityObject, ActivityType};
 use activitypub::context::ACTIVITY_STREAMS_CONTEXT;
 use activitypub::object::{BaseObject, OneOrMany};
+use db_utils::repository::Repository;
 use db_utils::transaction::Transaction;
 use did::federation::{SendActivityArgs, SendActivityArgsObject};
 use did::user::{UndoBoostArgs, UndoBoostError, UndoBoostResponse};
+use wasm_dbms_api::prelude::TransactionId;
 
 use crate::domain::boost::repository::BoostRepository;
+use crate::domain::feed::FeedRepository;
 use crate::domain::follower::FollowerRepository;
 use crate::domain::profile::ProfileRepository;
+use crate::domain::status::StatusRepository;
 use crate::domain::urls;
 use crate::error::{CanisterError, CanisterResult};
 use crate::schema::Schema;
@@ -68,7 +72,7 @@ async fn undo_boost_inner(status_url: String) -> CanisterResult<()> {
     recipients.dedup();
 
     Transaction::run::<_, _, _, CanisterError>(Schema, |tx| {
-        BoostRepository::with_transaction(tx).delete_boost_with_wrapper(wrapper_id)
+        delete_boost_with_wrapper(tx, wrapper_id)
     })?;
 
     if recipients.is_empty() {
@@ -87,6 +91,16 @@ async fn undo_boost_inner(status_url: String) -> CanisterResult<()> {
         .collect();
     crate::adapters::federation::send_activity(SendActivityArgs::Batch(batch)).await?;
 
+    Ok(())
+}
+
+/// Delete the boost row, its outbox feed entry, and the wrapper status row.
+/// Order matters because of FK Restrict: child (boost) → feed → parent
+/// (status).
+fn delete_boost_with_wrapper(tx: TransactionId, snowflake_id: u64) -> CanisterResult<()> {
+    BoostRepository::with_transaction(tx).delete_by_id(snowflake_id)?;
+    FeedRepository::with_transaction(tx).delete_by_id(snowflake_id)?;
+    StatusRepository::with_transaction(tx).delete_by_id(snowflake_id)?;
     Ok(())
 }
 
@@ -140,11 +154,14 @@ mod tests {
     use did::federation::{FetchStatusResponse, SendActivityArgs};
     use did::user::{BoostStatusArgs, BoostStatusResponse, UndoBoostArgs, UndoBoostResponse};
 
-    use super::undo_boost;
+    use super::*;
     use crate::adapters::federation::mock::{captured, push_fetch_status_response, reset_captured};
     use crate::domain::boost::boost_status::boost_status;
     use crate::domain::boost::repository::BoostRepository;
+    use crate::domain::feed::FeedRepository;
     use crate::domain::follower::FollowerRepository;
+    use crate::domain::status::StatusRepository;
+    use crate::error::CanisterError;
     use crate::test_utils::setup;
 
     const STATUS_URI: &str = "https://remote.example/users/bob/statuses/42";
@@ -239,5 +256,40 @@ mod tests {
         let after_second = captured().len();
 
         assert_eq!(after_first, after_second);
+    }
+
+    #[test]
+    fn test_should_delete_boost_with_wrapper_in_one_tx() {
+        setup();
+
+        Transaction::run::<_, _, _, CanisterError>(Schema, |tx| {
+            StatusRepository::with_transaction(tx).insert_wrapper(
+                77,
+                "boosted",
+                Visibility::Public,
+                None,
+                false,
+                1_000,
+            )?;
+            BoostRepository::with_transaction(tx).insert(77, STATUS_URI, 1_000)?;
+            FeedRepository::with_transaction(tx).insert_outbox(77, 1_000)
+        })
+        .expect("seed");
+
+        Transaction::run::<_, _, _, CanisterError>(Schema, |tx| delete_boost_with_wrapper(tx, 77))
+            .expect("delete");
+
+        assert!(
+            !BoostRepository::oneshot()
+                .is_boosted(STATUS_URI)
+                .expect("query")
+        );
+        assert!(
+            StatusRepository::oneshot()
+                .find_by_id(77)
+                .expect("query")
+                .is_none(),
+            "wrapper status row removed"
+        );
     }
 }

--- a/crates/canisters/user/src/domain/boost/undo_boost.rs
+++ b/crates/canisters/user/src/domain/boost/undo_boost.rs
@@ -49,7 +49,7 @@ async fn undo_boost_inner(status_url: String) -> CanisterResult<()> {
     };
 
     let wrapper_id = boost.id.expect("id").0;
-    let own_profile = ProfileRepository::get_profile()?;
+    let own_profile = ProfileRepository::oneshot().get_profile()?;
     let own_actor_uri = urls::actor_uri(&own_profile.handle.0)?;
 
     let mut recipients: Vec<String> = FollowerRepository::get_followers()?

--- a/crates/canisters/user/src/domain/boost/undo_boost.rs
+++ b/crates/canisters/user/src/domain/boost/undo_boost.rs
@@ -19,6 +19,7 @@ use activitypub::Activity;
 use activitypub::activity::{ActivityObject, ActivityType};
 use activitypub::context::ACTIVITY_STREAMS_CONTEXT;
 use activitypub::object::{BaseObject, OneOrMany};
+use db_utils::transaction::Transaction;
 use did::federation::{SendActivityArgs, SendActivityArgsObject};
 use did::user::{UndoBoostArgs, UndoBoostError, UndoBoostResponse};
 
@@ -26,7 +27,8 @@ use crate::domain::boost::repository::BoostRepository;
 use crate::domain::follower::FollowerRepository;
 use crate::domain::profile::ProfileRepository;
 use crate::domain::urls;
-use crate::error::CanisterResult;
+use crate::error::{CanisterError, CanisterResult};
+use crate::schema::Schema;
 
 const AS_PUBLIC: &str = "https://www.w3.org/ns/activitystreams#Public";
 
@@ -43,7 +45,7 @@ pub async fn undo_boost(UndoBoostArgs { status_url }: UndoBoostArgs) -> UndoBoos
 async fn undo_boost_inner(status_url: String) -> CanisterResult<()> {
     ic_utils::log!("Undoing boost on {status_url}");
 
-    let Some(boost) = BoostRepository::find_by_original_uri(&status_url)? else {
+    let Some(boost) = BoostRepository::oneshot().find_by_original_uri(&status_url)? else {
         ic_utils::log!("No boost row for {status_url}; idempotent ok");
         return Ok(());
     };
@@ -65,7 +67,9 @@ async fn undo_boost_inner(status_url: String) -> CanisterResult<()> {
     recipients.sort();
     recipients.dedup();
 
-    BoostRepository::delete_boost_with_wrapper(wrapper_id)?;
+    Transaction::run::<_, _, _, CanisterError>(Schema, |tx| {
+        BoostRepository::with_transaction(tx).delete_boost_with_wrapper(wrapper_id)
+    })?;
 
     if recipients.is_empty() {
         return Ok(());
@@ -185,7 +189,11 @@ mod tests {
         })
         .await;
         assert_eq!(resp, UndoBoostResponse::Ok);
-        assert!(!BoostRepository::is_boosted(STATUS_URI).expect("query"));
+        assert!(
+            !BoostRepository::oneshot()
+                .is_boosted(STATUS_URI)
+                .expect("query")
+        );
 
         let captured = captured();
         let SendActivityArgs::Batch(batch) = &captured[0] else {

--- a/crates/canisters/user/src/domain/feed.rs
+++ b/crates/canisters/user/src/domain/feed.rs
@@ -1,5 +1,8 @@
 //! User feed domain logic.
 
 mod read_feed;
+mod repository;
 
 pub use read_feed::read_feed;
+#[allow(unused_imports)]
+pub use repository::FeedRepository;

--- a/crates/canisters/user/src/domain/feed.rs
+++ b/crates/canisters/user/src/domain/feed.rs
@@ -4,5 +4,4 @@ mod read_feed;
 mod repository;
 
 pub use read_feed::read_feed;
-#[allow(unused_imports)]
 pub use repository::FeedRepository;

--- a/crates/canisters/user/src/domain/feed/read_feed.rs
+++ b/crates/canisters/user/src/domain/feed/read_feed.rs
@@ -110,11 +110,39 @@ fn hydrate_outbox(db: &impl Database, id: u64, owner_actor_uri: &str) -> Option<
         .map(|t| t.0.clone());
     let sensitive = find_value(row, "sensitive")?.as_boolean()?.0;
 
+    // If a `Boost` row exists for this status id, this is a wrapper status for
+    // a re-share: rewrite id/author from the boosted original and surface the
+    // owner as `boosted_by`.
+    let boost_row = db
+        .select::<crate::schema::Boost>(
+            Query::builder()
+                .all()
+                .and_where(Filter::eq("status_id", Value::from(id)))
+                .limit(1)
+                .build(),
+        )
+        .ok()
+        .and_then(|rows| rows.into_iter().next());
+
+    let (final_id, author, boosted_by) = match boost_row {
+        Some(row) => {
+            let original_uri = row
+                .original_status_uri
+                .expect("boosts.original_status_uri is non-null")
+                .0;
+            let original_id = crate::domain::urls::parse_status_id(&original_uri).unwrap_or(id);
+            let author = crate::domain::urls::actor_uri_from_status_uri(&original_uri)
+                .unwrap_or_else(|| owner_actor_uri.to_string());
+            (original_id, author, Some(owner_actor_uri.to_string()))
+        }
+        None => (id, owner_actor_uri.to_string(), None),
+    };
+
     Some(FeedItem {
         status: Status {
-            id,
+            id: final_id,
             content,
-            author: owner_actor_uri.to_string(),
+            author,
             created_at,
             visibility: db_vis.into(),
             like_count,
@@ -122,7 +150,7 @@ fn hydrate_outbox(db: &impl Database, id: u64, owner_actor_uri: &str) -> Option<
             spoiler_text,
             sensitive,
         },
-        boosted_by: None, // FIXME: eventually support boosts in M1
+        boosted_by,
     })
 }
 
@@ -276,9 +304,9 @@ mod tests {
 
     use super::read_feed;
     use crate::schema::{
-        ActivityType as DbActivityType, FeedEntry, FeedEntryInsertRequest, FeedSource,
-        InboxActivity, InboxActivityInsertRequest, Schema, Status, StatusInsertRequest,
-        Visibility as DbVisibility,
+        ActivityType as DbActivityType, Boost, BoostInsertRequest, FeedEntry,
+        FeedEntryInsertRequest, FeedSource, InboxActivity, InboxActivityInsertRequest, Schema,
+        Status, StatusInsertRequest, Visibility as DbVisibility,
     };
     use crate::test_utils::setup;
 
@@ -605,6 +633,82 @@ mod tests {
         assert_eq!(items.len(), 1);
         assert_eq!(items[0].status.content, "DM for you");
         assert_eq!(items[0].status.visibility, Visibility::Direct);
+    }
+
+    fn insert_boost_wrapper(snowflake: u64, original_uri: &str, content: &str, created_at: u64) {
+        DBMS_CONTEXT.with(|ctx| {
+            let tx_id =
+                ctx.begin_transaction(db_utils::transaction::transaction_caller(ic_utils::now()));
+            let mut db = WasmDbmsDatabase::from_transaction(ctx, Schema, tx_id);
+            db.insert::<Status>(StatusInsertRequest {
+                id: snowflake.into(),
+                content: content.into(),
+                visibility: DbVisibility::from(Visibility::Public),
+                like_count: 0u64.into(),
+                boost_count: 0u64.into(),
+                in_reply_to_uri: Nullable::Null,
+                spoiler_text: Nullable::Null,
+                sensitive: false.into(),
+                edited_at: Nullable::Null,
+                created_at: created_at.into(),
+            })
+            .expect("should insert wrapper status");
+            db.insert::<Boost>(BoostInsertRequest {
+                id: snowflake.into(),
+                status_id: snowflake.into(),
+                original_status_uri: original_uri.into(),
+                created_at: created_at.into(),
+            })
+            .expect("should insert boost");
+            db.insert::<FeedEntry>(FeedEntryInsertRequest {
+                id: snowflake.into(),
+                source: FeedSource::Outbox,
+                created_at: created_at.into(),
+            })
+            .expect("should insert feed entry");
+            db.commit().expect("should commit");
+        });
+    }
+
+    #[test]
+    fn test_outbox_boost_renders_boosted_by_self_and_original_author() {
+        setup();
+        let original = "https://remote.example/users/bob/statuses/99";
+        insert_boost_wrapper(7, original, "boosted text", 5_000);
+
+        let items = unwrap_ok(read_feed(ReadFeedArgs {
+            limit: 10,
+            offset: 0,
+        }));
+
+        assert_eq!(items.len(), 1);
+        assert_eq!(
+            items[0].boosted_by.as_deref(),
+            Some("https://mastic.social/users/rey_canisteryo")
+        );
+        assert_eq!(items[0].status.author, "https://remote.example/users/bob");
+        assert_eq!(items[0].status.id, 99);
+        assert_eq!(items[0].status.content, "boosted text");
+    }
+
+    #[test]
+    fn test_outbox_non_boost_renders_owner_as_author_with_no_boosted_by() {
+        setup();
+        insert_status(8, "Mine", Visibility::Public, 1_000);
+
+        let items = unwrap_ok(read_feed(ReadFeedArgs {
+            limit: 10,
+            offset: 0,
+        }));
+
+        assert_eq!(items.len(), 1);
+        assert!(items[0].boosted_by.is_none());
+        assert_eq!(
+            items[0].status.author,
+            "https://mastic.social/users/rey_canisteryo"
+        );
+        assert_eq!(items[0].status.id, 8);
+        assert_eq!(items[0].status.content, "Mine");
     }
 
     #[test]

--- a/crates/canisters/user/src/domain/feed/read_feed.rs
+++ b/crates/canisters/user/src/domain/feed/read_feed.rs
@@ -170,6 +170,37 @@ fn hydrate_inbox(db: &impl Database, id: u64, owner_actor_uri: &str) -> Option<F
     let row = rows.first()?;
 
     let created_at = find_value(row, "created_at")?.as_uint64()?.0;
+    let is_boost = find_value(row, "is_boost")
+        .and_then(|v| v.as_boolean())
+        .map(|b| b.0)
+        .unwrap_or(false);
+
+    if is_boost {
+        let original_uri = find_value(row, "original_status_uri")?.as_text()?.0.clone();
+        let booster = find_value(row, "actor_uri")?.as_text()?.0.clone();
+        let original_id = crate::domain::urls::parse_status_id(&original_uri).unwrap_or(0);
+        let author =
+            crate::domain::urls::actor_uri_from_status_uri(&original_uri).unwrap_or_default();
+
+        let (content, visibility, spoiler_text, sensitive) =
+            resolve_boost_original(db, &original_uri, original_id);
+
+        return Some(FeedItem {
+            status: Status {
+                id: original_id,
+                content,
+                author,
+                created_at,
+                visibility,
+                like_count: 0,
+                boost_count: 0,
+                spoiler_text,
+                sensitive,
+            },
+            boosted_by: Some(booster),
+        });
+    }
+
     let json_val = find_value(row, "object_data")?.as_json()?;
     let activity: Activity = serde_json::from_value(json_val.value().clone()).ok()?;
     let (content, visibility, spoiler_text, sensitive) = extract_note_from_activity(&activity)?;
@@ -193,8 +224,69 @@ fn hydrate_inbox(db: &impl Database, id: u64, owner_actor_uri: &str) -> Option<F
             spoiler_text,
             sensitive,
         },
-        boosted_by: None, // FIXME: eventually support boosts in M1
+        boosted_by: None,
     })
+}
+
+/// Resolve the original (boosted) status for an inbox boost render.
+///
+/// Tries:
+/// 1. Local statuses table (if the URI is hosted on this instance and the
+///    `find_by_id` lookup succeeds).
+/// 2. Cached inbox `Create(Note)` row whose `object_data.object.id` matches
+///    `original_uri`.
+/// 3. Fallback: empty content, `Visibility::Public`, no spoiler, not sensitive.
+fn resolve_boost_original(
+    db: &impl Database,
+    original_uri: &str,
+    original_id: u64,
+) -> (String, Visibility, Option<String>, bool) {
+    if let Ok(Some((_, _))) = crate::domain::urls::parse_local_status_uri(original_uri)
+        && let Ok(Some(row)) = crate::domain::status::StatusRepository::find_by_id(original_id)
+    {
+        let content = row.content.0.to_string();
+        let visibility: Visibility = row.visibility.into();
+        let spoiler_text = row.spoiler_text.into_opt().map(|t| t.0);
+        let sensitive = row.sensitive.0;
+        return (content, visibility, spoiler_text, sensitive);
+    }
+
+    if let Some((content, visibility, spoiler_text, sensitive)) =
+        find_cached_inbox_note(db, original_uri)
+    {
+        return (content, visibility, spoiler_text, sensitive);
+    }
+
+    (String::new(), Visibility::Public, None, false)
+}
+
+/// Scan the `inbox` table for a `Create(Note)` whose embedded note's `id`
+/// matches `original_uri`, returning the extracted note fields.
+fn find_cached_inbox_note(
+    db: &impl Database,
+    original_uri: &str,
+) -> Option<(String, Visibility, Option<String>, bool)> {
+    let query = Query::builder().all().build();
+    let rows = db.select_raw("inbox", query).ok()?;
+
+    for row in &rows {
+        let Some(json) = find_value(row, "object_data").and_then(|v| v.as_json()) else {
+            continue;
+        };
+        let Ok(activity) = serde_json::from_value::<Activity>(json.value().clone()) else {
+            continue;
+        };
+        if activity.base.kind != ApActivityType::Create {
+            continue;
+        }
+        let Some(ActivityObject::Object(note)) = activity.object.as_ref() else {
+            continue;
+        };
+        if note.id.as_deref() == Some(original_uri) {
+            return extract_note_from_activity(&activity);
+        }
+    }
+    None
 }
 
 /// Extracts the text content, inferred [`Visibility`], optional spoiler text,
@@ -728,5 +820,85 @@ mod tests {
         }));
 
         assert!(items.is_empty());
+    }
+
+    fn insert_inbox_announce(id: u64, booster: &str, target_uri: &str, created_at: u64) {
+        DBMS_CONTEXT.with(|ctx| {
+            let tx_id =
+                ctx.begin_transaction(db_utils::transaction::transaction_caller(ic_utils::now()));
+            let mut db = WasmDbmsDatabase::from_transaction(ctx, Schema, tx_id);
+            db.insert::<InboxActivity>(InboxActivityInsertRequest {
+                id: id.into(),
+                activity_type: DbActivityType::from(ApActivityType::Announce),
+                actor_uri: booster.into(),
+                object_data: serde_json::json!({"type": "Announce"}).into(),
+                is_boost: true.into(),
+                original_status_uri: Nullable::Value(target_uri.into()),
+                created_at: created_at.into(),
+            })
+            .expect("insert inbox row");
+            db.insert::<FeedEntry>(FeedEntryInsertRequest {
+                id: id.into(),
+                source: FeedSource::Inbox,
+                created_at: created_at.into(),
+            })
+            .expect("insert feed entry");
+            db.commit().expect("commit");
+        });
+    }
+
+    #[test]
+    fn test_inbox_boost_renders_boosted_by_booster_and_local_original_author() {
+        setup();
+        insert_status(99, "Bob's post", Visibility::Public, 1_000);
+        insert_inbox_announce(
+            500,
+            "https://remote.example/users/alice",
+            "https://mastic.social/users/rey_canisteryo/statuses/99",
+            2_000,
+        );
+
+        let items = unwrap_ok(read_feed(ReadFeedArgs {
+            limit: 10,
+            offset: 0,
+        }));
+
+        assert_eq!(items.len(), 2);
+        let boost = &items[0]; // newer first
+        assert_eq!(
+            boost.boosted_by.as_deref(),
+            Some("https://remote.example/users/alice")
+        );
+        assert_eq!(
+            boost.status.author,
+            "https://mastic.social/users/rey_canisteryo"
+        );
+        assert_eq!(boost.status.id, 99);
+        assert_eq!(boost.status.content, "Bob's post");
+    }
+
+    #[test]
+    fn test_inbox_boost_falls_back_to_empty_when_original_not_cached() {
+        setup();
+        insert_inbox_announce(
+            500,
+            "https://remote.example/users/alice",
+            "https://other.example/users/bob/statuses/99",
+            2_000,
+        );
+
+        let items = unwrap_ok(read_feed(ReadFeedArgs {
+            limit: 10,
+            offset: 0,
+        }));
+
+        assert_eq!(items.len(), 1);
+        assert_eq!(
+            items[0].boosted_by.as_deref(),
+            Some("https://remote.example/users/alice")
+        );
+        assert_eq!(items[0].status.author, "https://other.example/users/bob");
+        assert_eq!(items[0].status.id, 99);
+        assert_eq!(items[0].status.content, "");
     }
 }

--- a/crates/canisters/user/src/domain/feed/read_feed.rs
+++ b/crates/canisters/user/src/domain/feed/read_feed.rs
@@ -108,10 +108,7 @@ fn hydrate_outbox(db: &impl Database, id: u64, owner_actor_uri: &str) -> Option<
     let spoiler_text = find_value(row, "spoiler_text")
         .and_then(|v| v.as_text())
         .map(|t| t.0.clone());
-    let sensitive = find_value(row, "sensitive")
-        .and_then(|v| v.as_boolean())
-        .map(|b| b.0)
-        .unwrap_or(false);
+    let sensitive = find_value(row, "sensitive")?.as_boolean()?.0;
 
     Some(FeedItem {
         status: Status {

--- a/crates/canisters/user/src/domain/feed/read_feed.rs
+++ b/crates/canisters/user/src/domain/feed/read_feed.rs
@@ -105,6 +105,13 @@ fn hydrate_outbox(db: &impl Database, id: u64, owner_actor_uri: &str) -> Option<
 
     let like_count = find_value(row, "like_count")?.as_uint64()?.0;
     let boost_count = find_value(row, "boost_count")?.as_uint64()?.0;
+    let spoiler_text = find_value(row, "spoiler_text")
+        .and_then(|v| v.as_text())
+        .map(|t| t.0.clone());
+    let sensitive = find_value(row, "sensitive")
+        .and_then(|v| v.as_boolean())
+        .map(|b| b.0)
+        .unwrap_or(false);
 
     Some(FeedItem {
         status: Status {
@@ -115,6 +122,8 @@ fn hydrate_outbox(db: &impl Database, id: u64, owner_actor_uri: &str) -> Option<
             visibility: db_vis.into(),
             like_count,
             boost_count,
+            spoiler_text,
+            sensitive,
         },
         boosted_by: None, // FIXME: eventually support boosts in M1
     })
@@ -138,7 +147,7 @@ fn hydrate_inbox(db: &impl Database, id: u64, owner_actor_uri: &str) -> Option<F
     let created_at = find_value(row, "created_at")?.as_uint64()?.0;
     let json_val = find_value(row, "object_data")?.as_json()?;
     let activity: Activity = serde_json::from_value(json_val.value().clone()).ok()?;
-    let (content, visibility) = extract_note_from_activity(&activity)?;
+    let (content, visibility, spoiler_text, sensitive) = extract_note_from_activity(&activity)?;
 
     // Direct messages must only appear when the owner is explicitly addressed.
     if visibility == Visibility::Direct && !is_addressed_to(&activity.base, owner_actor_uri) {
@@ -156,13 +165,18 @@ fn hydrate_inbox(db: &impl Database, id: u64, owner_actor_uri: &str) -> Option<F
             visibility,
             like_count: 0,
             boost_count: 0,
+            spoiler_text,
+            sensitive,
         },
         boosted_by: None, // FIXME: eventually support boosts in M1
     })
 }
 
-/// Extracts the text content and inferred [`Visibility`] from a `Create(Note)` activity.
-fn extract_note_from_activity(activity: &Activity) -> Option<(String, Visibility)> {
+/// Extracts the text content, inferred [`Visibility`], optional spoiler text,
+/// and `sensitive` flag from a `Create(Note)` activity.
+fn extract_note_from_activity(
+    activity: &Activity,
+) -> Option<(String, Visibility, Option<String>, bool)> {
     let ActivityObject::Object(note) = activity.object.as_ref()? else {
         return None;
     };
@@ -173,8 +187,10 @@ fn extract_note_from_activity(activity: &Activity) -> Option<(String, Visibility
 
     let content = note.content.clone()?;
     let visibility = infer_visibility(&activity.base);
+    let spoiler_text = note.summary.clone();
+    let sensitive = note.sensitive.unwrap_or(false);
 
-    Some((content, visibility))
+    Some((content, visibility, spoiler_text, sensitive))
 }
 
 /// Infers [`Visibility`] from ActivityPub `to`/`cc` addressing conventions

--- a/crates/canisters/user/src/domain/feed/read_feed.rs
+++ b/crates/canisters/user/src/domain/feed/read_feed.rs
@@ -301,7 +301,8 @@ fn resolve_boost_original(
     original_id: u64,
 ) -> (String, Visibility, Option<String>, bool) {
     if let Ok(Some((_, _))) = crate::domain::urls::parse_local_status_uri(original_uri)
-        && let Ok(Some(row)) = crate::domain::status::StatusRepository::find_by_id(original_id)
+        && let Ok(Some(row)) =
+            crate::domain::status::StatusRepository::oneshot().find_by_id(original_id)
     {
         let content = row.content.0.to_string();
         let visibility: Visibility = row.visibility.into();

--- a/crates/canisters/user/src/domain/feed/read_feed.rs
+++ b/crates/canisters/user/src/domain/feed/read_feed.rs
@@ -3,6 +3,7 @@
 use activitypub::Activity;
 use activitypub::activity::{ActivityObject, ActivityType as ApActivityType};
 use activitypub::object::{BaseObject, ObjectType, OneOrMany};
+use db_utils::repository::Repository;
 use did::common::{FeedItem, Status, Visibility};
 use did::user::{ReadFeedArgs, ReadFeedError, ReadFeedResponse};
 use ic_dbms_canister::prelude::DBMS_CONTEXT;
@@ -447,6 +448,7 @@ mod tests {
     use activitypub::activity::{Activity, ActivityObject, ActivityType as ApActivityType};
     use activitypub::context::ACTIVITY_STREAMS_CONTEXT;
     use activitypub::object::{BaseObject, ObjectType, OneOrMany};
+    use db_utils::repository::Repository;
     use did::common::{FeedItem, Visibility};
     use did::user::{ReadFeedArgs, ReadFeedError, ReadFeedResponse};
     use ic_dbms_canister::prelude::DBMS_CONTEXT;

--- a/crates/canisters/user/src/domain/feed/read_feed.rs
+++ b/crates/canisters/user/src/domain/feed/read_feed.rs
@@ -9,11 +9,17 @@ use ic_dbms_canister::prelude::DBMS_CONTEXT;
 use wasm_dbms::WasmDbmsDatabase;
 use wasm_dbms_api::prelude::{ColumnDef, Database, Filter, Query, Value};
 
+use crate::domain::boost::BoostRepository;
+use crate::domain::liked::LikedRepository;
 use crate::error::CanisterResult;
 use crate::schema::{FeedSource, Schema, Visibility as DbVisibility};
 
 /// The ActivityStreams public addressing constant.
 const AS_PUBLIC: &str = "https://www.w3.org/ns/activitystreams#Public";
+
+/// Tuple of fields extracted from a `Create(Note)` activity:
+/// `(content, visibility, spoiler_text, sensitive, note_id)`.
+type ExtractedNote = (String, Visibility, Option<String>, bool, Option<String>);
 
 /// Reads the user's feed, which includes status updates from followed users.
 ///
@@ -124,7 +130,7 @@ fn hydrate_outbox(db: &impl Database, id: u64, owner_actor_uri: &str) -> Option<
         .ok()
         .and_then(|rows| rows.into_iter().next());
 
-    let (final_id, author, boosted_by) = match boost_row {
+    let (final_id, author, boosted_by, lookup_uri) = match boost_row {
         Some(row) => {
             let original_uri = row
                 .original_status_uri
@@ -133,10 +139,22 @@ fn hydrate_outbox(db: &impl Database, id: u64, owner_actor_uri: &str) -> Option<
             let original_id = crate::domain::urls::parse_status_id(&original_uri).unwrap_or(id);
             let author = crate::domain::urls::actor_uri_from_status_uri(&original_uri)
                 .unwrap_or_else(|| owner_actor_uri.to_string());
-            (original_id, author, Some(owner_actor_uri.to_string()))
+            (
+                original_id,
+                author,
+                Some(owner_actor_uri.to_string()),
+                original_uri,
+            )
         }
-        None => (id, owner_actor_uri.to_string(), None),
+        None => (
+            id,
+            owner_actor_uri.to_string(),
+            None,
+            format!("{owner_actor_uri}/statuses/{id}"),
+        ),
     };
+
+    let (liked, boosted) = viewer_flags(&lookup_uri);
 
     Some(FeedItem {
         status: Status {
@@ -151,6 +169,8 @@ fn hydrate_outbox(db: &impl Database, id: u64, owner_actor_uri: &str) -> Option<
             sensitive,
         },
         boosted_by,
+        liked,
+        boosted,
     })
 }
 
@@ -185,6 +205,8 @@ fn hydrate_inbox(db: &impl Database, id: u64, owner_actor_uri: &str) -> Option<F
         let (content, visibility, spoiler_text, sensitive) =
             resolve_boost_original(db, &original_uri, original_id);
 
+        let (liked, boosted) = viewer_flags(&original_uri);
+
         return Some(FeedItem {
             status: Status {
                 id: original_id,
@@ -198,12 +220,15 @@ fn hydrate_inbox(db: &impl Database, id: u64, owner_actor_uri: &str) -> Option<F
                 sensitive,
             },
             boosted_by: Some(booster),
+            liked,
+            boosted,
         });
     }
 
     let json_val = find_value(row, "object_data")?.as_json()?;
     let activity: Activity = serde_json::from_value(json_val.value().clone()).ok()?;
-    let (content, visibility, spoiler_text, sensitive) = extract_note_from_activity(&activity)?;
+    let (content, visibility, spoiler_text, sensitive, note_id) =
+        extract_note_from_activity(&activity)?;
 
     // Direct messages must only appear when the owner is explicitly addressed.
     if visibility == Visibility::Direct && !is_addressed_to(&activity.base, owner_actor_uri) {
@@ -211,6 +236,11 @@ fn hydrate_inbox(db: &impl Database, id: u64, owner_actor_uri: &str) -> Option<F
     }
 
     let author_uri = activity.actor.clone().unwrap_or_default();
+    let lookup_uri = note_id.and_then(|nid| canonical_status_uri(&nid, &author_uri));
+    let (liked, boosted) = lookup_uri
+        .as_deref()
+        .map(viewer_flags)
+        .unwrap_or((false, false));
 
     Some(FeedItem {
         status: Status {
@@ -225,7 +255,34 @@ fn hydrate_inbox(db: &impl Database, id: u64, owner_actor_uri: &str) -> Option<F
             sensitive,
         },
         boosted_by: None,
+        liked,
+        boosted,
     })
+}
+
+/// Returns `(liked, boosted)` for the given status URI from the viewer's
+/// own `liked` and `boosts` tables. Lookup failures degrade to `false` so
+/// hydration never blocks the feed render.
+fn viewer_flags(status_uri: &str) -> (bool, bool) {
+    let liked = LikedRepository::is_liked(status_uri).unwrap_or(false);
+    let boosted = BoostRepository::is_boosted(status_uri).unwrap_or(false);
+    (liked, boosted)
+}
+
+/// Resolve a note's `id` field into the canonical status URI used by the
+/// `liked` and `boosts` tables. When the note id is already an absolute
+/// URI it is returned unchanged; when it is a bare snowflake (as emitted
+/// today by [`make_activity`] in the publish pipeline) it is rebuilt as
+/// `{actor}/statuses/{id}`. Returns [`None`] when no actor is available
+/// to anchor a relative id.
+fn canonical_status_uri(note_id: &str, author_uri: &str) -> Option<String> {
+    if note_id.starts_with("http://") || note_id.starts_with("https://") {
+        Some(note_id.to_string())
+    } else if author_uri.is_empty() {
+        None
+    } else {
+        Some(format!("{author_uri}/statuses/{note_id}"))
+    }
 }
 
 /// Resolve the original (boosted) status for an inbox boost render.
@@ -251,7 +308,7 @@ fn resolve_boost_original(
         return (content, visibility, spoiler_text, sensitive);
     }
 
-    if let Some((content, visibility, spoiler_text, sensitive)) =
+    if let Some((content, visibility, spoiler_text, sensitive, _)) =
         find_cached_inbox_note(db, original_uri)
     {
         return (content, visibility, spoiler_text, sensitive);
@@ -262,10 +319,7 @@ fn resolve_boost_original(
 
 /// Scan the `inbox` table for a `Create(Note)` whose embedded note's `id`
 /// matches `original_uri`, returning the extracted note fields.
-fn find_cached_inbox_note(
-    db: &impl Database,
-    original_uri: &str,
-) -> Option<(String, Visibility, Option<String>, bool)> {
+fn find_cached_inbox_note(db: &impl Database, original_uri: &str) -> Option<ExtractedNote> {
     let query = Query::builder().all().build();
     let rows = db.select_raw("inbox", query).ok()?;
 
@@ -290,10 +344,9 @@ fn find_cached_inbox_note(
 }
 
 /// Extracts the text content, inferred [`Visibility`], optional spoiler text,
-/// and `sensitive` flag from a `Create(Note)` activity.
-fn extract_note_from_activity(
-    activity: &Activity,
-) -> Option<(String, Visibility, Option<String>, bool)> {
+/// `sensitive` flag, and the note's canonical id (when present) from a
+/// `Create(Note)` activity.
+fn extract_note_from_activity(activity: &Activity) -> Option<ExtractedNote> {
     let ActivityObject::Object(note) = activity.object.as_ref()? else {
         return None;
     };
@@ -306,8 +359,9 @@ fn extract_note_from_activity(
     let visibility = infer_visibility(&activity.base);
     let spoiler_text = note.summary.clone();
     let sensitive = note.sensitive.unwrap_or(false);
+    let note_id = note.id.clone();
 
-    Some((content, visibility, spoiler_text, sensitive))
+    Some((content, visibility, spoiler_text, sensitive, note_id))
 }
 
 /// Infers [`Visibility`] from ActivityPub `to`/`cc` addressing conventions
@@ -900,5 +954,182 @@ mod tests {
         assert_eq!(items[0].status.author, "https://other.example/users/bob");
         assert_eq!(items[0].status.id, 99);
         assert_eq!(items[0].status.content, "");
+    }
+
+    #[test]
+    fn test_outbox_status_flags_default_false() {
+        setup();
+        insert_status(1, "Plain", Visibility::Public, 1_000);
+
+        let items = unwrap_ok(read_feed(ReadFeedArgs {
+            limit: 10,
+            offset: 0,
+        }));
+
+        assert_eq!(items.len(), 1);
+        assert!(!items[0].liked);
+        assert!(!items[0].boosted);
+    }
+
+    #[test]
+    fn test_outbox_status_liked_flag_set_when_user_liked_own_status() {
+        setup();
+        insert_status(1, "Mine", Visibility::Public, 1_000);
+        let owner_uri = crate::domain::urls::actor_uri("rey_canisteryo").unwrap();
+        let status_uri = format!("{owner_uri}/statuses/1");
+        crate::domain::liked::LikedRepository::like_status(&status_uri).expect("like");
+
+        let items = unwrap_ok(read_feed(ReadFeedArgs {
+            limit: 10,
+            offset: 0,
+        }));
+
+        assert_eq!(items.len(), 1);
+        assert!(items[0].liked);
+        assert!(!items[0].boosted);
+    }
+
+    #[test]
+    fn test_outbox_self_boost_marks_wrapper_boosted_true() {
+        setup();
+        let owner_uri = crate::domain::urls::actor_uri("rey_canisteryo").unwrap();
+        // Original status authored by the owner, then boosted by the owner.
+        insert_status(1, "Mine", Visibility::Public, 1_000);
+        let original_uri = format!("{owner_uri}/statuses/1");
+        insert_boost_wrapper(7, &original_uri, "boosted text", 5_000);
+
+        let items = unwrap_ok(read_feed(ReadFeedArgs {
+            limit: 10,
+            offset: 0,
+        }));
+
+        assert_eq!(items.len(), 2);
+        // Newest first: boost wrapper, then the original.
+        let wrapper = &items[0];
+        assert!(wrapper.boosted_by.is_some());
+        assert!(wrapper.boosted, "wrapper resolves boosted=true");
+
+        let original = &items[1];
+        assert!(original.boosted_by.is_none());
+        assert!(
+            original.boosted,
+            "original status is also boosted by the viewer"
+        );
+    }
+
+    #[test]
+    fn test_inbox_boost_sets_liked_when_viewer_liked_original() {
+        setup();
+        // Viewer's local status acts as the boosted target.
+        insert_status(99, "Bob's post", Visibility::Public, 1_000);
+        let original_uri = "https://mastic.social/users/rey_canisteryo/statuses/99";
+        crate::domain::liked::LikedRepository::like_status(original_uri).expect("like");
+
+        insert_inbox_announce(
+            500,
+            "https://remote.example/users/alice",
+            original_uri,
+            2_000,
+        );
+
+        let items = unwrap_ok(read_feed(ReadFeedArgs {
+            limit: 10,
+            offset: 0,
+        }));
+
+        assert_eq!(items.len(), 2);
+        let boost_item = items
+            .iter()
+            .find(|i| i.boosted_by.is_some())
+            .expect("boost item present");
+        assert!(boost_item.liked);
+        assert!(!boost_item.boosted);
+    }
+
+    #[test]
+    fn test_inbox_create_note_uses_note_id_for_flag_lookup() {
+        setup();
+        // Build an inbox Create(Note) whose note carries an explicit `id`,
+        // and like that id from the viewer's perspective.
+        let note_uri = "https://remote.example/users/bob/statuses/42";
+        crate::domain::liked::LikedRepository::like_status(note_uri).expect("like");
+
+        let object_data = make_create_note_with_id(note_uri, "Remote post", Visibility::Public);
+        DBMS_CONTEXT.with(|ctx| {
+            let tx_id =
+                ctx.begin_transaction(db_utils::transaction::transaction_caller(ic_utils::now()));
+            let mut db = WasmDbmsDatabase::from_transaction(ctx, Schema, tx_id);
+            db.insert::<InboxActivity>(InboxActivityInsertRequest {
+                id: 200u64.into(),
+                activity_type: DbActivityType::from(ApActivityType::Create),
+                actor_uri: "https://remote.example/users/bob".into(),
+                object_data: object_data.into(),
+                is_boost: false.into(),
+                original_status_uri: Nullable::Null,
+                created_at: 3_000u64.into(),
+            })
+            .expect("insert inbox row");
+            db.insert::<FeedEntry>(FeedEntryInsertRequest {
+                id: 200u64.into(),
+                source: FeedSource::Inbox,
+                created_at: 3_000u64.into(),
+            })
+            .expect("insert feed entry");
+            db.commit().expect("commit");
+        });
+
+        let items = unwrap_ok(read_feed(ReadFeedArgs {
+            limit: 10,
+            offset: 0,
+        }));
+
+        assert_eq!(items.len(), 1);
+        assert!(items[0].liked);
+        assert!(!items[0].boosted);
+    }
+
+    fn make_create_note_with_id(
+        note_id: &str,
+        content: &str,
+        visibility: Visibility,
+    ) -> serde_json::Value {
+        let (to, cc) = match visibility {
+            Visibility::Public => (
+                Some(OneOrMany::One(
+                    "https://www.w3.org/ns/activitystreams#Public".to_string(),
+                )),
+                None,
+            ),
+            _ => (None, None),
+        };
+
+        let note = BaseObject {
+            kind: ObjectType::Note,
+            id: Some(note_id.to_string()),
+            content: Some(content.to_string()),
+            to: to.clone(),
+            cc: cc.clone(),
+            ..Default::default()
+        };
+
+        let activity = Activity {
+            base: BaseObject {
+                context: Some(activitypub::context::Context::Uri(
+                    ACTIVITY_STREAMS_CONTEXT.to_string(),
+                )),
+                kind: ApActivityType::Create,
+                to,
+                cc,
+                ..Default::default()
+            },
+            actor: Some("https://remote.example/users/bob".to_string()),
+            object: Some(ActivityObject::Object(Box::new(note))),
+            target: None,
+            result: None,
+            origin: None,
+            instrument: None,
+        };
+
+        serde_json::to_value(&activity).expect("serialize")
     }
 }

--- a/crates/canisters/user/src/domain/feed/read_feed.rs
+++ b/crates/canisters/user/src/domain/feed/read_feed.rs
@@ -267,7 +267,9 @@ fn viewer_flags(status_uri: &str) -> (bool, bool) {
     let liked = LikedRepository::oneshot()
         .is_liked(status_uri)
         .unwrap_or(false);
-    let boosted = BoostRepository::is_boosted(status_uri).unwrap_or(false);
+    let boosted = BoostRepository::oneshot()
+        .is_boosted(status_uri)
+        .unwrap_or(false);
     (liked, boosted)
 }
 

--- a/crates/canisters/user/src/domain/feed/read_feed.rs
+++ b/crates/canisters/user/src/domain/feed/read_feed.rs
@@ -51,7 +51,7 @@ pub fn read_feed(ReadFeedArgs { limit, offset }: ReadFeedArgs) -> ReadFeedRespon
 /// Sorting, offset and limit are fully handled at the database level,
 /// keeping memory usage bounded regardless of feed size.
 fn read_feed_inner(limit: u64, offset: u64) -> CanisterResult<Vec<FeedItem>> {
-    let own_profile = crate::domain::profile::ProfileRepository::get_profile()?;
+    let own_profile = crate::domain::profile::ProfileRepository::oneshot().get_profile()?;
     let owner_actor_uri = crate::domain::urls::actor_uri(&own_profile.handle.0)?;
 
     DBMS_CONTEXT.with(|ctx| {

--- a/crates/canisters/user/src/domain/feed/read_feed.rs
+++ b/crates/canisters/user/src/domain/feed/read_feed.rs
@@ -264,7 +264,9 @@ fn hydrate_inbox(db: &impl Database, id: u64, owner_actor_uri: &str) -> Option<F
 /// own `liked` and `boosts` tables. Lookup failures degrade to `false` so
 /// hydration never blocks the feed render.
 fn viewer_flags(status_uri: &str) -> (bool, bool) {
-    let liked = LikedRepository::is_liked(status_uri).unwrap_or(false);
+    let liked = LikedRepository::oneshot()
+        .is_liked(status_uri)
+        .unwrap_or(false);
     let boosted = BoostRepository::is_boosted(status_uri).unwrap_or(false);
     (liked, boosted)
 }
@@ -977,7 +979,9 @@ mod tests {
         insert_status(1, "Mine", Visibility::Public, 1_000);
         let owner_uri = crate::domain::urls::actor_uri("rey_canisteryo").unwrap();
         let status_uri = format!("{owner_uri}/statuses/1");
-        crate::domain::liked::LikedRepository::like_status(&status_uri).expect("like");
+        crate::domain::liked::LikedRepository::oneshot()
+            .like_status(&status_uri)
+            .expect("like");
 
         let items = unwrap_ok(read_feed(ReadFeedArgs {
             limit: 10,
@@ -1023,7 +1027,9 @@ mod tests {
         // Viewer's local status acts as the boosted target.
         insert_status(99, "Bob's post", Visibility::Public, 1_000);
         let original_uri = "https://mastic.social/users/rey_canisteryo/statuses/99";
-        crate::domain::liked::LikedRepository::like_status(original_uri).expect("like");
+        crate::domain::liked::LikedRepository::oneshot()
+            .like_status(original_uri)
+            .expect("like");
 
         insert_inbox_announce(
             500,
@@ -1052,7 +1058,9 @@ mod tests {
         // Build an inbox Create(Note) whose note carries an explicit `id`,
         // and like that id from the viewer's perspective.
         let note_uri = "https://remote.example/users/bob/statuses/42";
-        crate::domain::liked::LikedRepository::like_status(note_uri).expect("like");
+        crate::domain::liked::LikedRepository::oneshot()
+            .like_status(note_uri)
+            .expect("like");
 
         let object_data = make_create_note_with_id(note_uri, "Remote post", Visibility::Public);
         DBMS_CONTEXT.with(|ctx| {

--- a/crates/canisters/user/src/domain/feed/repository.rs
+++ b/crates/canisters/user/src/domain/feed/repository.rs
@@ -1,0 +1,191 @@
+//! Repository for the `feed` table.
+//!
+//! The `feed` table is a denormalized timeline that indexes both outbox
+//! entries (own statuses and boost wrappers) and inbox entries (received
+//! `Create` / `Announce` activities) under a single sorted timeline.
+//!
+//! Writes go through this repository so the lifecycle is centralised. Reads
+//! are still served by [`crate::domain::feed::read_feed`] which performs the
+//! full hydration join across `statuses` / `inbox` / `boosts`.
+
+use ic_dbms_canister::prelude::{DBMS_CONTEXT, IcAccessControlList, IcMemoryProvider};
+use wasm_dbms::WasmDbmsDatabase;
+use wasm_dbms::prelude::DbmsContext;
+use wasm_dbms_api::prelude::{Database, DeleteBehavior, Filter, TransactionId, Value};
+
+use crate::error::CanisterResult;
+use crate::schema::{FeedEntry, FeedEntryInsertRequest, FeedSource, Schema};
+
+/// Repository over the denormalized `feed` table.
+//
+// `#[allow(dead_code)]` is intentional: subsequent tasks (status / boost /
+// inbox refactors) will route their writes through this repository. Until
+// then, the constructors and methods are exercised only by the in-module
+// `#[cfg(test)]` suite.
+#[allow(dead_code)]
+pub struct FeedRepository {
+    tx: Option<TransactionId>,
+}
+
+#[allow(dead_code)]
+impl FeedRepository {
+    /// Build a repository instance that runs each operation in its own
+    /// auto-committed oneshot transaction.
+    pub const fn oneshot() -> Self {
+        Self { tx: None }
+    }
+
+    /// Build a repository instance that splices its writes into an
+    /// externally-driven transaction. Lifecycle (commit/rollback) is owned by
+    /// the caller — typically via [`db_utils::transaction::Transaction::run`].
+    pub const fn with_transaction(tx: TransactionId) -> Self {
+        Self { tx: Some(tx) }
+    }
+
+    fn db<'a>(
+        &self,
+        ctx: &'a DbmsContext<IcMemoryProvider, IcAccessControlList>,
+    ) -> WasmDbmsDatabase<'a, IcMemoryProvider, IcAccessControlList> {
+        match self.tx {
+            Some(id) => WasmDbmsDatabase::from_transaction(ctx, Schema, id),
+            None => WasmDbmsDatabase::oneshot(ctx, Schema),
+        }
+    }
+
+    /// Insert a feed entry tagged as [`FeedSource::Outbox`] — used for own
+    /// statuses and boost wrappers.
+    pub fn insert_outbox(&self, snowflake_id: u64, created_at: u64) -> CanisterResult<()> {
+        self.insert(snowflake_id, FeedSource::Outbox, created_at)
+    }
+
+    /// Insert a feed entry tagged as [`FeedSource::Inbox`] — used for received
+    /// `Create` / `Announce` activities.
+    pub fn insert_inbox(&self, snowflake_id: u64, created_at: u64) -> CanisterResult<()> {
+        self.insert(snowflake_id, FeedSource::Inbox, created_at)
+    }
+
+    fn insert(&self, snowflake_id: u64, source: FeedSource, created_at: u64) -> CanisterResult<()> {
+        DBMS_CONTEXT.with(|ctx| {
+            self.db(ctx).insert::<FeedEntry>(FeedEntryInsertRequest {
+                id: snowflake_id.into(),
+                source,
+                created_at: created_at.into(),
+            })?;
+            Ok(())
+        })
+    }
+
+    /// Remove the [`FeedEntry`] row whose primary key matches `snowflake_id`.
+    ///
+    /// Uses [`DeleteBehavior::Restrict`] — callers must drop the corresponding
+    /// `statuses` / `inbox` / `boosts` rows in the right order so referential
+    /// integrity is preserved.
+    pub fn delete_by_id(&self, snowflake_id: u64) -> CanisterResult<()> {
+        DBMS_CONTEXT.with(|ctx| {
+            self.db(ctx).delete::<FeedEntry>(
+                DeleteBehavior::Restrict,
+                Some(Filter::eq("id", Value::from(snowflake_id))),
+            )?;
+            Ok(())
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use db_utils::transaction::Transaction;
+    use wasm_dbms_api::prelude::Query;
+
+    use super::*;
+    use crate::error::CanisterError;
+    use crate::test_utils::setup;
+
+    fn select_all_entries() -> Vec<FeedEntry> {
+        DBMS_CONTEXT.with(|ctx| {
+            let db = WasmDbmsDatabase::oneshot(ctx, Schema);
+            db.select::<FeedEntry>(Query::builder().all().build())
+                .expect("select feed entries")
+                .into_iter()
+                .map(|r| FeedEntry {
+                    id: r.id.expect("id"),
+                    source: r.source.expect("source"),
+                    created_at: r.created_at.expect("created_at"),
+                })
+                .collect()
+        })
+    }
+
+    #[test]
+    fn test_should_insert_outbox_entry() {
+        setup();
+
+        FeedRepository::oneshot()
+            .insert_outbox(1, 1_000)
+            .expect("should insert outbox entry");
+
+        let entries = select_all_entries();
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].id.0, 1);
+        assert_eq!(entries[0].source, FeedSource::Outbox);
+        assert_eq!(entries[0].created_at.0, 1_000);
+    }
+
+    #[test]
+    fn test_should_insert_inbox_entry() {
+        setup();
+
+        FeedRepository::oneshot()
+            .insert_inbox(42, 2_000)
+            .expect("should insert inbox entry");
+
+        let entries = select_all_entries();
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].id.0, 42);
+        assert_eq!(entries[0].source, FeedSource::Inbox);
+        assert_eq!(entries[0].created_at.0, 2_000);
+    }
+
+    #[test]
+    fn test_should_delete_by_id() {
+        setup();
+        let repo = FeedRepository::oneshot();
+        repo.insert_outbox(7, 1_000).expect("insert");
+        assert_eq!(select_all_entries().len(), 1);
+
+        repo.delete_by_id(7).expect("delete");
+
+        assert!(select_all_entries().is_empty());
+    }
+
+    #[test]
+    fn test_should_insert_via_transaction_run() {
+        setup();
+
+        Transaction::run::<_, _, _, CanisterError>(Schema, |tx| {
+            FeedRepository::with_transaction(tx).insert_outbox(99, 5_000)
+        })
+        .expect("transaction should commit");
+
+        let entries = select_all_entries();
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].id.0, 99);
+        assert_eq!(entries[0].source, FeedSource::Outbox);
+        assert_eq!(entries[0].created_at.0, 5_000);
+    }
+
+    #[test]
+    fn test_rolls_back_when_tx_errors() {
+        setup();
+
+        let result: Result<(), CanisterError> = Transaction::run(Schema, |tx| {
+            FeedRepository::with_transaction(tx).insert_outbox(123, 9_000)?;
+            Err(CanisterError::Internal("boom".to_string()))
+        });
+        assert!(result.is_err());
+
+        assert!(
+            select_all_entries().is_empty(),
+            "errored tx must not persist its insert"
+        );
+    }
+}

--- a/crates/canisters/user/src/domain/feed/repository.rs
+++ b/crates/canisters/user/src/domain/feed/repository.rs
@@ -8,9 +8,8 @@
 //! are still served by [`crate::domain::feed::read_feed`] which performs the
 //! full hydration join across `statuses` / `inbox` / `boosts`.
 
-use ic_dbms_canister::prelude::{DBMS_CONTEXT, IcAccessControlList, IcMemoryProvider};
-use wasm_dbms::WasmDbmsDatabase;
-use wasm_dbms::prelude::DbmsContext;
+use db_utils::repository::Repository;
+use ic_dbms_canister::prelude::DBMS_CONTEXT;
 use wasm_dbms_api::prelude::{Database, DeleteBehavior, Filter, TransactionId, Value};
 
 use crate::error::CanisterResult;
@@ -22,33 +21,6 @@ pub struct FeedRepository {
 }
 
 impl FeedRepository {
-    /// Build a repository instance that runs each operation in its own
-    /// auto-committed oneshot transaction.
-    //
-    // `oneshot` callers land with the boost / inbox refactors; for now it is
-    // exercised only by the in-module `#[cfg(test)]` suite.
-    #[allow(dead_code)]
-    pub const fn oneshot() -> Self {
-        Self { tx: None }
-    }
-
-    /// Build a repository instance that splices its writes into an
-    /// externally-driven transaction. Lifecycle (commit/rollback) is owned by
-    /// the caller — typically via [`db_utils::transaction::Transaction::run`].
-    pub const fn with_transaction(tx: TransactionId) -> Self {
-        Self { tx: Some(tx) }
-    }
-
-    fn db<'a>(
-        &self,
-        ctx: &'a DbmsContext<IcMemoryProvider, IcAccessControlList>,
-    ) -> WasmDbmsDatabase<'a, IcMemoryProvider, IcAccessControlList> {
-        match self.tx {
-            Some(id) => WasmDbmsDatabase::from_transaction(ctx, Schema, id),
-            None => WasmDbmsDatabase::oneshot(ctx, Schema),
-        }
-    }
-
     /// Insert a feed entry tagged as [`FeedSource::Outbox`] — used for own
     /// statuses and boost wrappers.
     pub fn insert_outbox(&self, snowflake_id: u64, created_at: u64) -> CanisterResult<()> {
@@ -81,10 +53,6 @@ impl FeedRepository {
     /// Uses [`DeleteBehavior::Restrict`] — callers must drop the corresponding
     /// `statuses` / `inbox` / `boosts` rows in the right order so referential
     /// integrity is preserved.
-    //
-    // Wired in by the boost refactor (undo_boost flow); covered by the
-    // in-module test suite until then.
-    #[allow(dead_code)]
     pub fn delete_by_id(&self, snowflake_id: u64) -> CanisterResult<()> {
         DBMS_CONTEXT.with(|ctx| {
             self.db(ctx).delete::<FeedEntry>(
@@ -96,9 +64,30 @@ impl FeedRepository {
     }
 }
 
+impl Repository for FeedRepository {
+    type Schema = Schema;
+
+    fn schema() -> Self::Schema {
+        Schema
+    }
+
+    fn oneshot() -> Self {
+        Self { tx: None }
+    }
+
+    fn with_transaction(tx: TransactionId) -> Self {
+        Self { tx: Some(tx) }
+    }
+
+    fn tx(&self) -> Option<TransactionId> {
+        self.tx
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use db_utils::transaction::Transaction;
+    use wasm_dbms::WasmDbmsDatabase;
     use wasm_dbms_api::prelude::Query;
 
     use super::*;

--- a/crates/canisters/user/src/domain/feed/repository.rs
+++ b/crates/canisters/user/src/domain/feed/repository.rs
@@ -17,20 +17,17 @@ use crate::error::CanisterResult;
 use crate::schema::{FeedEntry, FeedEntryInsertRequest, FeedSource, Schema};
 
 /// Repository over the denormalized `feed` table.
-//
-// `#[allow(dead_code)]` is intentional: subsequent tasks (status / boost /
-// inbox refactors) will route their writes through this repository. Until
-// then, the constructors and methods are exercised only by the in-module
-// `#[cfg(test)]` suite.
-#[allow(dead_code)]
 pub struct FeedRepository {
     tx: Option<TransactionId>,
 }
 
-#[allow(dead_code)]
 impl FeedRepository {
     /// Build a repository instance that runs each operation in its own
     /// auto-committed oneshot transaction.
+    //
+    // `oneshot` callers land with the boost / inbox refactors; for now it is
+    // exercised only by the in-module `#[cfg(test)]` suite.
+    #[allow(dead_code)]
     pub const fn oneshot() -> Self {
         Self { tx: None }
     }
@@ -60,6 +57,10 @@ impl FeedRepository {
 
     /// Insert a feed entry tagged as [`FeedSource::Inbox`] — used for received
     /// `Create` / `Announce` activities.
+    //
+    // Wired in by the inbox refactor; covered by the in-module test suite
+    // until then.
+    #[allow(dead_code)]
     pub fn insert_inbox(&self, snowflake_id: u64, created_at: u64) -> CanisterResult<()> {
         self.insert(snowflake_id, FeedSource::Inbox, created_at)
     }
@@ -80,6 +81,10 @@ impl FeedRepository {
     /// Uses [`DeleteBehavior::Restrict`] — callers must drop the corresponding
     /// `statuses` / `inbox` / `boosts` rows in the right order so referential
     /// integrity is preserved.
+    //
+    // Wired in by the boost refactor (undo_boost flow); covered by the
+    // in-module test suite until then.
+    #[allow(dead_code)]
     pub fn delete_by_id(&self, snowflake_id: u64) -> CanisterResult<()> {
         DBMS_CONTEXT.with(|ctx| {
             self.db(ctx).delete::<FeedEntry>(

--- a/crates/canisters/user/src/domain/follow_request/get_follow_requests.rs
+++ b/crates/canisters/user/src/domain/follow_request/get_follow_requests.rs
@@ -1,5 +1,6 @@
 //! Get follow requests domain logic.
 
+use db_utils::repository::Repository;
 use did::user::{GetFollowRequestsArgs, GetFollowRequestsError, GetFollowRequestsResponse};
 
 use crate::domain::follow_request::FollowRequestRepository;

--- a/crates/canisters/user/src/domain/follow_request/get_follow_requests.rs
+++ b/crates/canisters/user/src/domain/follow_request/get_follow_requests.rs
@@ -27,7 +27,8 @@ pub fn get_follow_requests(args: GetFollowRequestsArgs) -> GetFollowRequestsResp
 fn inner_get_follow_requests(
     GetFollowRequestsArgs { limit, offset }: GetFollowRequestsArgs,
 ) -> CanisterResult<Vec<String>> {
-    FollowRequestRepository::get_paginated(offset as usize, limit as usize)
+    FollowRequestRepository::oneshot()
+        .get_paginated(offset as usize, limit as usize)
         .map(|requests| requests.into_iter().map(|r| r.actor_uri.0).collect())
 }
 
@@ -93,9 +94,12 @@ mod tests {
     fn test_should_return_follow_requests() {
         setup();
 
-        FollowRequestRepository::insert("https://mastic.social/users/alice")
+        FollowRequestRepository::oneshot()
+            .insert("https://mastic.social/users/alice")
             .expect("should insert");
-        FollowRequestRepository::insert("https://mastic.social/users/bob").expect("should insert");
+        FollowRequestRepository::oneshot()
+            .insert("https://mastic.social/users/bob")
+            .expect("should insert");
 
         let response = get_follow_requests(GetFollowRequestsArgs {
             offset: 0,
@@ -114,10 +118,14 @@ mod tests {
     fn test_should_paginate_follow_requests_with_limit() {
         setup();
 
-        FollowRequestRepository::insert("https://mastic.social/users/alice")
+        FollowRequestRepository::oneshot()
+            .insert("https://mastic.social/users/alice")
             .expect("should insert");
-        FollowRequestRepository::insert("https://mastic.social/users/bob").expect("should insert");
-        FollowRequestRepository::insert("https://mastic.social/users/charlie")
+        FollowRequestRepository::oneshot()
+            .insert("https://mastic.social/users/bob")
+            .expect("should insert");
+        FollowRequestRepository::oneshot()
+            .insert("https://mastic.social/users/charlie")
             .expect("should insert");
 
         let response = get_follow_requests(GetFollowRequestsArgs {
@@ -135,10 +143,14 @@ mod tests {
     fn test_should_paginate_follow_requests_with_offset() {
         setup();
 
-        FollowRequestRepository::insert("https://mastic.social/users/alice")
+        FollowRequestRepository::oneshot()
+            .insert("https://mastic.social/users/alice")
             .expect("should insert");
-        FollowRequestRepository::insert("https://mastic.social/users/bob").expect("should insert");
-        FollowRequestRepository::insert("https://mastic.social/users/charlie")
+        FollowRequestRepository::oneshot()
+            .insert("https://mastic.social/users/bob")
+            .expect("should insert");
+        FollowRequestRepository::oneshot()
+            .insert("https://mastic.social/users/charlie")
             .expect("should insert");
 
         let response = get_follow_requests(GetFollowRequestsArgs {
@@ -156,7 +168,8 @@ mod tests {
     fn test_should_return_empty_list_when_offset_exceeds_total() {
         setup();
 
-        FollowRequestRepository::insert("https://mastic.social/users/alice")
+        FollowRequestRepository::oneshot()
+            .insert("https://mastic.social/users/alice")
             .expect("should insert");
 
         let response = get_follow_requests(GetFollowRequestsArgs {

--- a/crates/canisters/user/src/domain/follow_request/repository.rs
+++ b/crates/canisters/user/src/domain/follow_request/repository.rs
@@ -1,8 +1,7 @@
 //! Follow request repository for managing incoming follow requests.
 
-use ic_dbms_canister::prelude::{DBMS_CONTEXT, IcAccessControlList, IcMemoryProvider};
-use wasm_dbms::WasmDbmsDatabase;
-use wasm_dbms::prelude::DbmsContext;
+use db_utils::repository::Repository;
+use ic_dbms_canister::prelude::DBMS_CONTEXT;
 use wasm_dbms_api::prelude::*;
 
 use crate::error::{CanisterError, CanisterResult};
@@ -14,28 +13,6 @@ pub struct FollowRequestRepository {
 }
 
 impl FollowRequestRepository {
-    pub const fn oneshot() -> Self {
-        Self { tx: None }
-    }
-
-    // Reserved for future cross-repo atomic flows that need to splice follow
-    // request reads/writes into an externally-driven transaction. Not yet wired
-    // up.
-    #[allow(dead_code)]
-    pub const fn with_transaction(tx: TransactionId) -> Self {
-        Self { tx: Some(tx) }
-    }
-
-    fn db<'a>(
-        &self,
-        ctx: &'a DbmsContext<IcMemoryProvider, IcAccessControlList>,
-    ) -> WasmDbmsDatabase<'a, IcMemoryProvider, IcAccessControlList> {
-        match self.tx {
-            Some(id) => WasmDbmsDatabase::from_transaction(ctx, Schema, id),
-            None => WasmDbmsDatabase::oneshot(ctx, Schema),
-        }
-    }
-
     /// Insert a new follow request for the given actor URI.
     pub fn insert(&self, actor_uri: &str) -> CanisterResult<()> {
         DBMS_CONTEXT.with(|ctx| {
@@ -101,6 +78,26 @@ impl FollowRequestRepository {
             actor_uri: record.actor_uri.expect("must have field"),
             created_at: record.created_at.expect("must have field"),
         }
+    }
+}
+
+impl Repository for FollowRequestRepository {
+    type Schema = Schema;
+
+    fn schema() -> Self::Schema {
+        Schema
+    }
+
+    fn oneshot() -> Self {
+        Self { tx: None }
+    }
+
+    fn with_transaction(tx: TransactionId) -> Self {
+        Self { tx: Some(tx) }
+    }
+
+    fn tx(&self) -> Option<TransactionId> {
+        self.tx
     }
 }
 

--- a/crates/canisters/user/src/domain/follow_request/repository.rs
+++ b/crates/canisters/user/src/domain/follow_request/repository.rs
@@ -1,35 +1,58 @@
 //! Follow request repository for managing incoming follow requests.
 
-use ic_dbms_canister::prelude::DBMS_CONTEXT;
+use ic_dbms_canister::prelude::{DBMS_CONTEXT, IcAccessControlList, IcMemoryProvider};
 use wasm_dbms::WasmDbmsDatabase;
+use wasm_dbms::prelude::DbmsContext;
 use wasm_dbms_api::prelude::*;
 
 use crate::error::{CanisterError, CanisterResult};
 use crate::schema::{FollowRequest, FollowRequestInsertRequest, FollowRequestRecord, Schema};
 
 /// Interface to access [`FollowRequest`] data.
-pub struct FollowRequestRepository;
+pub struct FollowRequestRepository {
+    tx: Option<TransactionId>,
+}
 
 impl FollowRequestRepository {
-    /// Insert a new follow request for the given actor URI.
-    pub fn insert(actor_uri: &str) -> CanisterResult<()> {
-        DBMS_CONTEXT.with(|ctx| {
-            let db = WasmDbmsDatabase::oneshot(ctx, Schema);
+    pub const fn oneshot() -> Self {
+        Self { tx: None }
+    }
 
-            db.insert::<FollowRequest>(FollowRequestInsertRequest {
-                actor_uri: actor_uri.into(),
-                created_at: ic_utils::now().into(),
-            })
-            .map_err(CanisterError::from)
+    // Reserved for future cross-repo atomic flows that need to splice follow
+    // request reads/writes into an externally-driven transaction. Not yet wired
+    // up.
+    #[allow(dead_code)]
+    pub const fn with_transaction(tx: TransactionId) -> Self {
+        Self { tx: Some(tx) }
+    }
+
+    fn db<'a>(
+        &self,
+        ctx: &'a DbmsContext<IcMemoryProvider, IcAccessControlList>,
+    ) -> WasmDbmsDatabase<'a, IcMemoryProvider, IcAccessControlList> {
+        match self.tx {
+            Some(id) => WasmDbmsDatabase::from_transaction(ctx, Schema, id),
+            None => WasmDbmsDatabase::oneshot(ctx, Schema),
+        }
+    }
+
+    /// Insert a new follow request for the given actor URI.
+    pub fn insert(&self, actor_uri: &str) -> CanisterResult<()> {
+        DBMS_CONTEXT.with(|ctx| {
+            self.db(ctx)
+                .insert::<FollowRequest>(FollowRequestInsertRequest {
+                    actor_uri: actor_uri.into(),
+                    created_at: ic_utils::now().into(),
+                })
+                .map_err(CanisterError::from)
         })
     }
 
     /// Find a follow request by actor URI.
-    pub fn find_by_actor_uri(actor_uri: &str) -> CanisterResult<Option<FollowRequest>> {
+    pub fn find_by_actor_uri(&self, actor_uri: &str) -> CanisterResult<Option<FollowRequest>> {
         DBMS_CONTEXT.with(|ctx| {
-            let db = WasmDbmsDatabase::oneshot(ctx, Schema);
-
-            let records = db
+            let records = self
+                .db(ctx)
                 .select::<FollowRequest>(
                     Query::builder()
                         .all()
@@ -46,11 +69,10 @@ impl FollowRequestRepository {
     }
 
     /// Get a paginated list of [`FollowRequest`]s.
-    pub fn get_paginated(offset: usize, limit: usize) -> CanisterResult<Vec<FollowRequest>> {
+    pub fn get_paginated(&self, offset: usize, limit: usize) -> CanisterResult<Vec<FollowRequest>> {
         DBMS_CONTEXT.with(|ctx| {
-            let db = WasmDbmsDatabase::oneshot(ctx, Schema);
-
-            let records = db
+            let records = self
+                .db(ctx)
                 .select::<FollowRequest>(Query::builder().all().offset(offset).limit(limit).build())
                 .map_err(CanisterError::from)?;
 
@@ -62,16 +84,15 @@ impl FollowRequestRepository {
     }
 
     /// Delete a follow request by actor URI.
-    pub fn delete_by_actor_uri(actor_uri: &str) -> CanisterResult<()> {
+    pub fn delete_by_actor_uri(&self, actor_uri: &str) -> CanisterResult<()> {
         DBMS_CONTEXT.with(|ctx| {
-            let db = WasmDbmsDatabase::oneshot(ctx, Schema);
-
-            db.delete::<FollowRequest>(
-                DeleteBehavior::Restrict,
-                Some(Filter::eq("actor_uri", Value::from(actor_uri.to_string()))),
-            )
-            .map(|_| ())
-            .map_err(CanisterError::from)
+            self.db(ctx)
+                .delete::<FollowRequest>(
+                    DeleteBehavior::Restrict,
+                    Some(Filter::eq("actor_uri", Value::from(actor_uri.to_string()))),
+                )
+                .map(|_| ())
+                .map_err(CanisterError::from)
         })
     }
 
@@ -93,10 +114,12 @@ mod tests {
     fn test_should_insert_and_find_follow_request() {
         setup();
 
-        FollowRequestRepository::insert("https://mastic.social/users/alice")
+        FollowRequestRepository::oneshot()
+            .insert("https://mastic.social/users/alice")
             .expect("should insert");
 
-        let found = FollowRequestRepository::find_by_actor_uri("https://mastic.social/users/alice")
+        let found = FollowRequestRepository::oneshot()
+            .find_by_actor_uri("https://mastic.social/users/alice")
             .expect("should query")
             .expect("should find follow request");
 
@@ -107,9 +130,9 @@ mod tests {
     fn test_should_return_none_for_missing_follow_request() {
         setup();
 
-        let found =
-            FollowRequestRepository::find_by_actor_uri("https://mastic.social/users/nobody")
-                .expect("should query");
+        let found = FollowRequestRepository::oneshot()
+            .find_by_actor_uri("https://mastic.social/users/nobody")
+            .expect("should query");
 
         assert!(found.is_none());
     }
@@ -118,13 +141,16 @@ mod tests {
     fn test_should_delete_follow_request() {
         setup();
 
-        FollowRequestRepository::insert("https://mastic.social/users/alice")
+        FollowRequestRepository::oneshot()
+            .insert("https://mastic.social/users/alice")
             .expect("should insert");
 
-        FollowRequestRepository::delete_by_actor_uri("https://mastic.social/users/alice")
+        FollowRequestRepository::oneshot()
+            .delete_by_actor_uri("https://mastic.social/users/alice")
             .expect("should delete");
 
-        let found = FollowRequestRepository::find_by_actor_uri("https://mastic.social/users/alice")
+        let found = FollowRequestRepository::oneshot()
+            .find_by_actor_uri("https://mastic.social/users/alice")
             .expect("should query");
 
         assert!(found.is_none());

--- a/crates/canisters/user/src/domain/follower/accept_follow.rs
+++ b/crates/canisters/user/src/domain/follower/accept_follow.rs
@@ -10,6 +10,7 @@
 use activitypub::activity::{Activity, ActivityObject, ActivityType};
 use activitypub::context::ACTIVITY_STREAMS_CONTEXT;
 use activitypub::object::{BaseObject, OneOrMany};
+use db_utils::repository::Repository;
 use did::federation::{SendActivityArgs, SendActivityArgsObject};
 use did::user::{AcceptFollowArgs, AcceptFollowError, AcceptFollowResponse};
 use ic_dbms_canister::prelude::DBMS_CONTEXT;

--- a/crates/canisters/user/src/domain/follower/accept_follow.rs
+++ b/crates/canisters/user/src/domain/follower/accept_follow.rs
@@ -52,7 +52,10 @@ impl From<CanisterError> for AcceptFollowDomainError {
 
 async fn accept_follow_inner(actor_uri: &str) -> Result<(), AcceptFollowDomainError> {
     // check that the follow request exists
-    if FollowRequestRepository::find_by_actor_uri(actor_uri)?.is_none() {
+    if FollowRequestRepository::oneshot()
+        .find_by_actor_uri(actor_uri)?
+        .is_none()
+    {
         ic_utils::log!("accept_follow: no pending request from {actor_uri}");
         return Err(AcceptFollowDomainError::RequestNotFound);
     }
@@ -147,7 +150,8 @@ mod tests {
         setup();
 
         // insert a pending follow request
-        FollowRequestRepository::insert("https://mastic.social/users/alice")
+        FollowRequestRepository::oneshot()
+            .insert("https://mastic.social/users/alice")
             .expect("should insert follow request");
 
         let response = accept_follow(AcceptFollowArgs {
@@ -158,9 +162,9 @@ mod tests {
         assert_eq!(response, AcceptFollowResponse::Ok);
 
         // follow request should be removed
-        let request =
-            FollowRequestRepository::find_by_actor_uri("https://mastic.social/users/alice")
-                .expect("should query");
+        let request = FollowRequestRepository::oneshot()
+            .find_by_actor_uri("https://mastic.social/users/alice")
+            .expect("should query");
         assert!(request.is_none(), "follow request should be deleted");
 
         // follower should be added

--- a/crates/canisters/user/src/domain/follower/accept_follow.rs
+++ b/crates/canisters/user/src/domain/follower/accept_follow.rs
@@ -164,7 +164,9 @@ mod tests {
         assert!(request.is_none(), "follow request should be deleted");
 
         // follower should be added
-        let followers = FollowerRepository::get_followers().expect("should query");
+        let followers = FollowerRepository::oneshot()
+            .get_followers()
+            .expect("should query");
         assert_eq!(followers.len(), 1);
         assert_eq!(
             followers[0].actor_uri.0,

--- a/crates/canisters/user/src/domain/follower/accept_follow.rs
+++ b/crates/canisters/user/src/domain/follower/accept_follow.rs
@@ -58,7 +58,7 @@ async fn accept_follow_inner(actor_uri: &str) -> Result<(), AcceptFollowDomainEr
     }
 
     // build own actor URI
-    let own_profile = ProfileRepository::get_profile()?;
+    let own_profile = ProfileRepository::oneshot().get_profile()?;
     let own_actor_uri = crate::domain::urls::actor_uri(&own_profile.handle.0)?;
 
     // build and send Accept(Follow) activity

--- a/crates/canisters/user/src/domain/follower/get_followers.rs
+++ b/crates/canisters/user/src/domain/follower/get_followers.rs
@@ -1,5 +1,6 @@
 //! Get followers domain logic.
 
+use db_utils::repository::Repository;
 use did::user::{GetFollowersArgs, GetFollowersError, GetFollowersResponse};
 
 use crate::domain::follower::FollowerRepository;

--- a/crates/canisters/user/src/domain/follower/get_followers.rs
+++ b/crates/canisters/user/src/domain/follower/get_followers.rs
@@ -22,7 +22,8 @@ pub fn get_followers(args: GetFollowersArgs) -> GetFollowersResponse {
 fn inner_get_followers(
     GetFollowersArgs { offset, limit }: GetFollowersArgs,
 ) -> CanisterResult<Vec<String>> {
-    FollowerRepository::get_paginated(offset as usize, limit as usize)
+    FollowerRepository::oneshot()
+        .get_paginated(offset as usize, limit as usize)
         .map(|followers| followers.into_iter().map(|f| f.actor_uri.0).collect())
 }
 
@@ -82,8 +83,12 @@ mod tests {
     fn test_should_return_followers() {
         setup();
 
-        FollowerRepository::insert("https://mastic.social/users/alice").expect("should insert");
-        FollowerRepository::insert("https://mastic.social/users/bob").expect("should insert");
+        FollowerRepository::oneshot()
+            .insert("https://mastic.social/users/alice")
+            .expect("should insert");
+        FollowerRepository::oneshot()
+            .insert("https://mastic.social/users/bob")
+            .expect("should insert");
 
         let response = get_followers(GetFollowersArgs {
             offset: 0,
@@ -102,9 +107,15 @@ mod tests {
     fn test_should_paginate_followers_with_limit() {
         setup();
 
-        FollowerRepository::insert("https://mastic.social/users/alice").expect("should insert");
-        FollowerRepository::insert("https://mastic.social/users/bob").expect("should insert");
-        FollowerRepository::insert("https://mastic.social/users/charlie").expect("should insert");
+        FollowerRepository::oneshot()
+            .insert("https://mastic.social/users/alice")
+            .expect("should insert");
+        FollowerRepository::oneshot()
+            .insert("https://mastic.social/users/bob")
+            .expect("should insert");
+        FollowerRepository::oneshot()
+            .insert("https://mastic.social/users/charlie")
+            .expect("should insert");
 
         let response = get_followers(GetFollowersArgs {
             offset: 0,
@@ -121,9 +132,15 @@ mod tests {
     fn test_should_paginate_followers_with_offset() {
         setup();
 
-        FollowerRepository::insert("https://mastic.social/users/alice").expect("should insert");
-        FollowerRepository::insert("https://mastic.social/users/bob").expect("should insert");
-        FollowerRepository::insert("https://mastic.social/users/charlie").expect("should insert");
+        FollowerRepository::oneshot()
+            .insert("https://mastic.social/users/alice")
+            .expect("should insert");
+        FollowerRepository::oneshot()
+            .insert("https://mastic.social/users/bob")
+            .expect("should insert");
+        FollowerRepository::oneshot()
+            .insert("https://mastic.social/users/charlie")
+            .expect("should insert");
 
         let response = get_followers(GetFollowersArgs {
             offset: 2,
@@ -140,7 +157,9 @@ mod tests {
     fn test_should_return_empty_list_when_offset_exceeds_total() {
         setup();
 
-        FollowerRepository::insert("https://mastic.social/users/alice").expect("should insert");
+        FollowerRepository::oneshot()
+            .insert("https://mastic.social/users/alice")
+            .expect("should insert");
 
         let response = get_followers(GetFollowersArgs {
             offset: 10,

--- a/crates/canisters/user/src/domain/follower/reject_follow.rs
+++ b/crates/canisters/user/src/domain/follower/reject_follow.rs
@@ -9,6 +9,7 @@
 use activitypub::activity::{Activity, ActivityObject, ActivityType};
 use activitypub::context::ACTIVITY_STREAMS_CONTEXT;
 use activitypub::object::{BaseObject, OneOrMany};
+use db_utils::repository::Repository;
 use did::federation::{SendActivityArgs, SendActivityArgsObject};
 use did::user::{RejectFollowArgs, RejectFollowError, RejectFollowResponse};
 

--- a/crates/canisters/user/src/domain/follower/reject_follow.rs
+++ b/crates/canisters/user/src/domain/follower/reject_follow.rs
@@ -47,7 +47,10 @@ impl From<CanisterError> for RejectFollowDomainError {
 
 async fn reject_follow_inner(actor_uri: &str) -> Result<(), RejectFollowDomainError> {
     // check that the follow request exists
-    if FollowRequestRepository::find_by_actor_uri(actor_uri)?.is_none() {
+    if FollowRequestRepository::oneshot()
+        .find_by_actor_uri(actor_uri)?
+        .is_none()
+    {
         ic_utils::log!("reject_follow: no pending request from {actor_uri}");
         return Err(RejectFollowDomainError::RequestNotFound);
     }
@@ -68,7 +71,7 @@ async fn reject_follow_inner(actor_uri: &str) -> Result<(), RejectFollowDomainEr
     crate::adapters::federation::send_activity(args).await?;
 
     // on success, delete the follow request
-    FollowRequestRepository::delete_by_actor_uri(actor_uri)?;
+    FollowRequestRepository::oneshot().delete_by_actor_uri(actor_uri)?;
 
     Ok(())
 }
@@ -115,7 +118,8 @@ mod tests {
         setup();
 
         // insert a pending follow request
-        FollowRequestRepository::insert("https://mastic.social/users/alice")
+        FollowRequestRepository::oneshot()
+            .insert("https://mastic.social/users/alice")
             .expect("should insert follow request");
 
         let response = reject_follow(RejectFollowArgs {
@@ -126,9 +130,9 @@ mod tests {
         assert_eq!(response, RejectFollowResponse::Ok);
 
         // follow request should be removed
-        let request =
-            FollowRequestRepository::find_by_actor_uri("https://mastic.social/users/alice")
-                .expect("should query");
+        let request = FollowRequestRepository::oneshot()
+            .find_by_actor_uri("https://mastic.social/users/alice")
+            .expect("should query");
         assert!(request.is_none(), "follow request should be deleted");
     }
 

--- a/crates/canisters/user/src/domain/follower/reject_follow.rs
+++ b/crates/canisters/user/src/domain/follower/reject_follow.rs
@@ -53,7 +53,7 @@ async fn reject_follow_inner(actor_uri: &str) -> Result<(), RejectFollowDomainEr
     }
 
     // build own actor URI
-    let own_profile = ProfileRepository::get_profile()?;
+    let own_profile = ProfileRepository::oneshot().get_profile()?;
     let own_actor_uri = crate::domain::urls::actor_uri(&own_profile.handle.0)?;
 
     // build and send Reject(Follow) activity

--- a/crates/canisters/user/src/domain/follower/repository.rs
+++ b/crates/canisters/user/src/domain/follower/repository.rs
@@ -1,8 +1,7 @@
 //! Follower repository.
 
-use ic_dbms_canister::prelude::{DBMS_CONTEXT, IcAccessControlList, IcMemoryProvider};
-use wasm_dbms::WasmDbmsDatabase;
-use wasm_dbms::prelude::DbmsContext;
+use db_utils::repository::Repository;
+use ic_dbms_canister::prelude::DBMS_CONTEXT;
 use wasm_dbms_api::prelude::*;
 
 use crate::error::{CanisterError, CanisterResult};
@@ -14,27 +13,6 @@ pub struct FollowerRepository {
 }
 
 impl FollowerRepository {
-    pub const fn oneshot() -> Self {
-        Self { tx: None }
-    }
-
-    // Reserved for future cross-repo atomic flows that need to splice follower
-    // reads/writes into an externally-driven transaction. Not yet wired up.
-    #[allow(dead_code)]
-    pub const fn with_transaction(tx: TransactionId) -> Self {
-        Self { tx: Some(tx) }
-    }
-
-    fn db<'a>(
-        &self,
-        ctx: &'a DbmsContext<IcMemoryProvider, IcAccessControlList>,
-    ) -> WasmDbmsDatabase<'a, IcMemoryProvider, IcAccessControlList> {
-        match self.tx {
-            Some(id) => WasmDbmsDatabase::from_transaction(ctx, Schema, id),
-            None => WasmDbmsDatabase::oneshot(ctx, Schema),
-        }
-    }
-
     /// Insert a new follower with the given actor URI.
     #[cfg_attr(
         not(test),
@@ -108,6 +86,26 @@ impl FollowerRepository {
             actor_uri: record.actor_uri.expect("must have field"),
             created_at: record.created_at.expect("must have field"),
         }
+    }
+}
+
+impl Repository for FollowerRepository {
+    type Schema = Schema;
+
+    fn schema() -> Self::Schema {
+        Schema
+    }
+
+    fn oneshot() -> Self {
+        Self { tx: None }
+    }
+
+    fn with_transaction(tx: TransactionId) -> Self {
+        Self { tx: Some(tx) }
+    }
+
+    fn tx(&self) -> Option<TransactionId> {
+        self.tx
     }
 }
 

--- a/crates/canisters/user/src/domain/follower/repository.rs
+++ b/crates/canisters/user/src/domain/follower/repository.rs
@@ -1,58 +1,79 @@
 //! Follower repository.
 
-use ic_dbms_canister::prelude::DBMS_CONTEXT;
+use ic_dbms_canister::prelude::{DBMS_CONTEXT, IcAccessControlList, IcMemoryProvider};
 use wasm_dbms::WasmDbmsDatabase;
+use wasm_dbms::prelude::DbmsContext;
 use wasm_dbms_api::prelude::*;
 
 use crate::error::{CanisterError, CanisterResult};
 use crate::schema::{Follower, FollowerInsertRequest, FollowerRecord, Schema};
 
 /// Interface to access [`Follower`]s data.
-pub struct FollowerRepository;
+pub struct FollowerRepository {
+    tx: Option<TransactionId>,
+}
 
 impl FollowerRepository {
+    pub const fn oneshot() -> Self {
+        Self { tx: None }
+    }
+
+    // Reserved for future cross-repo atomic flows that need to splice follower
+    // reads/writes into an externally-driven transaction. Not yet wired up.
+    #[allow(dead_code)]
+    pub const fn with_transaction(tx: TransactionId) -> Self {
+        Self { tx: Some(tx) }
+    }
+
+    fn db<'a>(
+        &self,
+        ctx: &'a DbmsContext<IcMemoryProvider, IcAccessControlList>,
+    ) -> WasmDbmsDatabase<'a, IcMemoryProvider, IcAccessControlList> {
+        match self.tx {
+            Some(id) => WasmDbmsDatabase::from_transaction(ctx, Schema, id),
+            None => WasmDbmsDatabase::oneshot(ctx, Schema),
+        }
+    }
+
     /// Insert a new follower with the given actor URI.
     #[cfg_attr(
         not(test),
         expect(dead_code, reason = "will be used by receive_activity handler")
     )]
-    pub fn insert(actor_uri: &str) -> CanisterResult<()> {
+    pub fn insert(&self, actor_uri: &str) -> CanisterResult<()> {
         DBMS_CONTEXT.with(|ctx| {
-            let db = WasmDbmsDatabase::oneshot(ctx, Schema);
-
-            db.insert::<Follower>(FollowerInsertRequest {
-                actor_uri: actor_uri.into(),
-                created_at: ic_utils::now().into(),
-            })
-            .map_err(CanisterError::from)
+            self.db(ctx)
+                .insert::<Follower>(FollowerInsertRequest {
+                    actor_uri: actor_uri.into(),
+                    created_at: ic_utils::now().into(),
+                })
+                .map_err(CanisterError::from)
         })
     }
 
     /// Get the list of [`Follower`]s of the user.
-    pub fn get_followers() -> CanisterResult<Vec<Follower>> {
+    pub fn get_followers(&self) -> CanisterResult<Vec<Follower>> {
         DBMS_CONTEXT.with(|ctx| {
-            let db = WasmDbmsDatabase::oneshot(ctx, Schema);
-
-            db.select::<Follower>(Query::builder().all().build())
+            self.db(ctx)
+                .select::<Follower>(Query::builder().all().build())
                 .map(|records| records.into_iter().map(Self::record_to_follower).collect())
                 .map_err(CanisterError::from)
         })
     }
 
     /// Checks if the given actor URI is a [`Follower`] of the user.
-    pub fn is_follower(actor_uri: &str) -> CanisterResult<bool> {
+    pub fn is_follower(&self, actor_uri: &str) -> CanisterResult<bool> {
         DBMS_CONTEXT.with(|ctx| {
-            let db = WasmDbmsDatabase::oneshot(ctx, Schema);
-
-            db.select::<Follower>(
-                Query::builder()
-                    .all()
-                    .and_where(Filter::eq("actor_uri", actor_uri.into()))
-                    .limit(1)
-                    .build(),
-            )
-            .map(|records| !records.is_empty())
-            .map_err(CanisterError::from)
+            self.db(ctx)
+                .select::<Follower>(
+                    Query::builder()
+                        .all()
+                        .and_where(Filter::eq("actor_uri", actor_uri.into()))
+                        .limit(1)
+                        .build(),
+                )
+                .map(|records| !records.is_empty())
+                .map_err(CanisterError::from)
         })
     }
 
@@ -60,25 +81,23 @@ impl FollowerRepository {
     ///
     /// Returns `true` if an entry was deleted, `false` if no entry was found
     /// with the given actor URI.
-    pub fn delete_by_actor_uri(actor_uri: &str) -> CanisterResult<bool> {
+    pub fn delete_by_actor_uri(&self, actor_uri: &str) -> CanisterResult<bool> {
         DBMS_CONTEXT.with(|ctx| {
-            let db = WasmDbmsDatabase::oneshot(ctx, Schema);
-
-            db.delete::<Follower>(
-                DeleteBehavior::Restrict,
-                Some(Filter::eq("actor_uri", Value::from(actor_uri.to_string()))),
-            )
-            .map(|entries| entries > 0)
-            .map_err(CanisterError::from)
+            self.db(ctx)
+                .delete::<Follower>(
+                    DeleteBehavior::Restrict,
+                    Some(Filter::eq("actor_uri", Value::from(actor_uri.to_string()))),
+                )
+                .map(|entries| entries > 0)
+                .map_err(CanisterError::from)
         })
     }
 
     /// Get the list of [`Follower`]s of the user.
-    pub fn get_paginated(offset: usize, limit: usize) -> CanisterResult<Vec<Follower>> {
+    pub fn get_paginated(&self, offset: usize, limit: usize) -> CanisterResult<Vec<Follower>> {
         DBMS_CONTEXT.with(|ctx| {
-            let db = WasmDbmsDatabase::oneshot(ctx, Schema);
-
-            db.select::<Follower>(Query::builder().all().offset(offset).limit(limit).build())
+            self.db(ctx)
+                .select::<Follower>(Query::builder().all().offset(offset).limit(limit).build())
                 .map(|records| records.into_iter().map(Self::record_to_follower).collect())
                 .map_err(CanisterError::from)
         })
@@ -102,9 +121,13 @@ mod tests {
     fn test_should_insert_follower() {
         setup();
 
-        FollowerRepository::insert("https://mastic.social/users/alice").expect("should insert");
+        FollowerRepository::oneshot()
+            .insert("https://mastic.social/users/alice")
+            .expect("should insert");
 
-        let followers = FollowerRepository::get_followers().expect("should query");
+        let followers = FollowerRepository::oneshot()
+            .get_followers()
+            .expect("should query");
         assert_eq!(followers.len(), 1);
         assert_eq!(
             followers[0].actor_uri.0,

--- a/crates/canisters/user/src/domain/following/follow_user.rs
+++ b/crates/canisters/user/src/domain/following/follow_user.rs
@@ -10,6 +10,7 @@
 use activitypub::activity::{Activity, ActivityType};
 use activitypub::context::ACTIVITY_STREAMS_CONTEXT;
 use activitypub::object::{BaseObject, OneOrMany};
+use db_utils::repository::Repository;
 use did::federation::{SendActivityArgs, SendActivityArgsObject};
 use did::user::{FollowUserArgs, FollowUserError, FollowUserResponse};
 

--- a/crates/canisters/user/src/domain/following/follow_user.rs
+++ b/crates/canisters/user/src/domain/following/follow_user.rs
@@ -52,7 +52,7 @@ impl From<CanisterError> for FollowUserDomainError {
 
 async fn follow_user_inner(handle: &str) -> Result<(), FollowUserDomainError> {
     // check if trying to follow self
-    let own_profile = ProfileRepository::get_profile()?;
+    let own_profile = ProfileRepository::oneshot().get_profile()?;
     if handle == own_profile.handle.as_str() {
         ic_utils::log!("follow_user: cannot follow own handle");
         return Err(FollowUserDomainError::CannotFollowSelf);

--- a/crates/canisters/user/src/domain/following/follow_user.rs
+++ b/crates/canisters/user/src/domain/following/follow_user.rs
@@ -63,13 +63,16 @@ async fn follow_user_inner(handle: &str) -> Result<(), FollowUserDomainError> {
     let target_actor_uri = crate::domain::urls::actor_uri(handle)?;
 
     // check if already following
-    if FollowingRepository::find_by_actor_uri(&target_actor_uri)?.is_some() {
+    if FollowingRepository::oneshot()
+        .find_by_actor_uri(&target_actor_uri)?
+        .is_some()
+    {
         ic_utils::log!("follow_user: already following {target_actor_uri}");
         return Err(FollowUserDomainError::AlreadyFollowing);
     }
 
     // insert pending follow and send activity
-    FollowingRepository::insert_pending(&target_actor_uri)?;
+    FollowingRepository::oneshot().insert_pending(&target_actor_uri)?;
 
     let activity = make_follow_activity(&own_actor_uri, &target_actor_uri)?;
     let args = SendActivityArgs::One(SendActivityArgsObject {
@@ -126,7 +129,8 @@ mod tests {
         assert_eq!(response, FollowUserResponse::Ok);
 
         // verify the entry was stored as pending with proper actor URI
-        let entry = FollowingRepository::find_by_actor_uri("https://mastic.social/users/alice")
+        let entry = FollowingRepository::oneshot()
+            .find_by_actor_uri("https://mastic.social/users/alice")
             .expect("should query following")
             .expect("should find following entry");
         assert_eq!(entry.status, FollowStatus::Pending);

--- a/crates/canisters/user/src/domain/following/get_following.rs
+++ b/crates/canisters/user/src/domain/following/get_following.rs
@@ -1,5 +1,6 @@
 //! Get following domain logic.
 
+use db_utils::repository::Repository;
 use did::user::{GetFollowingArgs, GetFollowingError, GetFollowingResponse};
 
 use crate::domain::following::FollowingRepository;

--- a/crates/canisters/user/src/domain/following/get_following.rs
+++ b/crates/canisters/user/src/domain/following/get_following.rs
@@ -22,23 +22,32 @@ pub fn get_following(args: GetFollowingArgs) -> GetFollowingResponse {
 fn inner_get_following(
     GetFollowingArgs { offset, limit }: GetFollowingArgs,
 ) -> CanisterResult<Vec<String>> {
-    FollowingRepository::get_accepted_following(offset as usize, limit as usize)
+    FollowingRepository::oneshot()
+        .get_accepted_following(offset as usize, limit as usize)
         .map(|following| following.into_iter().map(|f| f.actor_uri.0).collect())
 }
 
 #[cfg(test)]
 mod tests {
 
+    use db_utils::transaction::Transaction;
+
     use super::*;
     use crate::domain::following::FollowingRepository;
-    use crate::schema::FollowStatus;
+    use crate::error::CanisterError;
+    use crate::schema::{FollowStatus, Schema};
     use crate::test_utils::setup;
 
     /// Helper: insert a pending entry and accept it.
     fn insert_accepted(actor_uri: &str) {
-        FollowingRepository::insert_pending(actor_uri).expect("should insert");
-        FollowingRepository::update_status(actor_uri, FollowStatus::Accepted)
-            .expect("should accept");
+        FollowingRepository::oneshot()
+            .insert_pending(actor_uri)
+            .expect("should insert");
+        Transaction::run::<_, _, _, CanisterError>(Schema, |tx| {
+            FollowingRepository::with_transaction(tx)
+                .update_status(actor_uri, FollowStatus::Accepted)
+        })
+        .expect("should accept");
     }
 
     #[test]
@@ -113,7 +122,8 @@ mod tests {
         // insert one accepted, one pending
         insert_accepted("https://mastic.social/users/alice");
 
-        FollowingRepository::insert_pending("https://mastic.social/users/bob")
+        FollowingRepository::oneshot()
+            .insert_pending("https://mastic.social/users/bob")
             .expect("should insert");
         // bob stays pending
 

--- a/crates/canisters/user/src/domain/following/repository.rs
+++ b/crates/canisters/user/src/domain/following/repository.rs
@@ -1,36 +1,55 @@
 //! Following repository for managing follow relationships.
 
-use ic_dbms_canister::prelude::DBMS_CONTEXT;
+use ic_dbms_canister::prelude::{DBMS_CONTEXT, IcAccessControlList, IcMemoryProvider};
 use wasm_dbms::WasmDbmsDatabase;
+use wasm_dbms::prelude::DbmsContext;
 use wasm_dbms_api::prelude::*;
 
 use crate::error::{CanisterError, CanisterResult};
 use crate::schema::{FollowStatus, Following, FollowingInsertRequest, FollowingRecord, Schema};
 
 /// Interface to access [`Following`] data.
-pub struct FollowingRepository;
+pub struct FollowingRepository {
+    tx: Option<TransactionId>,
+}
 
 impl FollowingRepository {
-    /// Insert a new pending follow entry for the given actor URI.
-    pub fn insert_pending(actor_uri: &str) -> CanisterResult<()> {
-        DBMS_CONTEXT.with(|ctx| {
-            let db = WasmDbmsDatabase::oneshot(ctx, Schema);
+    pub const fn oneshot() -> Self {
+        Self { tx: None }
+    }
 
-            db.insert::<Following>(FollowingInsertRequest {
-                actor_uri: actor_uri.into(),
-                status: FollowStatus::Pending,
-                created_at: ic_utils::now().into(),
-            })
-            .map_err(CanisterError::from)
+    pub const fn with_transaction(tx: TransactionId) -> Self {
+        Self { tx: Some(tx) }
+    }
+
+    fn db<'a>(
+        &self,
+        ctx: &'a DbmsContext<IcMemoryProvider, IcAccessControlList>,
+    ) -> WasmDbmsDatabase<'a, IcMemoryProvider, IcAccessControlList> {
+        match self.tx {
+            Some(id) => WasmDbmsDatabase::from_transaction(ctx, Schema, id),
+            None => WasmDbmsDatabase::oneshot(ctx, Schema),
+        }
+    }
+
+    /// Insert a new pending follow entry for the given actor URI.
+    pub fn insert_pending(&self, actor_uri: &str) -> CanisterResult<()> {
+        DBMS_CONTEXT.with(|ctx| {
+            self.db(ctx)
+                .insert::<Following>(FollowingInsertRequest {
+                    actor_uri: actor_uri.into(),
+                    status: FollowStatus::Pending,
+                    created_at: ic_utils::now().into(),
+                })
+                .map_err(CanisterError::from)
         })
     }
 
     /// Find a following entry by actor URI.
-    pub fn find_by_actor_uri(actor_uri: &str) -> CanisterResult<Option<Following>> {
+    pub fn find_by_actor_uri(&self, actor_uri: &str) -> CanisterResult<Option<Following>> {
         DBMS_CONTEXT.with(|ctx| {
-            let db = WasmDbmsDatabase::oneshot(ctx, Schema);
-
-            let records = db
+            let records = self
+                .db(ctx)
                 .select::<Following>(
                     Query::builder()
                         .all()
@@ -46,48 +65,49 @@ impl FollowingRepository {
     /// Get the list of accepted [`Following`]s of the user.
     ///
     /// Only returns entries with [`FollowStatus::Accepted`].
-    pub fn get_accepted_following(offset: usize, limit: usize) -> CanisterResult<Vec<Following>> {
+    pub fn get_accepted_following(
+        &self,
+        offset: usize,
+        limit: usize,
+    ) -> CanisterResult<Vec<Following>> {
         DBMS_CONTEXT.with(|ctx| {
-            let db = WasmDbmsDatabase::oneshot(ctx, Schema);
-
-            db.select::<Following>(
-                Query::builder()
-                    .all()
-                    .and_where(Filter::eq("status", Value::from(FollowStatus::Accepted)))
-                    .offset(offset)
-                    .limit(limit)
-                    .build(),
-            )
-            .map(|records| records.into_iter().map(Self::record_to_following).collect())
-            .map_err(CanisterError::from)
+            self.db(ctx)
+                .select::<Following>(
+                    Query::builder()
+                        .all()
+                        .and_where(Filter::eq("status", Value::from(FollowStatus::Accepted)))
+                        .offset(offset)
+                        .limit(limit)
+                        .build(),
+                )
+                .map(|records| records.into_iter().map(Self::record_to_following).collect())
+                .map_err(CanisterError::from)
         })
     }
 
     /// Delete a following entry by actor URI.
     ///
     /// Returns `true` if an entry was deleted, `false` if no entry was found with the given actor URI.
-    pub fn delete_by_actor_uri(actor_uri: &str) -> CanisterResult<bool> {
+    pub fn delete_by_actor_uri(&self, actor_uri: &str) -> CanisterResult<bool> {
         DBMS_CONTEXT.with(|ctx| {
-            let db = WasmDbmsDatabase::oneshot(ctx, Schema);
-
-            db.delete::<Following>(
-                DeleteBehavior::Restrict,
-                Some(Filter::eq("actor_uri", Value::from(actor_uri.to_string()))),
-            )
-            .map(|entries| entries > 0)
-            .map_err(CanisterError::from)
+            self.db(ctx)
+                .delete::<Following>(
+                    DeleteBehavior::Restrict,
+                    Some(Filter::eq("actor_uri", Value::from(actor_uri.to_string()))),
+                )
+                .map(|entries| entries > 0)
+                .map_err(CanisterError::from)
         })
     }
 
     /// Update the follow status for a given actor URI.
     ///
     /// Implemented as delete + re-insert because wasm-dbms does not support
-    /// in-place updates. Runs inside a transaction to maintain atomicity.
-    pub fn update_status(actor_uri: &str, new_status: FollowStatus) -> CanisterResult<()> {
+    /// in-place updates. Callers must wrap this call in a `Transaction::run`
+    /// to preserve atomicity across the underlying delete + insert.
+    pub fn update_status(&self, actor_uri: &str, new_status: FollowStatus) -> CanisterResult<()> {
         DBMS_CONTEXT.with(|ctx| {
-            let tx_id =
-                ctx.begin_transaction(db_utils::transaction::transaction_caller(ic_utils::now()));
-            let mut db = WasmDbmsDatabase::from_transaction(ctx, Schema, tx_id);
+            let db = self.db(ctx);
 
             // read the existing entry
             let records = db.select::<Following>(
@@ -118,8 +138,6 @@ impl FollowingRepository {
                 created_at: existing.created_at,
             })?;
 
-            db.commit()?;
-
             Ok(())
         })
     }
@@ -136,6 +154,8 @@ impl FollowingRepository {
 #[cfg(test)]
 mod tests {
 
+    use db_utils::transaction::Transaction;
+
     use super::*;
     use crate::test_utils::setup;
 
@@ -143,13 +163,16 @@ mod tests {
     fn test_should_delete_following_by_actor_uri() {
         setup();
 
-        FollowingRepository::insert_pending("https://mastic.social/users/alice")
+        FollowingRepository::oneshot()
+            .insert_pending("https://mastic.social/users/alice")
             .expect("should insert");
 
-        FollowingRepository::delete_by_actor_uri("https://mastic.social/users/alice")
+        FollowingRepository::oneshot()
+            .delete_by_actor_uri("https://mastic.social/users/alice")
             .expect("should delete");
 
-        let found = FollowingRepository::find_by_actor_uri("https://mastic.social/users/alice")
+        let found = FollowingRepository::oneshot()
+            .find_by_actor_uri("https://mastic.social/users/alice")
             .expect("should query");
         assert!(found.is_none());
     }
@@ -158,16 +181,18 @@ mod tests {
     fn test_should_update_status_pending_to_accepted() {
         setup();
 
-        FollowingRepository::insert_pending("https://mastic.social/users/alice")
+        FollowingRepository::oneshot()
+            .insert_pending("https://mastic.social/users/alice")
             .expect("should insert");
 
-        FollowingRepository::update_status(
-            "https://mastic.social/users/alice",
-            FollowStatus::Accepted,
-        )
+        Transaction::run::<_, _, _, CanisterError>(Schema, |tx| {
+            FollowingRepository::with_transaction(tx)
+                .update_status("https://mastic.social/users/alice", FollowStatus::Accepted)
+        })
         .expect("should update");
 
-        let entry = FollowingRepository::find_by_actor_uri("https://mastic.social/users/alice")
+        let entry = FollowingRepository::oneshot()
+            .find_by_actor_uri("https://mastic.social/users/alice")
             .expect("should query")
             .expect("should find entry");
         assert_eq!(entry.status, FollowStatus::Accepted);
@@ -177,10 +202,10 @@ mod tests {
     fn test_update_status_should_fail_for_missing_entry() {
         setup();
 
-        let result = FollowingRepository::update_status(
-            "https://mastic.social/users/nobody",
-            FollowStatus::Accepted,
-        );
+        let result = Transaction::run::<_, _, _, CanisterError>(Schema, |tx| {
+            FollowingRepository::with_transaction(tx)
+                .update_status("https://mastic.social/users/nobody", FollowStatus::Accepted)
+        });
         assert!(result.is_err());
     }
 }

--- a/crates/canisters/user/src/domain/following/repository.rs
+++ b/crates/canisters/user/src/domain/following/repository.rs
@@ -1,8 +1,7 @@
 //! Following repository for managing follow relationships.
 
-use ic_dbms_canister::prelude::{DBMS_CONTEXT, IcAccessControlList, IcMemoryProvider};
-use wasm_dbms::WasmDbmsDatabase;
-use wasm_dbms::prelude::DbmsContext;
+use db_utils::repository::Repository;
+use ic_dbms_canister::prelude::DBMS_CONTEXT;
 use wasm_dbms_api::prelude::*;
 
 use crate::error::{CanisterError, CanisterResult};
@@ -14,24 +13,6 @@ pub struct FollowingRepository {
 }
 
 impl FollowingRepository {
-    pub const fn oneshot() -> Self {
-        Self { tx: None }
-    }
-
-    pub const fn with_transaction(tx: TransactionId) -> Self {
-        Self { tx: Some(tx) }
-    }
-
-    fn db<'a>(
-        &self,
-        ctx: &'a DbmsContext<IcMemoryProvider, IcAccessControlList>,
-    ) -> WasmDbmsDatabase<'a, IcMemoryProvider, IcAccessControlList> {
-        match self.tx {
-            Some(id) => WasmDbmsDatabase::from_transaction(ctx, Schema, id),
-            None => WasmDbmsDatabase::oneshot(ctx, Schema),
-        }
-    }
-
     /// Insert a new pending follow entry for the given actor URI.
     pub fn insert_pending(&self, actor_uri: &str) -> CanisterResult<()> {
         DBMS_CONTEXT.with(|ctx| {
@@ -148,6 +129,26 @@ impl FollowingRepository {
             status: record.status.expect("must have field"),
             created_at: record.created_at.expect("must have field"),
         }
+    }
+}
+
+impl Repository for FollowingRepository {
+    type Schema = Schema;
+
+    fn schema() -> Self::Schema {
+        Schema
+    }
+
+    fn oneshot() -> Self {
+        Self { tx: None }
+    }
+
+    fn with_transaction(tx: TransactionId) -> Self {
+        Self { tx: Some(tx) }
+    }
+
+    fn tx(&self) -> Option<TransactionId> {
+        self.tx
     }
 }
 

--- a/crates/canisters/user/src/domain/following/unfollow_user.rs
+++ b/crates/canisters/user/src/domain/following/unfollow_user.rs
@@ -11,6 +11,7 @@
 use activitypub::activity::{Activity, ActivityObject, ActivityType};
 use activitypub::context::ACTIVITY_STREAMS_CONTEXT;
 use activitypub::object::{BaseObject, OneOrMany};
+use db_utils::repository::Repository;
 use did::federation::{SendActivityArgs, SendActivityArgsObject};
 use did::user::{UnfollowUserArgs, UnfollowUserError, UnfollowUserResponse};
 

--- a/crates/canisters/user/src/domain/following/unfollow_user.rs
+++ b/crates/canisters/user/src/domain/following/unfollow_user.rs
@@ -37,7 +37,7 @@ pub async fn unfollow_user(
 async fn unfollow_user_inner(target_actor_uri: &str) -> CanisterResult<()> {
     // Idempotent: delete returns false when no row matched — nothing to do.
     // Removes the row regardless of status (Pending or Accepted).
-    if !FollowingRepository::delete_by_actor_uri(target_actor_uri)? {
+    if !FollowingRepository::oneshot().delete_by_actor_uri(target_actor_uri)? {
         ic_utils::log!("unfollow_user: not following {target_actor_uri}, no-op");
         return Ok(());
     }
@@ -97,10 +97,12 @@ fn make_undo_follow_activity(own_actor_uri: &str, target_actor_uri: &str) -> Act
 #[cfg(test)]
 mod tests {
 
+    use db_utils::transaction::Transaction;
     use did::user::{UnfollowUserArgs, UnfollowUserResponse};
 
     use super::*;
-    use crate::schema::FollowStatus;
+    use crate::error::CanisterError;
+    use crate::schema::{FollowStatus, Schema};
     use crate::test_utils::setup;
 
     const TARGET_URI: &str = "https://mastic.social/users/alice";
@@ -110,9 +112,14 @@ mod tests {
     async fn test_should_unfollow_accepted_target() {
         setup();
 
-        FollowingRepository::insert_pending(TARGET_URI).expect("should insert");
-        FollowingRepository::update_status(TARGET_URI, FollowStatus::Accepted)
-            .expect("should accept");
+        FollowingRepository::oneshot()
+            .insert_pending(TARGET_URI)
+            .expect("should insert");
+        Transaction::run::<_, _, _, CanisterError>(Schema, |tx| {
+            FollowingRepository::with_transaction(tx)
+                .update_status(TARGET_URI, FollowStatus::Accepted)
+        })
+        .expect("should accept");
 
         let response = unfollow_user(UnfollowUserArgs {
             actor_uri: TARGET_URI.to_string(),
@@ -121,7 +128,8 @@ mod tests {
 
         assert_eq!(response, UnfollowUserResponse::Ok);
         assert!(
-            FollowingRepository::find_by_actor_uri(TARGET_URI)
+            FollowingRepository::oneshot()
+                .find_by_actor_uri(TARGET_URI)
                 .expect("should query")
                 .is_none()
         );
@@ -131,7 +139,9 @@ mod tests {
     async fn test_should_unfollow_pending_target() {
         setup();
 
-        FollowingRepository::insert_pending(TARGET_URI).expect("should insert");
+        FollowingRepository::oneshot()
+            .insert_pending(TARGET_URI)
+            .expect("should insert");
 
         let response = unfollow_user(UnfollowUserArgs {
             actor_uri: TARGET_URI.to_string(),
@@ -140,7 +150,8 @@ mod tests {
 
         assert_eq!(response, UnfollowUserResponse::Ok);
         assert!(
-            FollowingRepository::find_by_actor_uri(TARGET_URI)
+            FollowingRepository::oneshot()
+                .find_by_actor_uri(TARGET_URI)
                 .expect("should query")
                 .is_none()
         );

--- a/crates/canisters/user/src/domain/following/unfollow_user.rs
+++ b/crates/canisters/user/src/domain/following/unfollow_user.rs
@@ -44,7 +44,7 @@ async fn unfollow_user_inner(target_actor_uri: &str) -> CanisterResult<()> {
     ic_utils::log!("unfollow_user: removed following entry for {target_actor_uri}");
 
     // Build own actor URI for the Undo(Follow) payload.
-    let own_profile = ProfileRepository::get_profile()?;
+    let own_profile = ProfileRepository::oneshot().get_profile()?;
     let own_actor_uri = crate::domain::urls::actor_uri(&own_profile.handle.0)?;
 
     let activity = make_undo_follow_activity(&own_actor_uri, target_actor_uri);

--- a/crates/canisters/user/src/domain/liked.rs
+++ b/crates/canisters/user/src/domain/liked.rs
@@ -7,4 +7,5 @@ mod unlike;
 
 pub use get_liked::get_liked;
 pub use like::like_status;
+pub use repository::LikedRepository;
 pub use unlike::unlike_status;

--- a/crates/canisters/user/src/domain/liked/get_liked.rs
+++ b/crates/canisters/user/src/domain/liked/get_liked.rs
@@ -19,7 +19,7 @@ use crate::domain::liked::repository::LikedRepository;
 pub fn get_liked(GetLikedArgs { offset, limit }: GetLikedArgs) -> GetLikedResponse {
     ic_utils::log!("Getting liked statuses with offset {offset} and limit {limit}");
 
-    match LikedRepository::get_liked(offset as usize, limit as usize) {
+    match LikedRepository::oneshot().get_liked(offset as usize, limit as usize) {
         Ok(liked) => GetLikedResponse::Ok(liked),
         Err(err) => {
             ic_utils::log!("Failed to get liked statuses: {err}");
@@ -54,9 +54,11 @@ mod tests {
     #[test]
     fn test_should_return_liked_status_uris() {
         setup();
-        LikedRepository::like_status("https://mastic.social/users/alice/statuses/1")
+        LikedRepository::oneshot()
+            .like_status("https://mastic.social/users/alice/statuses/1")
             .expect("should insert");
-        LikedRepository::like_status("https://mastic.social/users/bob/statuses/2")
+        LikedRepository::oneshot()
+            .like_status("https://mastic.social/users/bob/statuses/2")
             .expect("should insert");
 
         let response = get_liked(GetLikedArgs {
@@ -75,7 +77,8 @@ mod tests {
     fn test_should_paginate_liked_results() {
         setup();
         for i in 0..5 {
-            LikedRepository::like_status(&format!("https://mastic.social/users/a/statuses/{i}"))
+            LikedRepository::oneshot()
+                .like_status(&format!("https://mastic.social/users/a/statuses/{i}"))
                 .expect("should insert");
         }
 

--- a/crates/canisters/user/src/domain/liked/get_liked.rs
+++ b/crates/canisters/user/src/domain/liked/get_liked.rs
@@ -7,6 +7,7 @@
 //! Clients are expected to fetch each status individually if they need to
 //! render content.
 
+use db_utils::repository::Repository;
 use did::user::{GetLikedArgs, GetLikedError, GetLikedResponse};
 
 use crate::domain::liked::repository::LikedRepository;
@@ -31,6 +32,7 @@ pub fn get_liked(GetLikedArgs { offset, limit }: GetLikedArgs) -> GetLikedRespon
 #[cfg(test)]
 mod tests {
 
+    use db_utils::repository::Repository;
     use did::user::{GetLikedArgs, GetLikedResponse};
 
     use super::get_liked;

--- a/crates/canisters/user/src/domain/liked/like.rs
+++ b/crates/canisters/user/src/domain/liked/like.rs
@@ -40,7 +40,7 @@ async fn like_status_inner(status_uri: String) -> CanisterResult<()> {
     ic_utils::log!("Liking status with URI: {status_uri}");
 
     // Idempotent: if already liked, do not duplicate or re-emit.
-    if LikedRepository::is_liked(&status_uri)? {
+    if LikedRepository::oneshot().is_liked(&status_uri)? {
         ic_utils::log!("Status already liked: {status_uri}");
         return Ok(());
     }
@@ -48,7 +48,7 @@ async fn like_status_inner(status_uri: String) -> CanisterResult<()> {
     // Insert the like into the database first; if federation dispatch
     // later fails, the user can re-trigger and the row already exists,
     // making the second call a no-op.
-    LikedRepository::like_status(&status_uri)?;
+    LikedRepository::oneshot().like_status(&status_uri)?;
 
     // Derive the author's actor URI and inbox from the status URI.
     let Some(author_actor_uri) = crate::domain::urls::actor_uri_from_status_uri(&status_uri) else {
@@ -117,7 +117,11 @@ mod tests {
         .await;
 
         assert_eq!(response, LikeStatusResponse::Ok);
-        assert!(LikedRepository::is_liked(STATUS_URI).expect("should query"));
+        assert!(
+            LikedRepository::oneshot()
+                .is_liked(STATUS_URI)
+                .expect("should query")
+        );
 
         let captured = captured();
         assert_eq!(captured.len(), 1, "exactly one activity dispatched");

--- a/crates/canisters/user/src/domain/liked/like.rs
+++ b/crates/canisters/user/src/domain/liked/like.rs
@@ -58,7 +58,7 @@ async fn like_status_inner(status_uri: String) -> CanisterResult<()> {
     let target_inbox = crate::domain::urls::inbox_url_from_actor_uri(&author_actor_uri);
 
     // Build the Like activity actored by the caller.
-    let own_profile = ProfileRepository::get_profile()?;
+    let own_profile = ProfileRepository::oneshot().get_profile()?;
     let own_actor_uri = crate::domain::urls::actor_uri(&own_profile.handle.0)?;
     let activity = make_like_activity(&own_actor_uri, &author_actor_uri, &status_uri);
 

--- a/crates/canisters/user/src/domain/liked/like.rs
+++ b/crates/canisters/user/src/domain/liked/like.rs
@@ -18,6 +18,7 @@
 use activitypub::activity::{Activity, ActivityObject, ActivityType};
 use activitypub::context::ACTIVITY_STREAMS_CONTEXT;
 use activitypub::object::{BaseObject, OneOrMany};
+use db_utils::repository::Repository;
 use did::federation::{SendActivityArgs, SendActivityArgsObject};
 use did::user::{LikeStatusArgs, LikeStatusError, LikeStatusResponse};
 

--- a/crates/canisters/user/src/domain/liked/repository.rs
+++ b/crates/canisters/user/src/domain/liked/repository.rs
@@ -1,8 +1,7 @@
 //! Repository for the `liked` table.
 
-use ic_dbms_canister::prelude::{DBMS_CONTEXT, IcAccessControlList, IcMemoryProvider};
-use wasm_dbms::WasmDbmsDatabase;
-use wasm_dbms::prelude::DbmsContext;
+use db_utils::repository::Repository;
+use ic_dbms_canister::prelude::DBMS_CONTEXT;
 use wasm_dbms_api::prelude::{Database, DeleteBehavior, Filter, Query, TableSchema, TransactionId};
 
 use crate::error::{CanisterError, CanisterResult};
@@ -13,27 +12,6 @@ pub struct LikedRepository {
 }
 
 impl LikedRepository {
-    pub const fn oneshot() -> Self {
-        Self { tx: None }
-    }
-
-    // Reserved for future cross-repo atomic flows that need to splice liked
-    // reads/writes into an externally-driven transaction. Not yet wired up.
-    #[allow(dead_code)]
-    pub const fn with_transaction(tx: TransactionId) -> Self {
-        Self { tx: Some(tx) }
-    }
-
-    fn db<'a>(
-        &self,
-        ctx: &'a DbmsContext<IcMemoryProvider, IcAccessControlList>,
-    ) -> WasmDbmsDatabase<'a, IcMemoryProvider, IcAccessControlList> {
-        match self.tx {
-            Some(id) => WasmDbmsDatabase::from_transaction(ctx, Schema, id),
-            None => WasmDbmsDatabase::oneshot(ctx, Schema),
-        }
-    }
-
     /// Inserts a liked status into the database.
     pub fn like_status(&self, status_uri: &str) -> CanisterResult<()> {
         DBMS_CONTEXT
@@ -87,5 +65,25 @@ impl LikedRepository {
                     .collect()
             })
             .map_err(CanisterError::from)
+    }
+}
+
+impl Repository for LikedRepository {
+    type Schema = Schema;
+
+    fn schema() -> Self::Schema {
+        Schema
+    }
+
+    fn oneshot() -> Self {
+        Self { tx: None }
+    }
+
+    fn with_transaction(tx: TransactionId) -> Self {
+        Self { tx: Some(tx) }
+    }
+
+    fn tx(&self) -> Option<TransactionId> {
+        self.tx
     }
 }

--- a/crates/canisters/user/src/domain/liked/repository.rs
+++ b/crates/canisters/user/src/domain/liked/repository.rs
@@ -1,20 +1,44 @@
-use ic_dbms_canister::prelude::DBMS_CONTEXT;
+//! Repository for the `liked` table.
+
+use ic_dbms_canister::prelude::{DBMS_CONTEXT, IcAccessControlList, IcMemoryProvider};
 use wasm_dbms::WasmDbmsDatabase;
-use wasm_dbms_api::prelude::{Database, DeleteBehavior, Filter, Query, TableSchema};
+use wasm_dbms::prelude::DbmsContext;
+use wasm_dbms_api::prelude::{Database, DeleteBehavior, Filter, Query, TableSchema, TransactionId};
 
 use crate::error::{CanisterError, CanisterResult};
 use crate::schema::{Liked, LikedInsertRequest, Schema};
 
-pub struct LikedRepository;
+pub struct LikedRepository {
+    tx: Option<TransactionId>,
+}
 
 impl LikedRepository {
+    pub const fn oneshot() -> Self {
+        Self { tx: None }
+    }
+
+    // Reserved for future cross-repo atomic flows that need to splice liked
+    // reads/writes into an externally-driven transaction. Not yet wired up.
+    #[allow(dead_code)]
+    pub const fn with_transaction(tx: TransactionId) -> Self {
+        Self { tx: Some(tx) }
+    }
+
+    fn db<'a>(
+        &self,
+        ctx: &'a DbmsContext<IcMemoryProvider, IcAccessControlList>,
+    ) -> WasmDbmsDatabase<'a, IcMemoryProvider, IcAccessControlList> {
+        match self.tx {
+            Some(id) => WasmDbmsDatabase::from_transaction(ctx, Schema, id),
+            None => WasmDbmsDatabase::oneshot(ctx, Schema),
+        }
+    }
+
     /// Inserts a liked status into the database.
-    pub fn like_status(status_uri: &str) -> CanisterResult<()> {
+    pub fn like_status(&self, status_uri: &str) -> CanisterResult<()> {
         DBMS_CONTEXT
             .with(|ctx| {
-                let db = WasmDbmsDatabase::oneshot(ctx, Schema);
-
-                db.insert::<Liked>(LikedInsertRequest {
+                self.db(ctx).insert::<Liked>(LikedInsertRequest {
                     status_uri: status_uri.into(),
                     created_at: ic_utils::now().into(),
                 })
@@ -23,12 +47,10 @@ impl LikedRepository {
     }
 
     /// Deletes a liked status from the database.
-    pub fn unlike_status(status_uri: &str) -> CanisterResult<()> {
+    pub fn unlike_status(&self, status_uri: &str) -> CanisterResult<()> {
         DBMS_CONTEXT
             .with(|ctx| {
-                let db = WasmDbmsDatabase::oneshot(ctx, Schema);
-
-                db.delete::<Liked>(
+                self.db(ctx).delete::<Liked>(
                     DeleteBehavior::Cascade,
                     Some(Filter::eq(Liked::primary_key(), status_uri.into())),
                 )
@@ -38,12 +60,10 @@ impl LikedRepository {
     }
 
     /// Checks if a status is liked by the user.
-    pub fn is_liked(status_uri: &str) -> CanisterResult<bool> {
+    pub fn is_liked(&self, status_uri: &str) -> CanisterResult<bool> {
         DBMS_CONTEXT
             .with(|ctx| {
-                let db = WasmDbmsDatabase::oneshot(ctx, Schema);
-
-                db.select::<Liked>(
+                self.db(ctx).select::<Liked>(
                     Query::builder()
                         .and_where(Filter::eq(Liked::primary_key(), status_uri.into()))
                         .limit(1)
@@ -54,12 +74,11 @@ impl LikedRepository {
             .map_err(CanisterError::from)
     }
 
-    pub fn get_liked(offset: usize, limit: usize) -> CanisterResult<Vec<String>> {
+    pub fn get_liked(&self, offset: usize, limit: usize) -> CanisterResult<Vec<String>> {
         DBMS_CONTEXT
             .with(|ctx| {
-                let db = WasmDbmsDatabase::oneshot(ctx, Schema);
-
-                db.select::<Liked>(Query::builder().all().offset(offset).limit(limit).build())
+                self.db(ctx)
+                    .select::<Liked>(Query::builder().all().offset(offset).limit(limit).build())
             })
             .map(|records| {
                 records

--- a/crates/canisters/user/src/domain/liked/unlike.rs
+++ b/crates/canisters/user/src/domain/liked/unlike.rs
@@ -39,12 +39,12 @@ async fn unlike_status_inner(status_uri: String) -> CanisterResult<()> {
     ic_utils::log!("Unliking status with URI: {status_uri}");
 
     // Idempotent: nothing to do if the row is absent.
-    if !LikedRepository::is_liked(&status_uri)? {
+    if !LikedRepository::oneshot().is_liked(&status_uri)? {
         ic_utils::log!("Status not liked: {status_uri}; nothing to do");
         return Ok(());
     }
 
-    LikedRepository::unlike_status(&status_uri)?;
+    LikedRepository::oneshot().unlike_status(&status_uri)?;
 
     let Some(author_actor_uri) = crate::domain::urls::actor_uri_from_status_uri(&status_uri) else {
         ic_utils::log!("unlike_status: could not derive author actor URI from {status_uri}");
@@ -121,7 +121,9 @@ mod tests {
     async fn test_should_unlike_status_after_like() {
         setup();
 
-        LikedRepository::like_status(STATUS_URI).expect("should insert liked");
+        LikedRepository::oneshot()
+            .like_status(STATUS_URI)
+            .expect("should insert liked");
 
         let response = unlike_status(UnlikeStatusArgs {
             status_url: STATUS_URI.to_string(),
@@ -129,7 +131,11 @@ mod tests {
         .await;
 
         assert_eq!(response, UnlikeStatusResponse::Ok);
-        assert!(!LikedRepository::is_liked(STATUS_URI).expect("should query"));
+        assert!(
+            !LikedRepository::oneshot()
+                .is_liked(STATUS_URI)
+                .expect("should query")
+        );
 
         let captured = captured();
         assert_eq!(captured.len(), 1);

--- a/crates/canisters/user/src/domain/liked/unlike.rs
+++ b/crates/canisters/user/src/domain/liked/unlike.rs
@@ -15,6 +15,7 @@
 use activitypub::activity::{Activity, ActivityObject, ActivityType};
 use activitypub::context::ACTIVITY_STREAMS_CONTEXT;
 use activitypub::object::{BaseObject, OneOrMany};
+use db_utils::repository::Repository;
 use did::federation::{SendActivityArgs, SendActivityArgsObject};
 use did::user::{UnlikeStatusArgs, UnlikeStatusError, UnlikeStatusResponse};
 

--- a/crates/canisters/user/src/domain/liked/unlike.rs
+++ b/crates/canisters/user/src/domain/liked/unlike.rs
@@ -52,7 +52,7 @@ async fn unlike_status_inner(status_uri: String) -> CanisterResult<()> {
     };
     let target_inbox = crate::domain::urls::inbox_url_from_actor_uri(&author_actor_uri);
 
-    let own_profile = ProfileRepository::get_profile()?;
+    let own_profile = ProfileRepository::oneshot().get_profile()?;
     let own_actor_uri = crate::domain::urls::actor_uri(&own_profile.handle.0)?;
     let activity = make_undo_like_activity(&own_actor_uri, &author_actor_uri, &status_uri);
 

--- a/crates/canisters/user/src/domain/profile/create_profile.rs
+++ b/crates/canisters/user/src/domain/profile/create_profile.rs
@@ -1,6 +1,7 @@
 //! Create profile flow.
 
 use candid::Principal;
+use db_utils::repository::Repository;
 
 use crate::domain::profile::ProfileRepository;
 use crate::error::CanisterResult;

--- a/crates/canisters/user/src/domain/profile/create_profile.rs
+++ b/crates/canisters/user/src/domain/profile/create_profile.rs
@@ -10,7 +10,7 @@ use crate::error::CanisterResult;
 /// This flow is called on canister init and just initialize the user with its handle.
 pub fn create_profile(principal: Principal, handle: &str) -> CanisterResult<()> {
     ic_utils::log!("Creating profile for principal {principal} with handle {handle}");
-    ProfileRepository::create_profile(principal, handle)
+    ProfileRepository::oneshot().create_profile(principal, handle)
 }
 
 #[cfg(test)]

--- a/crates/canisters/user/src/domain/profile/emit_delete.rs
+++ b/crates/canisters/user/src/domain/profile/emit_delete.rs
@@ -86,7 +86,7 @@ async fn dispatch() -> CanisterResult<()> {
 
 fn followers_minus_blocked() -> CanisterResult<Vec<String>> {
     let followers = FollowerRepository::get_followers()?;
-    let blocked = BlockRepository::list_blocked_uris()?;
+    let blocked = BlockRepository::oneshot().list_blocked_uris()?;
     Ok(followers
         .into_iter()
         .map(|f| f.actor_uri.0)

--- a/crates/canisters/user/src/domain/profile/emit_delete.rs
+++ b/crates/canisters/user/src/domain/profile/emit_delete.rs
@@ -85,7 +85,7 @@ async fn dispatch() -> CanisterResult<()> {
 }
 
 fn followers_minus_blocked() -> CanisterResult<Vec<String>> {
-    let followers = FollowerRepository::get_followers()?;
+    let followers = FollowerRepository::oneshot().get_followers()?;
     let blocked = BlockRepository::oneshot().list_blocked_uris()?;
     Ok(followers
         .into_iter()

--- a/crates/canisters/user/src/domain/profile/emit_delete.rs
+++ b/crates/canisters/user/src/domain/profile/emit_delete.rs
@@ -3,6 +3,7 @@
 use activitypub::activity::{Activity, ActivityObject, ActivityType};
 use activitypub::context::{ACTIVITY_STREAMS_CONTEXT, Context};
 use activitypub::object::{BaseObject, OneOrMany};
+use db_utils::repository::Repository;
 use did::federation::{SendActivityArgs, SendActivityArgsObject};
 use did::user::{EmitDeleteProfileActivityError, EmitDeleteProfileActivityResponse};
 

--- a/crates/canisters/user/src/domain/profile/emit_delete.rs
+++ b/crates/canisters/user/src/domain/profile/emit_delete.rs
@@ -35,7 +35,7 @@ pub async fn emit_delete_profile_activity() -> EmitDeleteProfileActivityResponse
 }
 
 async fn dispatch() -> CanisterResult<()> {
-    let profile = ProfileRepository::get_profile()?;
+    let profile = ProfileRepository::oneshot().get_profile()?;
     let handle = profile.handle.0.clone();
     let owner_uri = urls::actor_uri(&handle)?;
 

--- a/crates/canisters/user/src/domain/profile/get_profile.rs
+++ b/crates/canisters/user/src/domain/profile/get_profile.rs
@@ -8,7 +8,7 @@ use crate::error::CanisterError;
 
 /// Gets the profile of the user.
 pub fn get_profile() -> GetProfileResponse {
-    let user = match ProfileRepository::get_profile() {
+    let user = match ProfileRepository::oneshot().get_profile() {
         Ok(profile) => profile,
         Err(CanisterError::Settings(_)) => {
             return GetProfileResponse::Err(GetProfileError::NotFound);

--- a/crates/canisters/user/src/domain/profile/get_profile.rs
+++ b/crates/canisters/user/src/domain/profile/get_profile.rs
@@ -1,5 +1,6 @@
 //! Get profile flow.
 
+use db_utils::repository::Repository;
 use did::common::UserProfile;
 use did::user::{GetProfileError, GetProfileResponse};
 

--- a/crates/canisters/user/src/domain/profile/repository.rs
+++ b/crates/canisters/user/src/domain/profile/repository.rs
@@ -2,11 +2,10 @@
 
 use candid::Principal;
 use db_utils::field_update::field_update_to_nullable;
+use db_utils::repository::Repository;
 use db_utils::settings::SettingsError;
 use did::common::FieldUpdate;
-use ic_dbms_canister::prelude::{DBMS_CONTEXT, IcAccessControlList, IcMemoryProvider};
-use wasm_dbms::WasmDbmsDatabase;
-use wasm_dbms::prelude::DbmsContext;
+use ic_dbms_canister::prelude::DBMS_CONTEXT;
 use wasm_dbms_api::prelude::*;
 
 use crate::error::{CanisterError, CanisterResult};
@@ -17,27 +16,6 @@ pub struct ProfileRepository {
 }
 
 impl ProfileRepository {
-    pub const fn oneshot() -> Self {
-        Self { tx: None }
-    }
-
-    // Reserved for future cross-repo atomic flows that need to splice profile
-    // reads/writes into an externally-driven transaction. Not yet wired up.
-    #[allow(dead_code)]
-    pub const fn with_transaction(tx: TransactionId) -> Self {
-        Self { tx: Some(tx) }
-    }
-
-    fn db<'a>(
-        &self,
-        ctx: &'a DbmsContext<IcMemoryProvider, IcAccessControlList>,
-    ) -> WasmDbmsDatabase<'a, IcMemoryProvider, IcAccessControlList> {
-        match self.tx {
-            Some(id) => WasmDbmsDatabase::from_transaction(ctx, Schema, id),
-            None => WasmDbmsDatabase::oneshot(ctx, Schema),
-        }
-    }
-
     /// Get the profile of the current user.
     pub fn get_profile(&self) -> CanisterResult<Profile> {
         let row = DBMS_CONTEXT.with(|ctx| {
@@ -115,5 +93,25 @@ impl ProfileRepository {
             created_at: record.created_at.expect("created at cannot be missing"),
             updated_at: record.updated_at.expect("updated at cannot be missing"),
         }
+    }
+}
+
+impl Repository for ProfileRepository {
+    type Schema = Schema;
+
+    fn schema() -> Self::Schema {
+        Schema
+    }
+
+    fn oneshot() -> Self {
+        Self { tx: None }
+    }
+
+    fn with_transaction(tx: TransactionId) -> Self {
+        Self { tx: Some(tx) }
+    }
+
+    fn tx(&self) -> Option<TransactionId> {
+        self.tx
     }
 }

--- a/crates/canisters/user/src/domain/profile/repository.rs
+++ b/crates/canisters/user/src/domain/profile/repository.rs
@@ -4,22 +4,46 @@ use candid::Principal;
 use db_utils::field_update::field_update_to_nullable;
 use db_utils::settings::SettingsError;
 use did::common::FieldUpdate;
-use ic_dbms_canister::prelude::DBMS_CONTEXT;
+use ic_dbms_canister::prelude::{DBMS_CONTEXT, IcAccessControlList, IcMemoryProvider};
 use wasm_dbms::WasmDbmsDatabase;
+use wasm_dbms::prelude::DbmsContext;
 use wasm_dbms_api::prelude::*;
 
 use crate::error::{CanisterError, CanisterResult};
 use crate::schema::{Profile, ProfileInsertRequest, ProfileRecord, ProfileUpdateRequest, Schema};
 
-pub struct ProfileRepository;
+pub struct ProfileRepository {
+    tx: Option<TransactionId>,
+}
 
 impl ProfileRepository {
-    /// Get the profile of the current user.
-    pub fn get_profile() -> CanisterResult<Profile> {
-        let row = DBMS_CONTEXT.with(|ctx| {
-            let db = WasmDbmsDatabase::oneshot(ctx, Schema);
+    pub const fn oneshot() -> Self {
+        Self { tx: None }
+    }
 
-            let record = db.select::<Profile>(Query::builder().all().limit(1).build())?;
+    // Reserved for future cross-repo atomic flows that need to splice profile
+    // reads/writes into an externally-driven transaction. Not yet wired up.
+    #[allow(dead_code)]
+    pub const fn with_transaction(tx: TransactionId) -> Self {
+        Self { tx: Some(tx) }
+    }
+
+    fn db<'a>(
+        &self,
+        ctx: &'a DbmsContext<IcMemoryProvider, IcAccessControlList>,
+    ) -> WasmDbmsDatabase<'a, IcMemoryProvider, IcAccessControlList> {
+        match self.tx {
+            Some(id) => WasmDbmsDatabase::from_transaction(ctx, Schema, id),
+            None => WasmDbmsDatabase::oneshot(ctx, Schema),
+        }
+    }
+
+    /// Get the profile of the current user.
+    pub fn get_profile(&self) -> CanisterResult<Profile> {
+        let row = DBMS_CONTEXT.with(|ctx| {
+            let record = self
+                .db(ctx)
+                .select::<Profile>(Query::builder().all().limit(1).build())?;
 
             Ok::<Option<ProfileRecord>, CanisterError>(record.into_iter().next())
         })?;
@@ -32,7 +56,7 @@ impl ProfileRepository {
     }
 
     /// Create a new profile for the given principal and handle.
-    pub fn create_profile(principal: Principal, handle: &str) -> CanisterResult<()> {
+    pub fn create_profile(&self, principal: Principal, handle: &str) -> CanisterResult<()> {
         let insert_request = ProfileInsertRequest {
             principal: ic_dbms_canister::prelude::Principal(principal),
             handle: handle.into(),
@@ -45,9 +69,7 @@ impl ProfileRepository {
         };
 
         DBMS_CONTEXT.with(|ctx| {
-            let db = WasmDbmsDatabase::oneshot(ctx, Schema);
-
-            db.insert::<Profile>(insert_request)?;
+            self.db(ctx).insert::<Profile>(insert_request)?;
 
             Ok(())
         })
@@ -59,6 +81,7 @@ impl ProfileRepository {
     /// field is [`FieldUpdate::Leave`] (no-op). The caller can use the
     /// boolean to decide whether to fan out an activity.
     pub fn update_profile(
+        &self,
         bio: FieldUpdate<String>,
         display_name: FieldUpdate<String>,
     ) -> CanisterResult<bool> {
@@ -76,11 +99,7 @@ impl ProfileRepository {
             ..Default::default()
         };
 
-        DBMS_CONTEXT.with(|ctx| {
-            let db = WasmDbmsDatabase::oneshot(ctx, Schema);
-
-            db.update::<Profile>(patch)
-        })?;
+        DBMS_CONTEXT.with(|ctx| self.db(ctx).update::<Profile>(patch))?;
 
         Ok(true)
     }

--- a/crates/canisters/user/src/domain/profile/update_profile.rs
+++ b/crates/canisters/user/src/domain/profile/update_profile.rs
@@ -4,6 +4,7 @@ use activitypub::activity::{Activity, ActivityObject, ActivityType};
 use activitypub::actor::{Actor, ActorType};
 use activitypub::context::{ACTIVITY_STREAMS_CONTEXT, Context};
 use activitypub::object::{BaseObject, OneOrMany};
+use db_utils::repository::Repository;
 use did::federation::{SendActivityArgs, SendActivityArgsObject};
 use did::user::{UpdateProfileArgs, UpdateProfileError, UpdateProfileResponse};
 

--- a/crates/canisters/user/src/domain/profile/update_profile.rs
+++ b/crates/canisters/user/src/domain/profile/update_profile.rs
@@ -74,7 +74,7 @@ async fn dispatch_update_activity() -> CanisterResult<()> {
 /// Return the follower actor URIs, excluding blocked actors.
 fn followers_minus_blocked() -> CanisterResult<Vec<String>> {
     let followers = FollowerRepository::get_followers()?;
-    let blocked = BlockRepository::list_blocked_uris()?;
+    let blocked = BlockRepository::oneshot().list_blocked_uris()?;
     Ok(followers
         .into_iter()
         .map(|f| f.actor_uri.0)

--- a/crates/canisters/user/src/domain/profile/update_profile.rs
+++ b/crates/canisters/user/src/domain/profile/update_profile.rs
@@ -75,7 +75,7 @@ async fn dispatch_update_activity() -> CanisterResult<()> {
 
 /// Return the follower actor URIs, excluding blocked actors.
 fn followers_minus_blocked() -> CanisterResult<Vec<String>> {
-    let followers = FollowerRepository::get_followers()?;
+    let followers = FollowerRepository::oneshot().get_followers()?;
     let blocked = BlockRepository::oneshot().list_blocked_uris()?;
     Ok(followers
         .into_iter()

--- a/crates/canisters/user/src/domain/profile/update_profile.rs
+++ b/crates/canisters/user/src/domain/profile/update_profile.rs
@@ -33,10 +33,12 @@ pub async fn update_profile(args: UpdateProfileArgs) -> UpdateProfileResponse {
 async fn update_profile_inner(
     UpdateProfileArgs { bio, display_name }: UpdateProfileArgs,
 ) -> Result<(), UpdateProfileError> {
-    let written = ProfileRepository::update_profile(bio, display_name).map_err(|err| {
-        ic_utils::log!("Failed to update profile: {err}");
-        UpdateProfileError::Internal(err.to_string())
-    })?;
+    let written = ProfileRepository::oneshot()
+        .update_profile(bio, display_name)
+        .map_err(|err| {
+            ic_utils::log!("Failed to update profile: {err}");
+            UpdateProfileError::Internal(err.to_string())
+        })?;
 
     if !written {
         return Ok(());
@@ -48,7 +50,7 @@ async fn update_profile_inner(
 }
 
 async fn dispatch_update_activity() -> CanisterResult<()> {
-    let profile = ProfileRepository::get_profile()?;
+    let profile = ProfileRepository::oneshot().get_profile()?;
     let handle = profile.handle.0.clone();
     let owner_uri = urls::actor_uri(&handle)?;
 

--- a/crates/canisters/user/src/domain/status.rs
+++ b/crates/canisters/user/src/domain/status.rs
@@ -1,5 +1,6 @@
 //! Status domain
 
+mod get_local_status;
 mod get_statuses;
 mod publish;
 mod repository;
@@ -7,6 +8,7 @@ mod repository;
 /// Maximum allowed length for the status content.
 pub const MAX_STATUS_LENGTH: usize = 500;
 
+pub use self::get_local_status::{get_local_status, get_local_status_with_caller};
 pub use self::get_statuses::get_statuses;
 pub use self::publish::publish_status;
 pub use self::repository::StatusRepository;

--- a/crates/canisters/user/src/domain/status.rs
+++ b/crates/canisters/user/src/domain/status.rs
@@ -8,7 +8,7 @@ mod repository;
 /// Maximum allowed length for the status content.
 pub const MAX_STATUS_LENGTH: usize = 500;
 
-pub use self::get_local_status::{get_local_status, get_local_status_with_caller};
+pub use self::get_local_status::get_local_status;
 pub use self::get_statuses::get_statuses;
 pub use self::publish::publish_status;
 pub use self::repository::StatusRepository;

--- a/crates/canisters/user/src/domain/status.rs
+++ b/crates/canisters/user/src/domain/status.rs
@@ -5,10 +5,144 @@ mod get_statuses;
 mod publish;
 mod repository;
 
-/// Maximum allowed length for the status content.
-pub const MAX_STATUS_LENGTH: usize = 500;
+use did::common::Visibility;
+use wasm_dbms_api::prelude::TransactionId;
 
 pub use self::get_local_status::get_local_status;
 pub use self::get_statuses::get_statuses;
 pub use self::publish::publish_status;
 pub use self::repository::StatusRepository;
+use crate::domain::feed::FeedRepository;
+use crate::error::CanisterResult;
+
+/// Maximum allowed length for the status content.
+pub const MAX_STATUS_LENGTH: usize = 500;
+
+/// Insert a status row plus its outbox feed entry inside the given
+/// transaction. Caller must drive the transaction lifecycle, typically
+/// via [`db_utils::transaction::Transaction::run`].
+pub(crate) fn create_status_with_feed(
+    tx: TransactionId,
+    snowflake_id: u64,
+    content: String,
+    visibility: Visibility,
+    created_at: u64,
+) -> CanisterResult<()> {
+    StatusRepository::with_transaction(tx).insert(snowflake_id, content, visibility, created_at)?;
+    FeedRepository::with_transaction(tx).insert_outbox(snowflake_id, created_at)?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use db_utils::transaction::Transaction;
+    use did::common::Visibility;
+    use ic_dbms_canister::prelude::DBMS_CONTEXT;
+    use wasm_dbms::WasmDbmsDatabase;
+    use wasm_dbms_api::prelude::{Database, Query};
+
+    use super::*;
+    use crate::domain::snowflake::Snowflake;
+    use crate::error::CanisterError;
+    use crate::schema::{FeedEntry, Schema};
+    use crate::test_utils::setup;
+
+    fn count_feed_entries() -> usize {
+        DBMS_CONTEXT.with(|ctx| {
+            let db = WasmDbmsDatabase::oneshot(ctx, Schema);
+            db.select::<FeedEntry>(Query::builder().all().build())
+                .expect("select feed")
+                .len()
+        })
+    }
+
+    #[test]
+    fn test_create_status_with_feed_should_insert_status_and_feed_entry() {
+        setup();
+
+        let snowflake: u64 = Snowflake::new().into();
+        Transaction::run::<_, _, _, CanisterError>(Schema, |tx| {
+            create_status_with_feed(
+                tx,
+                snowflake,
+                "Hello world".to_string(),
+                Visibility::Public,
+                42_000,
+            )
+        })
+        .expect("should create");
+
+        // verify the status was inserted
+        let statuses = StatusRepository::oneshot()
+            .get_paginated_by_visibility(&[Visibility::Public], 0, 10)
+            .expect("should query");
+
+        assert_eq!(statuses.len(), 1);
+        assert_eq!(statuses[0].id.0, snowflake);
+        assert_eq!(statuses[0].content.0, "Hello world");
+        assert_eq!(statuses[0].created_at.0, 42_000);
+
+        // verify the feed entry was inserted alongside
+        assert_eq!(count_feed_entries(), 1);
+    }
+
+    #[test]
+    fn test_create_status_with_feed_should_rollback_on_error() {
+        setup();
+
+        // First create a status with a known ID via the helper
+        let snowflake: u64 = Snowflake::new().into();
+        Transaction::run::<_, _, _, CanisterError>(Schema, |tx| {
+            create_status_with_feed(
+                tx,
+                snowflake,
+                "first".to_string(),
+                Visibility::Public,
+                1_000,
+            )
+        })
+        .expect("first create");
+
+        let initial_count = StatusRepository::oneshot()
+            .get_paginated_by_visibility(&[Visibility::Public], 0, 100)
+            .expect("query")
+            .len();
+        assert_eq!(initial_count, 1);
+
+        // Run a transaction that errors out — neither the status nor the
+        // feed entry must be persisted.
+        let rollback_id: u64 = Snowflake::new().into();
+        let result: Result<(), CanisterError> = Transaction::run(Schema, |tx| {
+            create_status_with_feed(
+                tx,
+                rollback_id,
+                "rollback".to_string(),
+                Visibility::Public,
+                2_000,
+            )?;
+            Err(CanisterError::Internal("boom".to_string()))
+        });
+        assert!(result.is_err());
+
+        let after_count = StatusRepository::oneshot()
+            .get_paginated_by_visibility(&[Visibility::Public], 0, 100)
+            .expect("query")
+            .len();
+        assert_eq!(after_count, 1, "errored tx must not persist its insert");
+
+        // The rollback status must not be present
+        assert!(
+            StatusRepository::oneshot()
+                .find_by_id(rollback_id)
+                .expect("query")
+                .is_none()
+        );
+
+        // The feed entry from the rolled-back transaction must not be persisted.
+        assert_eq!(
+            count_feed_entries(),
+            1,
+            "errored tx must not persist its feed entry"
+        );
+    }
+}

--- a/crates/canisters/user/src/domain/status.rs
+++ b/crates/canisters/user/src/domain/status.rs
@@ -1,5 +1,6 @@
 //! Status domain
 
+use db_utils::repository::Repository;
 mod get_local_status;
 mod get_statuses;
 mod publish;

--- a/crates/canisters/user/src/domain/status/get_local_status.rs
+++ b/crates/canisters/user/src/domain/status/get_local_status.rs
@@ -19,10 +19,6 @@ use crate::error::CanisterResult;
 
 /// Public entry point. Pulls `ic_utils::caller()` and forwards to
 /// [`get_local_status_with_caller`].
-#[cfg_attr(
-    not(test),
-    expect(dead_code, reason = "wired up by the get_local_status API endpoint")
-)]
 pub fn get_local_status(args: GetLocalStatusArgs) -> GetLocalStatusResponse {
     get_local_status_with_caller(ic_utils::caller(), args)
 }

--- a/crates/canisters/user/src/domain/status/get_local_status.rs
+++ b/crates/canisters/user/src/domain/status/get_local_status.rs
@@ -84,7 +84,7 @@ impl Scope {
             (Scope::Owner, _) => Ok(true),
             (_, Visibility::Public) | (_, Visibility::Unlisted) => Ok(true),
             (Scope::FederationWithRequester(uri), Visibility::FollowersOnly) => {
-                FollowerRepository::is_follower(uri)
+                FollowerRepository::oneshot().is_follower(uri)
             }
             _ => Ok(false),
         }
@@ -117,7 +117,9 @@ mod tests {
     const NON_FOLLOWER_URI: &str = "https://remote.example/users/charlie";
 
     fn insert_follower(uri: &str) {
-        FollowerRepository::insert(uri).expect("insert follower");
+        FollowerRepository::oneshot()
+            .insert(uri)
+            .expect("insert follower");
     }
 
     #[test]

--- a/crates/canisters/user/src/domain/status/get_local_status.rs
+++ b/crates/canisters/user/src/domain/status/get_local_status.rs
@@ -56,7 +56,7 @@ fn get_local_status_inner(
         return Ok(None);
     }
 
-    let own_profile = crate::domain::profile::ProfileRepository::get_profile()?;
+    let own_profile = crate::domain::profile::ProfileRepository::oneshot().get_profile()?;
     let author_uri = urls::actor_uri(&own_profile.handle.0)?;
 
     Ok(Some(Status {

--- a/crates/canisters/user/src/domain/status/get_local_status.rs
+++ b/crates/canisters/user/src/domain/status/get_local_status.rs
@@ -1,0 +1,245 @@
+//! `get_local_status` flow.
+//!
+//! Returns a single [`Status`] by id, applying caller-scoped visibility rules.
+//! See the visibility table in the design doc:
+//! - Owner: any visibility.
+//! - Federation principal + `Some(requester)`: Public/Unlisted always;
+//!   FollowersOnly iff `requester` is a follower; Direct → `NotFound`.
+//! - Federation principal + `None`: Public/Unlisted only.
+//! - Anonymous / other: Public/Unlisted only.
+
+use candid::Principal;
+use did::common::{Status, Visibility};
+use did::user::{GetLocalStatusArgs, GetLocalStatusError, GetLocalStatusResponse};
+
+use crate::domain::follower::FollowerRepository;
+use crate::domain::status::StatusRepository;
+use crate::domain::urls;
+use crate::error::CanisterResult;
+
+/// Public entry point. Pulls `ic_utils::caller()` and forwards to
+/// [`get_local_status_with_caller`].
+#[cfg_attr(
+    not(test),
+    expect(dead_code, reason = "wired up by the get_local_status API endpoint")
+)]
+pub fn get_local_status(args: GetLocalStatusArgs) -> GetLocalStatusResponse {
+    get_local_status_with_caller(ic_utils::caller(), args)
+}
+
+/// Caller-explicit entry — separated from [`get_local_status`] so tests can
+/// stub the caller principal (the non-wasm `ic_utils::caller()` is fixed).
+pub fn get_local_status_with_caller(
+    caller: Principal,
+    args: GetLocalStatusArgs,
+) -> GetLocalStatusResponse {
+    match get_local_status_inner(caller, args) {
+        Ok(Some(status)) => GetLocalStatusResponse::Ok(status),
+        Ok(None) => GetLocalStatusResponse::Err(GetLocalStatusError::NotFound),
+        Err(err) => {
+            ic_utils::log!("get_local_status: {err}");
+            GetLocalStatusResponse::Err(GetLocalStatusError::Internal(err.to_string()))
+        }
+    }
+}
+
+fn get_local_status_inner(
+    caller: Principal,
+    GetLocalStatusArgs {
+        id,
+        requester_actor_uri,
+    }: GetLocalStatusArgs,
+) -> CanisterResult<Option<Status>> {
+    let scope = resolve_scope(caller, requester_actor_uri.as_deref());
+    let Some(record) = StatusRepository::find_by_id(id)? else {
+        return Ok(None);
+    };
+
+    let record_visibility: Visibility = record.visibility.into();
+    if !scope.allows(&record_visibility)? {
+        return Ok(None);
+    }
+
+    let own_profile = crate::domain::profile::ProfileRepository::get_profile()?;
+    let author_uri = urls::actor_uri(&own_profile.handle.0)?;
+
+    Ok(Some(Status {
+        id: record.id.0,
+        content: record.content.0,
+        author: author_uri,
+        created_at: record.created_at.0,
+        visibility: record_visibility,
+        like_count: record.like_count.0,
+        boost_count: record.boost_count.0,
+        spoiler_text: record.spoiler_text.into_opt().map(|t| t.0),
+        sensitive: record.sensitive.0,
+    }))
+}
+
+enum Scope {
+    Owner,
+    FederationWithRequester(String),
+    PublicOnly,
+}
+
+impl Scope {
+    fn allows(&self, vis: &Visibility) -> CanisterResult<bool> {
+        match (self, vis) {
+            (Scope::Owner, _) => Ok(true),
+            (_, Visibility::Public) | (_, Visibility::Unlisted) => Ok(true),
+            (Scope::FederationWithRequester(uri), Visibility::FollowersOnly) => {
+                FollowerRepository::is_follower(uri)
+            }
+            _ => Ok(false),
+        }
+    }
+}
+
+fn resolve_scope(caller: Principal, requester_actor_uri: Option<&str>) -> Scope {
+    if crate::api::inspect::is_owner(caller) {
+        return Scope::Owner;
+    }
+    if crate::api::inspect::is_federation_canister(caller) {
+        return match requester_actor_uri {
+            Some(uri) => Scope::FederationWithRequester(uri.to_string()),
+            None => Scope::PublicOnly,
+        };
+    }
+    Scope::PublicOnly
+}
+
+#[cfg(test)]
+mod tests {
+    use did::common::Visibility;
+    use did::user::{GetLocalStatusArgs, GetLocalStatusError, GetLocalStatusResponse};
+
+    use super::get_local_status_with_caller;
+    use crate::domain::follower::FollowerRepository;
+    use crate::test_utils::{admin, federation, insert_status, setup};
+
+    const FOLLOWER_URI: &str = "https://remote.example/users/bob";
+    const NON_FOLLOWER_URI: &str = "https://remote.example/users/charlie";
+
+    fn insert_follower(uri: &str) {
+        FollowerRepository::insert(uri).expect("insert follower");
+    }
+
+    #[test]
+    fn test_owner_can_read_any_visibility() {
+        setup();
+        insert_status(1, "secret", Visibility::Direct, 1_000);
+
+        let resp = get_local_status_with_caller(
+            admin(),
+            GetLocalStatusArgs {
+                id: 1,
+                requester_actor_uri: None,
+            },
+        );
+        assert!(matches!(resp, GetLocalStatusResponse::Ok(_)));
+    }
+
+    #[test]
+    fn test_federation_with_follower_uri_can_see_followers_only() {
+        setup();
+        insert_follower(FOLLOWER_URI);
+        insert_status(2, "fo", Visibility::FollowersOnly, 1_000);
+
+        let resp = get_local_status_with_caller(
+            federation(),
+            GetLocalStatusArgs {
+                id: 2,
+                requester_actor_uri: Some(FOLLOWER_URI.to_string()),
+            },
+        );
+        assert!(matches!(resp, GetLocalStatusResponse::Ok(_)));
+    }
+
+    #[test]
+    fn test_federation_with_non_follower_blocks_followers_only() {
+        setup();
+        insert_follower(FOLLOWER_URI);
+        insert_status(3, "fo", Visibility::FollowersOnly, 1_000);
+
+        let resp = get_local_status_with_caller(
+            federation(),
+            GetLocalStatusArgs {
+                id: 3,
+                requester_actor_uri: Some(NON_FOLLOWER_URI.to_string()),
+            },
+        );
+        assert_eq!(
+            resp,
+            GetLocalStatusResponse::Err(GetLocalStatusError::NotFound)
+        );
+    }
+
+    #[test]
+    fn test_federation_without_requester_blocks_followers_only() {
+        setup();
+        insert_status(4, "fo", Visibility::FollowersOnly, 1_000);
+
+        let resp = get_local_status_with_caller(
+            federation(),
+            GetLocalStatusArgs {
+                id: 4,
+                requester_actor_uri: None,
+            },
+        );
+        assert_eq!(
+            resp,
+            GetLocalStatusResponse::Err(GetLocalStatusError::NotFound)
+        );
+    }
+
+    #[test]
+    fn test_anonymous_can_read_public() {
+        setup();
+        insert_status(5, "hi", Visibility::Public, 1_000);
+
+        let resp = get_local_status_with_caller(
+            candid::Principal::anonymous(),
+            GetLocalStatusArgs {
+                id: 5,
+                requester_actor_uri: None,
+            },
+        );
+        assert!(matches!(resp, GetLocalStatusResponse::Ok(_)));
+    }
+
+    #[test]
+    fn test_direct_blocked_for_anyone_but_owner() {
+        setup();
+        insert_follower(FOLLOWER_URI);
+        insert_status(6, "dm", Visibility::Direct, 1_000);
+
+        let resp = get_local_status_with_caller(
+            federation(),
+            GetLocalStatusArgs {
+                id: 6,
+                requester_actor_uri: Some(FOLLOWER_URI.to_string()),
+            },
+        );
+        assert_eq!(
+            resp,
+            GetLocalStatusResponse::Err(GetLocalStatusError::NotFound)
+        );
+    }
+
+    #[test]
+    fn test_returns_not_found_for_missing_id() {
+        setup();
+
+        let resp = get_local_status_with_caller(
+            admin(),
+            GetLocalStatusArgs {
+                id: 999,
+                requester_actor_uri: None,
+            },
+        );
+        assert_eq!(
+            resp,
+            GetLocalStatusResponse::Err(GetLocalStatusError::NotFound)
+        );
+    }
+}

--- a/crates/canisters/user/src/domain/status/get_local_status.rs
+++ b/crates/canisters/user/src/domain/status/get_local_status.rs
@@ -47,7 +47,7 @@ fn get_local_status_inner(
     }: GetLocalStatusArgs,
 ) -> CanisterResult<Option<Status>> {
     let scope = resolve_scope(caller, requester_actor_uri.as_deref());
-    let Some(record) = StatusRepository::find_by_id(id)? else {
+    let Some(record) = StatusRepository::oneshot().find_by_id(id)? else {
         return Ok(None);
     };
 

--- a/crates/canisters/user/src/domain/status/get_local_status.rs
+++ b/crates/canisters/user/src/domain/status/get_local_status.rs
@@ -9,6 +9,7 @@
 //! - Anonymous / other: Public/Unlisted only.
 
 use candid::Principal;
+use db_utils::repository::Repository;
 use did::common::{Status, Visibility};
 use did::user::{GetLocalStatusArgs, GetLocalStatusError, GetLocalStatusResponse};
 
@@ -106,6 +107,7 @@ fn resolve_scope(caller: Principal, requester_actor_uri: Option<&str>) -> Scope 
 
 #[cfg(test)]
 mod tests {
+    use db_utils::repository::Repository;
     use did::common::Visibility;
     use did::user::{GetLocalStatusArgs, GetLocalStatusError, GetLocalStatusResponse};
 

--- a/crates/canisters/user/src/domain/status/get_statuses.rs
+++ b/crates/canisters/user/src/domain/status/get_statuses.rs
@@ -1,6 +1,7 @@
 //! Get statuses flow logic.
 
 use candid::Principal;
+use db_utils::repository::Repository;
 use did::common::{Status, Visibility};
 use did::user::{GetStatusesArgs, GetStatusesError, GetStatusesResponse};
 

--- a/crates/canisters/user/src/domain/status/get_statuses.rs
+++ b/crates/canisters/user/src/domain/status/get_statuses.rs
@@ -128,6 +128,8 @@ fn status_to_did(owner_actor_uri: &str, status: crate::schema::Status) -> Status
         author: owner_actor_uri.to_string(),
         like_count: status.like_count.0,
         boost_count: status.boost_count.0,
+        spoiler_text: status.spoiler_text.into_opt().map(|t| t.0),
+        sensitive: status.sensitive.0,
     }
 }
 

--- a/crates/canisters/user/src/domain/status/get_statuses.rs
+++ b/crates/canisters/user/src/domain/status/get_statuses.rs
@@ -47,7 +47,7 @@ async fn get_statuses_inner(
     let relationship = determine_relationship(caller).await?;
 
     // build owner actor URI
-    let own_profile = crate::domain::profile::ProfileRepository::get_profile()?;
+    let own_profile = crate::domain::profile::ProfileRepository::oneshot().get_profile()?;
     let owner_actor_uri = crate::domain::urls::actor_uri(&own_profile.handle.0)?;
 
     // query statuses

--- a/crates/canisters/user/src/domain/status/get_statuses.rs
+++ b/crates/canisters/user/src/domain/status/get_statuses.rs
@@ -52,18 +52,15 @@ async fn get_statuses_inner(
 
     // query statuses
     let visibility_filter = visibility_filter_for_relationship(relationship);
-    StatusRepository::get_paginated_by_visibility(
-        &visibility_filter,
-        offset as usize,
-        limit as usize,
-    )
-    .map(|statuses| {
-        statuses
-            .into_iter()
-            .map(|s| status_to_did(&owner_actor_uri, s))
-            .collect()
-    })
-    .map(GetStatusesResponse::Ok)
+    StatusRepository::oneshot()
+        .get_paginated_by_visibility(&visibility_filter, offset as usize, limit as usize)
+        .map(|statuses| {
+            statuses
+                .into_iter()
+                .map(|s| status_to_did(&owner_actor_uri, s))
+                .collect()
+        })
+        .map(GetStatusesResponse::Ok)
 }
 
 /// Determines the relationship of the caller with the user, which affects the visibility of statuses.

--- a/crates/canisters/user/src/domain/status/get_statuses.rs
+++ b/crates/canisters/user/src/domain/status/get_statuses.rs
@@ -92,7 +92,7 @@ async fn determine_relationship(caller: Principal) -> CanisterResult<CallerRelat
 
     let actor_uri = crate::domain::urls::actor_uri(&handle)?;
 
-    if FollowerRepository::is_follower(&actor_uri)? {
+    if FollowerRepository::oneshot().is_follower(&actor_uri)? {
         ic_utils::log!("Caller {caller} is a follower");
         return Ok(CallerRelationship::Follower);
     }

--- a/crates/canisters/user/src/domain/status/publish.rs
+++ b/crates/canisters/user/src/domain/status/publish.rs
@@ -9,7 +9,7 @@ use did::federation::{SendActivityArgs, SendActivityArgsObject};
 use did::user::{PublishStatusArgs, PublishStatusError, PublishStatusResponse};
 
 use crate::domain::follower::FollowerRepository;
-use crate::domain::status::StatusRepository;
+use crate::domain::snowflake::Snowflake;
 use crate::error::{CanisterError, CanisterResult};
 use crate::schema::{Schema, StatusContentSanitizer};
 
@@ -73,8 +73,15 @@ async fn save_status_and_publish_to_federation(
 ) -> CanisterResult<Status> {
     // insert
     let created_at = ic_utils::now();
-    let snowflake_id = Transaction::run::<_, _, _, CanisterError>(Schema, |tx| {
-        StatusRepository::with_transaction(tx).create(content.clone(), visibility, created_at)
+    let snowflake_id = Snowflake::new();
+    Transaction::run::<_, _, _, CanisterError>(Schema, |tx| {
+        crate::domain::status::create_status_with_feed(
+            tx,
+            snowflake_id.into(),
+            content.clone(),
+            visibility,
+            created_at,
+        )
     })?;
     ic_utils::log!("Status created with ID: {snowflake_id}");
 

--- a/crates/canisters/user/src/domain/status/publish.rs
+++ b/crates/canisters/user/src/domain/status/publish.rs
@@ -95,7 +95,8 @@ async fn save_status_and_publish_to_federation(
     let recipients = match visibility {
         Visibility::Direct => mentions.clone(),
         Visibility::Public | Visibility::Unlisted | Visibility::FollowersOnly => {
-            FollowerRepository::get_followers()?
+            FollowerRepository::oneshot()
+                .get_followers()?
                 .into_iter()
                 .map(|f| f.actor_uri.0)
                 .collect()

--- a/crates/canisters/user/src/domain/status/publish.rs
+++ b/crates/canisters/user/src/domain/status/publish.rs
@@ -88,6 +88,8 @@ async fn save_status_and_publish_to_federation(
         visibility,
         like_count: 0,
         boost_count: 0,
+        spoiler_text: None,
+        sensitive: false,
     };
 
     let recipients = match visibility {
@@ -484,6 +486,8 @@ mod tests {
             visibility,
             like_count: 0,
             boost_count: 0,
+            spoiler_text: None,
+            sensitive: false,
         }
     }
 
@@ -497,6 +501,8 @@ mod tests {
             visibility: Visibility::Public,
             like_count: 0,
             boost_count: 0,
+            spoiler_text: None,
+            sensitive: false,
         };
 
         let args = make_activity(BOB_URI, &status, &[]);

--- a/crates/canisters/user/src/domain/status/publish.rs
+++ b/crates/canisters/user/src/domain/status/publish.rs
@@ -3,6 +3,7 @@
 use activitypub::activity::{Activity, ActivityObject, ActivityType};
 use activitypub::context::ACTIVITY_STREAMS_CONTEXT;
 use activitypub::object::{BaseObject, ObjectType, OneOrMany};
+use db_utils::repository::Repository;
 use db_utils::transaction::Transaction;
 use did::common::{Status, Visibility};
 use did::federation::{SendActivityArgs, SendActivityArgsObject};

--- a/crates/canisters/user/src/domain/status/publish.rs
+++ b/crates/canisters/user/src/domain/status/publish.rs
@@ -76,7 +76,7 @@ async fn save_status_and_publish_to_federation(
     ic_utils::log!("Status created with ID: {snowflake_id}");
 
     // build owner actor URI
-    let own_profile = crate::domain::profile::ProfileRepository::get_profile()?;
+    let own_profile = crate::domain::profile::ProfileRepository::oneshot().get_profile()?;
     let owner_actor_uri = crate::domain::urls::actor_uri(&own_profile.handle.0)?;
 
     // make status object

--- a/crates/canisters/user/src/domain/status/publish.rs
+++ b/crates/canisters/user/src/domain/status/publish.rs
@@ -3,14 +3,15 @@
 use activitypub::activity::{Activity, ActivityObject, ActivityType};
 use activitypub::context::ACTIVITY_STREAMS_CONTEXT;
 use activitypub::object::{BaseObject, ObjectType, OneOrMany};
+use db_utils::transaction::Transaction;
 use did::common::{Status, Visibility};
 use did::federation::{SendActivityArgs, SendActivityArgsObject};
 use did::user::{PublishStatusArgs, PublishStatusError, PublishStatusResponse};
 
 use crate::domain::follower::FollowerRepository;
 use crate::domain::status::StatusRepository;
-use crate::error::CanisterResult;
-use crate::schema::StatusContentSanitizer;
+use crate::error::{CanisterError, CanisterResult};
+use crate::schema::{Schema, StatusContentSanitizer};
 
 /// The ActivityStreams public addressing constant.
 const AS_PUBLIC: &str = "https://www.w3.org/ns/activitystreams#Public";
@@ -72,7 +73,9 @@ async fn save_status_and_publish_to_federation(
 ) -> CanisterResult<Status> {
     // insert
     let created_at = ic_utils::now();
-    let snowflake_id = StatusRepository::create(content.clone(), visibility, created_at)?;
+    let snowflake_id = Transaction::run::<_, _, _, CanisterError>(Schema, |tx| {
+        StatusRepository::with_transaction(tx).create(content.clone(), visibility, created_at)
+    })?;
     ic_utils::log!("Status created with ID: {snowflake_id}");
 
     // build owner actor URI

--- a/crates/canisters/user/src/domain/status/repository.rs
+++ b/crates/canisters/user/src/domain/status/repository.rs
@@ -372,13 +372,21 @@ mod tests {
         StatusRepository::increment_boost_count(7).expect("inc");
         StatusRepository::decrement_boost_count(7).expect("dec");
         assert_eq!(
-            StatusRepository::find_by_id(7).unwrap().unwrap().boost_count.0,
+            StatusRepository::find_by_id(7)
+                .unwrap()
+                .unwrap()
+                .boost_count
+                .0,
             0
         );
 
         StatusRepository::decrement_boost_count(7).expect("dec at zero");
         assert_eq!(
-            StatusRepository::find_by_id(7).unwrap().unwrap().boost_count.0,
+            StatusRepository::find_by_id(7)
+                .unwrap()
+                .unwrap()
+                .boost_count
+                .0,
             0
         );
     }

--- a/crates/canisters/user/src/domain/status/repository.rs
+++ b/crates/canisters/user/src/domain/status/repository.rs
@@ -1,30 +1,55 @@
 //! Status repository
 
 use did::common::Visibility;
-use ic_dbms_canister::prelude::DBMS_CONTEXT;
+use ic_dbms_canister::prelude::{DBMS_CONTEXT, IcAccessControlList, IcMemoryProvider};
 use wasm_dbms::WasmDbmsDatabase;
+use wasm_dbms::prelude::DbmsContext;
 use wasm_dbms_api::prelude::*;
 
 use crate::domain::snowflake::Snowflake;
-use crate::error::CanisterResult;
+use crate::error::{CanisterError, CanisterResult};
 use crate::schema::{
     FeedEntry, FeedEntryInsertRequest, FeedSource, Schema, Status, StatusInsertRequest,
     StatusRecord, StatusUpdateRequest,
 };
 
 /// Interface for the [`Status`] repository.
-pub struct StatusRepository;
+pub struct StatusRepository {
+    tx: Option<TransactionId>,
+}
 
 impl StatusRepository {
+    pub const fn oneshot() -> Self {
+        Self { tx: None }
+    }
+
+    pub const fn with_transaction(tx: TransactionId) -> Self {
+        Self { tx: Some(tx) }
+    }
+
+    fn db<'a>(
+        &self,
+        ctx: &'a DbmsContext<IcMemoryProvider, IcAccessControlList>,
+    ) -> WasmDbmsDatabase<'a, IcMemoryProvider, IcAccessControlList> {
+        match self.tx {
+            Some(id) => WasmDbmsDatabase::from_transaction(ctx, Schema, id),
+            None => WasmDbmsDatabase::oneshot(ctx, Schema),
+        }
+    }
+
     /// Create a new [`Status`] with the given content, timestamp and visibility.
     ///
-    /// A new [`Snowflake`] ID is generated for the status, and the current timestamp is used as the creation time.
+    /// A new [`Snowflake`] ID is generated for the status, and the current
+    /// timestamp is used as the creation time.
     ///
-    /// Both the `statuses` row and the corresponding `feed` entry are
-    /// inserted inside a single transaction.
+    /// Both the `statuses` row and the corresponding `feed` entry are inserted,
+    /// but transaction lifecycle is owned by the caller — typically via
+    /// `Transaction::run` — to keep the two writes atomic.
     ///
-    /// In case of success the [`Snowflake`] ID of the newly created status is returned.
+    /// In case of success the [`Snowflake`] ID of the newly created status is
+    /// returned.
     pub fn create(
+        &self,
         content: String,
         visibility: Visibility,
         created_at: u64,
@@ -32,9 +57,7 @@ impl StatusRepository {
         let snowflake_id = Snowflake::new();
 
         DBMS_CONTEXT.with(|ctx| {
-            let tx_id =
-                ctx.begin_transaction(db_utils::transaction::transaction_caller(ic_utils::now()));
-            let mut db = WasmDbmsDatabase::from_transaction(ctx, Schema, tx_id);
+            let db = self.db(ctx);
 
             db.insert::<Status>(StatusInsertRequest {
                 id: snowflake_id.into(),
@@ -55,7 +78,7 @@ impl StatusRepository {
                 created_at: created_at.into(),
             })?;
 
-            db.commit()
+            Ok::<(), CanisterError>(())
         })?;
 
         Ok(snowflake_id)
@@ -65,12 +88,13 @@ impl StatusRepository {
     ///
     /// This function is used to implement the `get_statuses` API, and the returned statuses are filtered based on the relationship of the caller with the user (owner, follower, or other).
     pub fn get_paginated_by_visibility(
+        &self,
         visibility: &[Visibility],
         offset: usize,
         limit: usize,
     ) -> CanisterResult<Vec<Status>> {
         DBMS_CONTEXT.with(|ctx| {
-            let db = WasmDbmsDatabase::oneshot(ctx, Schema);
+            let db = self.db(ctx);
 
             let mut query = Query::builder()
                 .all()
@@ -89,10 +113,9 @@ impl StatusRepository {
 
     /// Look up a single [`Status`] by its [`Snowflake`] id, returning [`None`]
     /// if no row matches.
-    pub fn find_by_id(id: u64) -> CanisterResult<Option<Status>> {
+    pub fn find_by_id(&self, id: u64) -> CanisterResult<Option<Status>> {
         DBMS_CONTEXT.with(|ctx| {
-            let db = WasmDbmsDatabase::oneshot(ctx, Schema);
-            let rows = db.select::<Status>(
+            let rows = self.db(ctx).select::<Status>(
                 Query::builder()
                     .all()
                     .and_where(Filter::eq(Status::primary_key(), Value::from(id)))
@@ -108,20 +131,20 @@ impl StatusRepository {
     /// Returns `Ok(true)` when the row exists and was updated, `Ok(false)`
     /// when no row matched (silently ignored: a missing target means we are
     /// not the author of that status, so the counter does not concern us).
-    pub fn increment_like_count(id: u64) -> CanisterResult<bool> {
-        Self::adjust_like_count(id, 1, true)
+    pub fn increment_like_count(&self, id: u64) -> CanisterResult<bool> {
+        self.adjust_like_count(id, 1, true)
     }
 
     /// Saturating-decrement the cached `like_count` of the [`Status`] with the
     /// given id. Decrementing from `0` is a no-op rather than an underflow.
     ///
     /// Returns `Ok(true)` when the row exists, `Ok(false)` when no row matched.
-    pub fn decrement_like_count(id: u64) -> CanisterResult<bool> {
-        Self::adjust_like_count(id, 1, false)
+    pub fn decrement_like_count(&self, id: u64) -> CanisterResult<bool> {
+        self.adjust_like_count(id, 1, false)
     }
 
-    fn adjust_like_count(id: u64, delta: u64, increment: bool) -> CanisterResult<bool> {
-        let Some(status) = Self::find_by_id(id)? else {
+    fn adjust_like_count(&self, id: u64, delta: u64, increment: bool) -> CanisterResult<bool> {
+        let Some(status) = self.find_by_id(id)? else {
             return Ok(false);
         };
         let current = status.like_count.0;
@@ -140,10 +163,7 @@ impl StatusRepository {
             ..Default::default()
         };
 
-        DBMS_CONTEXT.with(|ctx| {
-            let db = WasmDbmsDatabase::oneshot(ctx, Schema);
-            db.update::<Status>(patch)
-        })?;
+        DBMS_CONTEXT.with(|ctx| self.db(ctx).update::<Status>(patch))?;
         Ok(true)
     }
 
@@ -152,20 +172,20 @@ impl StatusRepository {
     /// Returns `Ok(true)` when the row exists and was updated, `Ok(false)`
     /// when no row matched (silently ignored: a missing target means we are
     /// not the author of that status, so the counter does not concern us).
-    pub fn increment_boost_count(id: u64) -> CanisterResult<bool> {
-        Self::adjust_boost_count(id, 1, true)
+    pub fn increment_boost_count(&self, id: u64) -> CanisterResult<bool> {
+        self.adjust_boost_count(id, 1, true)
     }
 
     /// Saturating-decrement the cached `boost_count` of the [`Status`] with the
     /// given id. Decrementing from `0` is a no-op rather than an underflow.
     ///
     /// Returns `Ok(true)` when the row exists, `Ok(false)` when no row matched.
-    pub fn decrement_boost_count(id: u64) -> CanisterResult<bool> {
-        Self::adjust_boost_count(id, 1, false)
+    pub fn decrement_boost_count(&self, id: u64) -> CanisterResult<bool> {
+        self.adjust_boost_count(id, 1, false)
     }
 
-    fn adjust_boost_count(id: u64, delta: u64, increment: bool) -> CanisterResult<bool> {
-        let Some(status) = Self::find_by_id(id)? else {
+    fn adjust_boost_count(&self, id: u64, delta: u64, increment: bool) -> CanisterResult<bool> {
+        let Some(status) = self.find_by_id(id)? else {
             return Ok(false);
         };
         let current = status.boost_count.0;
@@ -182,10 +202,7 @@ impl StatusRepository {
             where_clause: Some(Filter::eq(Status::primary_key(), Value::from(id))),
             ..Default::default()
         };
-        DBMS_CONTEXT.with(|ctx| {
-            let db = WasmDbmsDatabase::oneshot(ctx, Schema);
-            db.update::<Status>(patch)
-        })?;
+        DBMS_CONTEXT.with(|ctx| self.db(ctx).update::<Status>(patch))?;
         Ok(true)
     }
 
@@ -208,16 +225,18 @@ impl StatusRepository {
 #[cfg(test)]
 mod tests {
 
+    use db_utils::transaction::Transaction;
     use did::common::Visibility;
 
-    use super::StatusRepository;
+    use super::*;
     use crate::test_utils::{insert_status, setup};
 
     #[test]
     fn test_should_return_empty_when_no_statuses() {
         setup();
 
-        let result = StatusRepository::get_paginated_by_visibility(&[Visibility::Public], 0, 10)
+        let result = StatusRepository::oneshot()
+            .get_paginated_by_visibility(&[Visibility::Public], 0, 10)
             .expect("should query");
 
         assert!(result.is_empty());
@@ -230,7 +249,8 @@ mod tests {
         insert_status(2, "Mid", Visibility::Public, 2000);
         insert_status(3, "New", Visibility::Public, 3000);
 
-        let result = StatusRepository::get_paginated_by_visibility(&[Visibility::Public], 0, 10)
+        let result = StatusRepository::oneshot()
+            .get_paginated_by_visibility(&[Visibility::Public], 0, 10)
             .expect("should query");
 
         assert_eq!(result.len(), 3);
@@ -247,7 +267,8 @@ mod tests {
         }
 
         // skip 1, take 2 → newest-first: 5,4,3,2,1 → skip 1 → 4,3
-        let result = StatusRepository::get_paginated_by_visibility(&[Visibility::Public], 1, 2)
+        let result = StatusRepository::oneshot()
+            .get_paginated_by_visibility(&[Visibility::Public], 1, 2)
             .expect("should query");
 
         assert_eq!(result.len(), 2);
@@ -263,7 +284,8 @@ mod tests {
         insert_status(3, "FollowersOnly", Visibility::FollowersOnly, 3000);
         insert_status(4, "Direct", Visibility::Direct, 4000);
 
-        let result = StatusRepository::get_paginated_by_visibility(&[Visibility::Public], 0, 10)
+        let result = StatusRepository::oneshot()
+            .get_paginated_by_visibility(&[Visibility::Public], 0, 10)
             .expect("should query");
 
         assert_eq!(result.len(), 1);
@@ -278,16 +300,17 @@ mod tests {
         insert_status(3, "FollowersOnly", Visibility::FollowersOnly, 3000);
         insert_status(4, "Direct", Visibility::Direct, 4000);
 
-        let result = StatusRepository::get_paginated_by_visibility(
-            &[
-                Visibility::Public,
-                Visibility::Unlisted,
-                Visibility::FollowersOnly,
-            ],
-            0,
-            10,
-        )
-        .expect("should query");
+        let result = StatusRepository::oneshot()
+            .get_paginated_by_visibility(
+                &[
+                    Visibility::Public,
+                    Visibility::Unlisted,
+                    Visibility::FollowersOnly,
+                ],
+                0,
+                10,
+            )
+            .expect("should query");
 
         assert_eq!(result.len(), 3);
         // ordered newest-first
@@ -304,17 +327,18 @@ mod tests {
         insert_status(3, "FollowersOnly", Visibility::FollowersOnly, 3000);
         insert_status(4, "Direct", Visibility::Direct, 4000);
 
-        let result = StatusRepository::get_paginated_by_visibility(
-            &[
-                Visibility::Public,
-                Visibility::Unlisted,
-                Visibility::FollowersOnly,
-                Visibility::Direct,
-            ],
-            0,
-            10,
-        )
-        .expect("should query");
+        let result = StatusRepository::oneshot()
+            .get_paginated_by_visibility(
+                &[
+                    Visibility::Public,
+                    Visibility::Unlisted,
+                    Visibility::FollowersOnly,
+                    Visibility::Direct,
+                ],
+                0,
+                10,
+            )
+            .expect("should query");
 
         assert_eq!(result.len(), 4);
     }
@@ -324,7 +348,8 @@ mod tests {
         setup();
         insert_status(1, "Only one", Visibility::Public, 1000);
 
-        let result = StatusRepository::get_paginated_by_visibility(&[Visibility::Public], 100, 10)
+        let result = StatusRepository::oneshot()
+            .get_paginated_by_visibility(&[Visibility::Public], 100, 10)
             .expect("should query");
 
         assert!(result.is_empty());
@@ -334,12 +359,18 @@ mod tests {
     fn test_create_should_insert_status_and_feed_entry() {
         setup();
 
-        let snowflake =
-            StatusRepository::create("Hello world".to_string(), Visibility::Public, 42_000)
-                .expect("should create");
+        let snowflake = Transaction::run::<_, _, _, CanisterError>(Schema, |tx| {
+            StatusRepository::with_transaction(tx).create(
+                "Hello world".to_string(),
+                Visibility::Public,
+                42_000,
+            )
+        })
+        .expect("should create");
 
         // verify the status was inserted
-        let statuses = StatusRepository::get_paginated_by_visibility(&[Visibility::Public], 0, 10)
+        let statuses = StatusRepository::oneshot()
+            .get_paginated_by_visibility(&[Visibility::Public], 0, 10)
             .expect("should query");
 
         assert_eq!(statuses.len(), 1);
@@ -349,30 +380,82 @@ mod tests {
     }
 
     #[test]
+    fn test_create_should_rollback_on_error() {
+        setup();
+
+        // First create a status with a known ID via transaction
+        let snowflake = Transaction::run::<_, _, _, CanisterError>(Schema, |tx| {
+            StatusRepository::with_transaction(tx).create(
+                "first".to_string(),
+                Visibility::Public,
+                1_000,
+            )
+        })
+        .expect("first create");
+
+        let initial_count = StatusRepository::oneshot()
+            .get_paginated_by_visibility(&[Visibility::Public], 0, 100)
+            .expect("query")
+            .len();
+        assert_eq!(initial_count, 1);
+        let _ = snowflake;
+
+        // run a transaction that errors out — nothing must be persisted
+        let result: Result<(), CanisterError> = Transaction::run(Schema, |tx| {
+            StatusRepository::with_transaction(tx).create(
+                "rollback".to_string(),
+                Visibility::Public,
+                2_000,
+            )?;
+            Err(CanisterError::Internal("boom".to_string()))
+        });
+        assert!(result.is_err());
+
+        let after_count = StatusRepository::oneshot()
+            .get_paginated_by_visibility(&[Visibility::Public], 0, 100)
+            .expect("query")
+            .len();
+        assert_eq!(after_count, 1, "errored tx must not persist its insert");
+    }
+
+    #[test]
     fn test_should_increment_boost_count() {
         setup();
         insert_status(7, "Hi", Visibility::Public, 1_000);
 
-        assert!(StatusRepository::increment_boost_count(7).expect("should adjust"));
+        assert!(
+            StatusRepository::oneshot()
+                .increment_boost_count(7)
+                .expect("should adjust")
+        );
 
-        let row = StatusRepository::find_by_id(7).unwrap().unwrap();
+        let row = StatusRepository::oneshot().find_by_id(7).unwrap().unwrap();
         assert_eq!(row.boost_count.0, 1);
     }
 
     #[test]
     fn test_increment_boost_count_returns_false_when_missing() {
         setup();
-        assert!(!StatusRepository::increment_boost_count(99).expect("should adjust"));
+        assert!(
+            !StatusRepository::oneshot()
+                .increment_boost_count(99)
+                .expect("should adjust")
+        );
     }
 
     #[test]
     fn test_should_decrement_boost_count_saturating() {
         setup();
         insert_status(7, "Hi", Visibility::Public, 1_000);
-        StatusRepository::increment_boost_count(7).expect("inc");
-        StatusRepository::decrement_boost_count(7).expect("dec");
+        StatusRepository::oneshot()
+            .increment_boost_count(7)
+            .expect("inc");
+        StatusRepository::oneshot()
+            .decrement_boost_count(7)
+            .expect("dec");
         assert_eq!(
-            StatusRepository::find_by_id(7)
+            StatusRepository::oneshot()
+                .find_by_id(7)
                 .unwrap()
                 .unwrap()
                 .boost_count
@@ -380,9 +463,12 @@ mod tests {
             0
         );
 
-        StatusRepository::decrement_boost_count(7).expect("dec at zero");
+        StatusRepository::oneshot()
+            .decrement_boost_count(7)
+            .expect("dec at zero");
         assert_eq!(
-            StatusRepository::find_by_id(7)
+            StatusRepository::oneshot()
+                .find_by_id(7)
                 .unwrap()
                 .unwrap()
                 .boost_count

--- a/crates/canisters/user/src/domain/status/repository.rs
+++ b/crates/canisters/user/src/domain/status/repository.rs
@@ -147,6 +147,48 @@ impl StatusRepository {
         Ok(true)
     }
 
+    /// Increment the cached `boost_count` of the [`Status`] with the given id.
+    ///
+    /// Returns `Ok(true)` when the row exists and was updated, `Ok(false)`
+    /// when no row matched (silently ignored: a missing target means we are
+    /// not the author of that status, so the counter does not concern us).
+    pub fn increment_boost_count(id: u64) -> CanisterResult<bool> {
+        Self::adjust_boost_count(id, 1, true)
+    }
+
+    /// Saturating-decrement the cached `boost_count` of the [`Status`] with the
+    /// given id. Decrementing from `0` is a no-op rather than an underflow.
+    ///
+    /// Returns `Ok(true)` when the row exists, `Ok(false)` when no row matched.
+    pub fn decrement_boost_count(id: u64) -> CanisterResult<bool> {
+        Self::adjust_boost_count(id, 1, false)
+    }
+
+    fn adjust_boost_count(id: u64, delta: u64, increment: bool) -> CanisterResult<bool> {
+        let Some(status) = Self::find_by_id(id)? else {
+            return Ok(false);
+        };
+        let current = status.boost_count.0;
+        let next = if increment {
+            current.saturating_add(delta)
+        } else {
+            current.saturating_sub(delta)
+        };
+        if next == current {
+            return Ok(true);
+        }
+        let patch = StatusUpdateRequest {
+            boost_count: Some(next.into()),
+            where_clause: Some(Filter::eq(Status::primary_key(), Value::from(id))),
+            ..Default::default()
+        };
+        DBMS_CONTEXT.with(|ctx| {
+            let db = WasmDbmsDatabase::oneshot(ctx, Schema);
+            db.update::<Status>(patch)
+        })?;
+        Ok(true)
+    }
+
     fn record_to_status(record: StatusRecord) -> Status {
         Status {
             id: record.id.expect("must have field"),
@@ -304,5 +346,40 @@ mod tests {
         assert_eq!(statuses[0].id, snowflake.into());
         assert_eq!(statuses[0].content.0, "Hello world");
         assert_eq!(statuses[0].created_at.0, 42_000);
+    }
+
+    #[test]
+    fn test_should_increment_boost_count() {
+        setup();
+        insert_status(7, "Hi", Visibility::Public, 1_000);
+
+        assert!(StatusRepository::increment_boost_count(7).expect("should adjust"));
+
+        let row = StatusRepository::find_by_id(7).unwrap().unwrap();
+        assert_eq!(row.boost_count.0, 1);
+    }
+
+    #[test]
+    fn test_increment_boost_count_returns_false_when_missing() {
+        setup();
+        assert!(!StatusRepository::increment_boost_count(99).expect("should adjust"));
+    }
+
+    #[test]
+    fn test_should_decrement_boost_count_saturating() {
+        setup();
+        insert_status(7, "Hi", Visibility::Public, 1_000);
+        StatusRepository::increment_boost_count(7).expect("inc");
+        StatusRepository::decrement_boost_count(7).expect("dec");
+        assert_eq!(
+            StatusRepository::find_by_id(7).unwrap().unwrap().boost_count.0,
+            0
+        );
+
+        StatusRepository::decrement_boost_count(7).expect("dec at zero");
+        assert_eq!(
+            StatusRepository::find_by_id(7).unwrap().unwrap().boost_count.0,
+            0
+        );
     }
 }

--- a/crates/canisters/user/src/domain/status/repository.rs
+++ b/crates/canisters/user/src/domain/status/repository.rs
@@ -6,12 +6,8 @@ use wasm_dbms::WasmDbmsDatabase;
 use wasm_dbms::prelude::DbmsContext;
 use wasm_dbms_api::prelude::*;
 
-use crate::domain::snowflake::Snowflake;
-use crate::error::{CanisterError, CanisterResult};
-use crate::schema::{
-    FeedEntry, FeedEntryInsertRequest, FeedSource, Schema, Status, StatusInsertRequest,
-    StatusRecord, StatusUpdateRequest,
-};
+use crate::error::CanisterResult;
+use crate::schema::{Schema, Status, StatusInsertRequest, StatusRecord, StatusUpdateRequest};
 
 /// Interface for the [`Status`] repository.
 pub struct StatusRepository {
@@ -37,29 +33,21 @@ impl StatusRepository {
         }
     }
 
-    /// Create a new [`Status`] with the given content, timestamp and visibility.
+    /// Insert a row into the `statuses` table with default flags
+    /// (`like_count = 0`, `boost_count = 0`, no reply, no spoiler, not
+    /// sensitive, never edited).
     ///
-    /// A new [`Snowflake`] ID is generated for the status, and the current
-    /// timestamp is used as the creation time.
-    ///
-    /// Both the `statuses` row and the corresponding `feed` entry are inserted,
-    /// but transaction lifecycle is owned by the caller — typically via
-    /// `Transaction::run` — to keep the two writes atomic.
-    ///
-    /// In case of success the [`Snowflake`] ID of the newly created status is
-    /// returned.
-    pub fn create(
+    /// The caller mints `snowflake_id` and is responsible for any cross-table
+    /// orchestration (e.g. the matching `feed` entry) via `Transaction::run`.
+    pub fn insert(
         &self,
+        snowflake_id: u64,
         content: String,
         visibility: Visibility,
         created_at: u64,
-    ) -> CanisterResult<Snowflake> {
-        let snowflake_id = Snowflake::new();
-
+    ) -> CanisterResult<()> {
         DBMS_CONTEXT.with(|ctx| {
-            let db = self.db(ctx);
-
-            db.insert::<Status>(StatusInsertRequest {
+            self.db(ctx).insert::<Status>(StatusInsertRequest {
                 id: snowflake_id.into(),
                 content: content.into(),
                 visibility: visibility.into(),
@@ -71,17 +59,63 @@ impl StatusRepository {
                 edited_at: Nullable::Null,
                 created_at: created_at.into(),
             })?;
+            Ok(())
+        })
+    }
 
-            db.insert::<FeedEntry>(FeedEntryInsertRequest {
+    /// Insert a wrapper-style `statuses` row used for boost wrappers, where
+    /// `spoiler_text` and `sensitive` may be set from the boosted status.
+    ///
+    /// The caller mints `snowflake_id` and is responsible for any cross-table
+    /// orchestration (e.g. matching `boosts` and `feed` rows) via
+    /// `Transaction::run`.
+    //
+    // Wired in by the boost refactor; covered by the in-module test suite
+    // until then.
+    #[allow(dead_code)]
+    pub fn insert_wrapper(
+        &self,
+        snowflake_id: u64,
+        content: &str,
+        visibility: Visibility,
+        spoiler_text: Option<&str>,
+        sensitive: bool,
+        created_at: u64,
+    ) -> CanisterResult<()> {
+        DBMS_CONTEXT.with(|ctx| {
+            self.db(ctx).insert::<Status>(StatusInsertRequest {
                 id: snowflake_id.into(),
-                source: FeedSource::Outbox,
+                content: content.into(),
+                visibility: visibility.into(),
+                like_count: 0u64.into(),
+                boost_count: 0u64.into(),
+                in_reply_to_uri: Nullable::Null,
+                spoiler_text: spoiler_text.map_or(Nullable::Null, |s| Nullable::Value(s.into())),
+                sensitive: sensitive.into(),
+                edited_at: Nullable::Null,
                 created_at: created_at.into(),
             })?;
+            Ok(())
+        })
+    }
 
-            Ok::<(), CanisterError>(())
-        })?;
-
-        Ok(snowflake_id)
+    /// Delete the [`Status`] row whose primary key matches `snowflake_id`.
+    ///
+    /// Uses [`DeleteBehavior::Restrict`] — callers must drop dependent rows
+    /// (`boosts`, `feed`) in the right order so referential integrity is
+    /// preserved.
+    //
+    // Wired in by the boost refactor (undo_boost flow); covered by the
+    // in-module test suite until then.
+    #[allow(dead_code)]
+    pub fn delete_by_id(&self, snowflake_id: u64) -> CanisterResult<()> {
+        DBMS_CONTEXT.with(|ctx| {
+            self.db(ctx).delete::<Status>(
+                DeleteBehavior::Restrict,
+                Some(Filter::eq(Status::primary_key(), Value::from(snowflake_id))),
+            )?;
+            Ok(())
+        })
     }
 
     /// Get a paginated list of [`Status`]es with the given visibility, ordered from the most recent to the oldest.
@@ -225,7 +259,6 @@ impl StatusRepository {
 #[cfg(test)]
 mod tests {
 
-    use db_utils::transaction::Transaction;
     use did::common::Visibility;
 
     use super::*;
@@ -356,66 +389,71 @@ mod tests {
     }
 
     #[test]
-    fn test_create_should_insert_status_and_feed_entry() {
+    fn test_delete_by_id_should_remove_status_row() {
         setup();
+        insert_status(11, "to delete", Visibility::Public, 1_000);
 
-        let snowflake = Transaction::run::<_, _, _, CanisterError>(Schema, |tx| {
-            StatusRepository::with_transaction(tx).create(
-                "Hello world".to_string(),
-                Visibility::Public,
-                42_000,
-            )
-        })
-        .expect("should create");
+        StatusRepository::oneshot()
+            .delete_by_id(11)
+            .expect("should delete");
 
-        // verify the status was inserted
-        let statuses = StatusRepository::oneshot()
-            .get_paginated_by_visibility(&[Visibility::Public], 0, 10)
-            .expect("should query");
-
-        assert_eq!(statuses.len(), 1);
-        assert_eq!(statuses[0].id, snowflake.into());
-        assert_eq!(statuses[0].content.0, "Hello world");
-        assert_eq!(statuses[0].created_at.0, 42_000);
+        assert!(
+            StatusRepository::oneshot()
+                .find_by_id(11)
+                .expect("query")
+                .is_none()
+        );
     }
 
     #[test]
-    fn test_create_should_rollback_on_error() {
+    fn test_delete_by_id_should_be_noop_when_missing() {
         setup();
 
-        // First create a status with a known ID via transaction
-        let snowflake = Transaction::run::<_, _, _, CanisterError>(Schema, |tx| {
-            StatusRepository::with_transaction(tx).create(
-                "first".to_string(),
-                Visibility::Public,
-                1_000,
-            )
-        })
-        .expect("first create");
+        StatusRepository::oneshot()
+            .delete_by_id(999)
+            .expect("delete missing must succeed");
+    }
 
-        let initial_count = StatusRepository::oneshot()
-            .get_paginated_by_visibility(&[Visibility::Public], 0, 100)
+    #[test]
+    fn test_insert_should_persist_default_flags() {
+        setup();
+
+        StatusRepository::oneshot()
+            .insert(123, "hello".to_string(), Visibility::Public, 7_000)
+            .expect("should insert");
+
+        let row = StatusRepository::oneshot()
+            .find_by_id(123)
             .expect("query")
-            .len();
-        assert_eq!(initial_count, 1);
-        let _ = snowflake;
+            .expect("row exists");
+        assert_eq!(row.content.0, "hello");
+        assert_eq!(row.created_at.0, 7_000);
+        assert_eq!(row.like_count.0, 0);
+        assert_eq!(row.boost_count.0, 0);
+        assert!(!row.sensitive.0);
+        assert!(row.spoiler_text.clone().into_opt().is_none());
+        assert!(row.in_reply_to_uri.clone().into_opt().is_none());
+        assert!(row.edited_at.into_opt().is_none());
+    }
 
-        // run a transaction that errors out — nothing must be persisted
-        let result: Result<(), CanisterError> = Transaction::run(Schema, |tx| {
-            StatusRepository::with_transaction(tx).create(
-                "rollback".to_string(),
-                Visibility::Public,
-                2_000,
-            )?;
-            Err(CanisterError::Internal("boom".to_string()))
-        });
-        assert!(result.is_err());
+    #[test]
+    fn test_insert_wrapper_should_persist_spoiler_and_sensitive() {
+        setup();
 
-        let after_count = StatusRepository::oneshot()
-            .get_paginated_by_visibility(&[Visibility::Public], 0, 100)
+        StatusRepository::oneshot()
+            .insert_wrapper(321, "wrapper", Visibility::Public, Some("cw"), true, 8_000)
+            .expect("should insert wrapper");
+
+        let row = StatusRepository::oneshot()
+            .find_by_id(321)
             .expect("query")
-            .len();
-        assert_eq!(after_count, 1, "errored tx must not persist its insert");
+            .expect("row exists");
+        assert_eq!(row.content.0, "wrapper");
+        assert_eq!(
+            row.spoiler_text.clone().into_opt().expect("spoiler").0,
+            "cw"
+        );
+        assert!(row.sensitive.0);
     }
 
     #[test]

--- a/crates/canisters/user/src/domain/status/repository.rs
+++ b/crates/canisters/user/src/domain/status/repository.rs
@@ -1,9 +1,8 @@
 //! Status repository
 
+use db_utils::repository::Repository;
 use did::common::Visibility;
-use ic_dbms_canister::prelude::{DBMS_CONTEXT, IcAccessControlList, IcMemoryProvider};
-use wasm_dbms::WasmDbmsDatabase;
-use wasm_dbms::prelude::DbmsContext;
+use ic_dbms_canister::prelude::DBMS_CONTEXT;
 use wasm_dbms_api::prelude::*;
 
 use crate::error::CanisterResult;
@@ -15,24 +14,6 @@ pub struct StatusRepository {
 }
 
 impl StatusRepository {
-    pub const fn oneshot() -> Self {
-        Self { tx: None }
-    }
-
-    pub const fn with_transaction(tx: TransactionId) -> Self {
-        Self { tx: Some(tx) }
-    }
-
-    fn db<'a>(
-        &self,
-        ctx: &'a DbmsContext<IcMemoryProvider, IcAccessControlList>,
-    ) -> WasmDbmsDatabase<'a, IcMemoryProvider, IcAccessControlList> {
-        match self.tx {
-            Some(id) => WasmDbmsDatabase::from_transaction(ctx, Schema, id),
-            None => WasmDbmsDatabase::oneshot(ctx, Schema),
-        }
-    }
-
     /// Insert a row into the `statuses` table with default flags
     /// (`like_count = 0`, `boost_count = 0`, no reply, no spoiler, not
     /// sensitive, never edited).
@@ -69,10 +50,6 @@ impl StatusRepository {
     /// The caller mints `snowflake_id` and is responsible for any cross-table
     /// orchestration (e.g. matching `boosts` and `feed` rows) via
     /// `Transaction::run`.
-    //
-    // Wired in by the boost refactor; covered by the in-module test suite
-    // until then.
-    #[allow(dead_code)]
     pub fn insert_wrapper(
         &self,
         snowflake_id: u64,
@@ -104,10 +81,6 @@ impl StatusRepository {
     /// Uses [`DeleteBehavior::Restrict`] — callers must drop dependent rows
     /// (`boosts`, `feed`) in the right order so referential integrity is
     /// preserved.
-    //
-    // Wired in by the boost refactor (undo_boost flow); covered by the
-    // in-module test suite until then.
-    #[allow(dead_code)]
     pub fn delete_by_id(&self, snowflake_id: u64) -> CanisterResult<()> {
         DBMS_CONTEXT.with(|ctx| {
             self.db(ctx).delete::<Status>(
@@ -253,6 +226,26 @@ impl StatusRepository {
             edited_at: record.edited_at.expect("must have field"),
             created_at: record.created_at.expect("must have field"),
         }
+    }
+}
+
+impl Repository for StatusRepository {
+    type Schema = Schema;
+
+    fn schema() -> Self::Schema {
+        Schema
+    }
+
+    fn oneshot() -> Self {
+        Self { tx: None }
+    }
+
+    fn with_transaction(tx: TransactionId) -> Self {
+        Self { tx: Some(tx) }
+    }
+
+    fn tx(&self) -> Option<TransactionId> {
+        self.tx
     }
 }
 

--- a/crates/canisters/user/src/domain/urls.rs
+++ b/crates/canisters/user/src/domain/urls.rs
@@ -66,6 +66,17 @@ pub fn actor_uri_from_status_uri(uri: &str) -> Option<String> {
     Some(head.to_string())
 }
 
+/// Parse the numeric id from any `…/statuses/<id>` URI, returning [`None`]
+/// when the URI does not end in `…/statuses/<digits>` (or has trailing
+/// path after the id).
+pub fn parse_status_id(uri: &str) -> Option<u64> {
+    let (_, tail) = uri.rsplit_once("/statuses/")?;
+    if tail.is_empty() || tail.contains('/') {
+        return None;
+    }
+    tail.parse::<u64>().ok()
+}
+
 /// Parse a local status URI of the form
 /// `{public_url}/users/{handle}/statuses/{id}`, returning `(handle, id)` when
 /// the URI is hosted on this instance and the path matches the canonical
@@ -175,6 +186,15 @@ mod tests {
     #[test]
     fn test_actor_uri_from_status_uri_rejects_missing_id() {
         assert!(actor_uri_from_status_uri("https://mastic.social/users/alice/statuses/").is_none());
+    }
+
+    #[test]
+    fn test_parse_status_id() {
+        assert_eq!(parse_status_id("https://x/users/a/statuses/42"), Some(42));
+        assert_eq!(parse_status_id("https://x/users/a/statuses/42/foo"), None);
+        assert_eq!(parse_status_id("https://x/users/a/statuses/"), None);
+        assert_eq!(parse_status_id("https://x/users/a"), None);
+        assert_eq!(parse_status_id("not-a-url/statuses/notnum"), None);
     }
 
     #[test]

--- a/crates/canisters/user/src/error.rs
+++ b/crates/canisters/user/src/error.rs
@@ -22,4 +22,7 @@ pub enum CanisterError {
     /// Settings error.
     #[error("Settings error: {0}")]
     Settings(#[from] db_utils::settings::SettingsError),
+    /// Internal error.
+    #[error("Internal error: {0}")]
+    Internal(String),
 }

--- a/crates/canisters/user/src/inspect.rs
+++ b/crates/canisters/user/src/inspect.rs
@@ -5,12 +5,14 @@ pub fn inspect() {
 
     match method_name.as_str() {
         "accept_follow"
+        | "boost_status"
         | "follow_user"
         | "get_follow_requests"
         | "like_status"
         | "publish_status"
         | "read_feed"
         | "reject_follow"
+        | "undo_boost"
         | "unfollow_user"
         | "unlike_status"
         | "update_profile" => {

--- a/crates/canisters/user/src/lib.rs
+++ b/crates/canisters/user/src/lib.rs
@@ -61,6 +61,11 @@ fn get_following(args: GetFollowingArgs) -> GetFollowingResponse {
 }
 
 #[ic_cdk::query]
+fn get_local_status(args: GetLocalStatusArgs) -> GetLocalStatusResponse {
+    api::get_local_status(args)
+}
+
+#[ic_cdk::query]
 fn get_liked(args: GetLikedArgs) -> GetLikedResponse {
     api::get_liked(args)
 }

--- a/crates/canisters/user/src/lib.rs
+++ b/crates/canisters/user/src/lib.rs
@@ -61,13 +61,13 @@ fn get_following(args: GetFollowingArgs) -> GetFollowingResponse {
 }
 
 #[ic_cdk::query]
-fn get_local_status(args: GetLocalStatusArgs) -> GetLocalStatusResponse {
-    api::get_local_status(args)
+fn get_liked(args: GetLikedArgs) -> GetLikedResponse {
+    api::get_liked(args)
 }
 
 #[ic_cdk::query]
-fn get_liked(args: GetLikedArgs) -> GetLikedResponse {
-    api::get_liked(args)
+fn get_local_status(args: GetLocalStatusArgs) -> GetLocalStatusResponse {
+    api::get_local_status(args)
 }
 
 #[ic_cdk::query]

--- a/crates/canisters/user/src/lib.rs
+++ b/crates/canisters/user/src/lib.rs
@@ -31,6 +31,11 @@ async fn accept_follow(args: AcceptFollowArgs) -> AcceptFollowResponse {
 }
 
 #[ic_cdk::update]
+async fn boost_status(args: BoostStatusArgs) -> BoostStatusResponse {
+    api::boost_status(args).await
+}
+
+#[ic_cdk::update]
 async fn follow_user(args: FollowUserArgs) -> FollowUserResponse {
     api::follow_user(args).await
 }
@@ -93,6 +98,11 @@ fn receive_activity(args: ReceiveActivityArgs) -> ReceiveActivityResponse {
 #[ic_cdk::update]
 async fn reject_follow(args: RejectFollowArgs) -> RejectFollowResponse {
     api::reject_follow(args).await
+}
+
+#[ic_cdk::update]
+async fn undo_boost(args: UndoBoostArgs) -> UndoBoostResponse {
+    api::undo_boost(args).await
 }
 
 #[ic_cdk::update]

--- a/crates/canisters/user/src/schema.rs
+++ b/crates/canisters/user/src/schema.rs
@@ -398,7 +398,7 @@ pub struct ProfileMetadata {
     pub value: Text,
 }
 
-#[derive(DatabaseSchema, Clone)]
+#[derive(DatabaseSchema, Clone, Copy)]
 #[tables(
     Settings = "settings",
     Profile = "profiles",

--- a/crates/canisters/user/src/test_utils.rs
+++ b/crates/canisters/user/src/test_utils.rs
@@ -25,6 +25,7 @@ pub fn directory() -> Principal {
 
 pub fn setup() {
     crate::adapters::federation::mock::reset_captured();
+    crate::adapters::federation::mock::reset_fetch_status();
     crate::api::init(UserInstallArgs::Init {
         owner: admin(),
         federation_canister: federation(),

--- a/crates/libs/db-utils/src/lib.rs
+++ b/crates/libs/db-utils/src/lib.rs
@@ -6,6 +6,7 @@ pub mod handle;
 pub mod hashtag;
 pub mod media;
 pub mod migration;
+pub mod repository;
 pub mod settings;
 pub mod transaction;
 pub mod url;

--- a/crates/libs/db-utils/src/repository.rs
+++ b/crates/libs/db-utils/src/repository.rs
@@ -1,0 +1,47 @@
+//! Repository trait — common shape for canister-local repositories.
+
+use ic_dbms_canister::prelude::{IcAccessControlList, IcMemoryProvider};
+use wasm_dbms::WasmDbmsDatabase;
+use wasm_dbms::prelude::{DatabaseSchema, DbmsContext};
+use wasm_dbms_api::prelude::TransactionId;
+
+/// Common shape for repositories backed by the canister-local
+/// `DBMS_CONTEXT`.
+///
+/// Implementors provide the [`DatabaseSchema`] via [`Self::schema`], the
+/// two constructors [`Self::oneshot`] / [`Self::with_transaction`], and the
+/// transaction-id read-back [`Self::tx`]. The trait then provides a default
+/// [`Self::db`] accessor that routes between an oneshot auto-committed
+/// handle and a transaction-bound handle.
+pub trait Repository: Sized {
+    /// Schema type used by this repository.
+    type Schema: DatabaseSchema<IcMemoryProvider, IcAccessControlList> + Copy + 'static;
+
+    /// Schema instance shared by oneshot and transactional handles.
+    fn schema() -> Self::Schema;
+
+    /// Build an oneshot repository: each operation runs in its own
+    /// auto-committed transaction.
+    fn oneshot() -> Self;
+
+    /// Build a repository whose operations splice into an externally-driven
+    /// transaction. Lifecycle (commit/rollback) is owned by the caller —
+    /// typically via [`crate::transaction::Transaction::run`].
+    fn with_transaction(tx: TransactionId) -> Self;
+
+    /// Externally-driven transaction id, when the repository was constructed
+    /// with [`Self::with_transaction`]. Oneshot repositories return `None`.
+    fn tx(&self) -> Option<TransactionId>;
+
+    /// Build a [`WasmDbmsDatabase`] handle bound to this repository's
+    /// transaction lifetime.
+    fn db<'a>(
+        &self,
+        ctx: &'a DbmsContext<IcMemoryProvider, IcAccessControlList>,
+    ) -> WasmDbmsDatabase<'a, IcMemoryProvider, IcAccessControlList> {
+        match self.tx() {
+            Some(id) => WasmDbmsDatabase::from_transaction(ctx, Self::schema(), id),
+            None => WasmDbmsDatabase::oneshot(ctx, Self::schema()),
+        }
+    }
+}

--- a/crates/libs/db-utils/src/transaction.rs
+++ b/crates/libs/db-utils/src/transaction.rs
@@ -1,5 +1,11 @@
 //! Transaction utilities.
 
+use ic_dbms_canister::prelude::{DBMS_CONTEXT, IcAccessControlList, IcMemoryProvider};
+use wasm_dbms::WasmDbmsDatabase;
+use wasm_dbms::prelude::DatabaseSchema;
+use wasm_dbms_api::error::DbmsError;
+use wasm_dbms_api::prelude::{Database, TransactionId};
+
 /// Build a transaction caller ID from a timestamp.
 ///
 /// Converts the given `u64` timestamp into its 8-byte big-endian
@@ -9,10 +15,103 @@ pub fn transaction_caller(timestamp: u64) -> Vec<u8> {
     timestamp.to_be_bytes().to_vec()
 }
 
+/// Transaction lifecycle primitive operating on the canister-local
+/// `DBMS_CONTEXT`. Repositories never commit themselves — callers drive
+/// lifecycle through `Transaction::begin`/`commit`/`rollback` or the
+/// `Transaction::run` sugar.
+pub struct Transaction;
+
+impl Transaction {
+    /// Open a new transaction owned by the current `ic_utils::now()`
+    /// timestamp.
+    pub fn begin() -> TransactionId {
+        DBMS_CONTEXT.with(|ctx| ctx.begin_transaction(transaction_caller(ic_utils::now())))
+    }
+
+    /// Commit the transaction `tx` against `schema`.
+    pub fn commit<S>(schema: S, tx: TransactionId) -> Result<(), DbmsError>
+    where
+        S: DatabaseSchema<IcMemoryProvider, IcAccessControlList>,
+    {
+        DBMS_CONTEXT.with(|ctx| {
+            let mut db = WasmDbmsDatabase::from_transaction(ctx, schema, tx);
+            db.commit()
+        })
+    }
+
+    /// Roll back the transaction `tx` against `schema`.
+    pub fn rollback<S>(schema: S, tx: TransactionId) -> Result<(), DbmsError>
+    where
+        S: DatabaseSchema<IcMemoryProvider, IcAccessControlList>,
+    {
+        DBMS_CONTEXT.with(|ctx| {
+            let mut db = WasmDbmsDatabase::from_transaction(ctx, schema, tx);
+            db.rollback()
+        })
+    }
+
+    /// Run `f` inside a transaction, committing on `Ok` and rolling back on
+    /// `Err`. The closure receives the live `TransactionId`, which it must
+    /// pass to `XRepository::with_transaction(tx)` for every repo call inside.
+    pub fn run<S, F, T, E>(schema: S, f: F) -> Result<T, E>
+    where
+        S: DatabaseSchema<IcMemoryProvider, IcAccessControlList> + Copy,
+        F: FnOnce(TransactionId) -> Result<T, E>,
+        E: From<DbmsError>,
+    {
+        let tx = Self::begin();
+        match f(tx) {
+            Ok(value) => {
+                Self::commit(schema, tx)?;
+                Ok(value)
+            }
+            Err(err) => {
+                // best-effort rollback; the caller's error wins
+                let _ = Self::rollback(schema, tx);
+                Err(err)
+            }
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
 
+    use std::cell::Cell;
+
+    use wasm_dbms_api::prelude::{
+        DatabaseSchema as DatabaseSchemaDerive, Filter, Query, Table, Uint64, Value,
+    };
+
     use super::*;
+
+    /// Minimal single-table fixture used to exercise commit/rollback against
+    /// the canister-local `DBMS_CONTEXT`.
+    #[derive(Debug, Table, Clone, PartialEq, Eq)]
+    #[table = "items"]
+    pub struct Item {
+        #[primary_key]
+        pub id: Uint64,
+    }
+
+    #[derive(Clone, Copy, DatabaseSchemaDerive)]
+    #[tables(Item = "items")]
+    pub struct TestSchema;
+
+    thread_local! {
+        static REGISTERED: Cell<bool> = const { Cell::new(false) };
+    }
+
+    fn register_test_schema() {
+        REGISTERED.with(|flag| {
+            if !flag.get() {
+                DBMS_CONTEXT.with(|ctx| {
+                    TestSchema::register_tables(ctx).expect("register tables");
+                });
+                flag.set(true);
+            }
+        });
+    }
 
     #[test]
     fn test_transaction_caller_returns_8_bytes() {
@@ -24,5 +123,87 @@ mod tests {
     fn test_transaction_caller_is_big_endian() {
         let caller = transaction_caller(0x0102_0304_0506_0708);
         assert_eq!(caller, vec![0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08]);
+    }
+
+    #[test]
+    fn test_transaction_begin_returns_distinct_ids() {
+        let a = Transaction::begin();
+        let b = Transaction::begin();
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn test_transaction_commit_persists_inserts() {
+        register_test_schema();
+
+        let tx = Transaction::begin();
+        DBMS_CONTEXT.with(|ctx| {
+            let db = WasmDbmsDatabase::from_transaction(ctx, TestSchema, tx);
+            db.insert::<Item>(ItemInsertRequest { id: 1u64.into() })
+                .expect("insert");
+        });
+        Transaction::commit(TestSchema, tx).expect("commit");
+
+        let rows = DBMS_CONTEXT.with(|ctx| {
+            WasmDbmsDatabase::oneshot(ctx, TestSchema)
+                .select::<Item>(
+                    Query::builder()
+                        .and_where(Filter::eq("id", Value::from(1u64)))
+                        .build(),
+                )
+                .expect("select")
+        });
+        assert_eq!(rows.len(), 1);
+    }
+
+    #[test]
+    fn test_transaction_run_commits_on_ok() {
+        register_test_schema();
+
+        Transaction::run::<_, _, _, DbmsError>(TestSchema, |tx| {
+            DBMS_CONTEXT.with(|ctx| {
+                let db = WasmDbmsDatabase::from_transaction(ctx, TestSchema, tx);
+                db.insert::<Item>(ItemInsertRequest { id: 7u64.into() })
+            })
+        })
+        .expect("run");
+
+        let rows = DBMS_CONTEXT.with(|ctx| {
+            WasmDbmsDatabase::oneshot(ctx, TestSchema)
+                .select::<Item>(
+                    Query::builder()
+                        .and_where(Filter::eq("id", Value::from(7u64)))
+                        .build(),
+                )
+                .expect("select")
+        });
+        assert_eq!(rows.len(), 1);
+    }
+
+    #[test]
+    fn test_transaction_run_rolls_back_on_err() {
+        register_test_schema();
+
+        let result: Result<(), DbmsError> = Transaction::run(TestSchema, |tx| {
+            DBMS_CONTEXT.with(|ctx| {
+                let db = WasmDbmsDatabase::from_transaction(ctx, TestSchema, tx);
+                db.insert::<Item>(ItemInsertRequest { id: 9u64.into() })?;
+                Err(DbmsError::Transaction(
+                    wasm_dbms_api::prelude::TransactionError::NoActiveTransaction,
+                ))
+            })
+        });
+        assert!(result.is_err());
+
+        let rows = DBMS_CONTEXT.with(|ctx| {
+            WasmDbmsDatabase::oneshot(ctx, TestSchema)
+                .select::<Item>(
+                    Query::builder()
+                        .and_where(Filter::eq("id", Value::from(9u64)))
+                        .build(),
+                )
+                .expect("select")
+        });
+        assert!(rows.is_empty(), "rollback should drop the staged insert");
     }
 }

--- a/crates/libs/did/src/common.rs
+++ b/crates/libs/did/src/common.rs
@@ -75,6 +75,13 @@ pub struct FeedItem {
     /// It works like this: if Alice creates a status, and Bob boosts it,
     /// then a new Feed Item is created with `boosted_by` set to Bob's actor URI.
     pub boosted_by: Option<String>,
+    /// `true` if the viewing user has liked the underlying [`Status`].
+    pub liked: bool,
+    /// `true` if the viewing user has boosted (reblogged) the underlying
+    /// [`Status`]. For the user's own boost wrapper this is always `true`;
+    /// for inbox boost items it indicates the viewer has independently
+    /// boosted the same original status.
+    pub boosted: bool,
 }
 
 /// A helper enum for update operations on optional fields.

--- a/crates/libs/did/src/common.rs
+++ b/crates/libs/did/src/common.rs
@@ -57,6 +57,10 @@ pub struct Status {
     pub like_count: u64,
     /// Cached count of `Announce` (boost) activities received for this status.
     pub boost_count: u64,
+    /// Optional content warning / spoiler text shown before content.
+    pub spoiler_text: Option<String>,
+    /// Whether the status should be hidden behind a content warning by clients.
+    pub sensitive: bool,
 }
 
 /// A single entry in a user's feed. Wraps a [`Status`] and optionally indicates

--- a/crates/libs/did/src/common/tests.rs
+++ b/crates/libs/did/src/common/tests.rs
@@ -56,6 +56,8 @@ fn test_should_roundtrip_status() {
         visibility: Visibility::Public,
         like_count: 0,
         boost_count: 0,
+        spoiler_text: None,
+        sensitive: false,
     };
     let bytes = Encode!(&status).unwrap();
     let decoded = Decode!(&bytes, Status).unwrap();
@@ -73,6 +75,8 @@ fn test_should_roundtrip_feed_item() {
             visibility: Visibility::FollowersOnly,
             like_count: 0,
             boost_count: 0,
+            spoiler_text: None,
+            sensitive: false,
         },
         boosted_by: Some("https://mastic.social/users/bob".to_string()),
     };
@@ -92,6 +96,8 @@ fn test_should_roundtrip_feed_item_without_boost() {
             visibility: Visibility::Unlisted,
             like_count: 0,
             boost_count: 0,
+            spoiler_text: None,
+            sensitive: false,
         },
         boosted_by: None,
     };

--- a/crates/libs/did/src/common/tests.rs
+++ b/crates/libs/did/src/common/tests.rs
@@ -79,6 +79,8 @@ fn test_should_roundtrip_feed_item() {
             sensitive: false,
         },
         boosted_by: Some("https://mastic.social/users/bob".to_string()),
+        liked: true,
+        boosted: true,
     };
     let bytes = Encode!(&item).unwrap();
     let decoded = Decode!(&bytes, FeedItem).unwrap();
@@ -100,6 +102,8 @@ fn test_should_roundtrip_feed_item_without_boost() {
             sensitive: false,
         },
         boosted_by: None,
+        liked: false,
+        boosted: false,
     };
     let bytes = Encode!(&item).unwrap();
     let decoded = Decode!(&bytes, FeedItem).unwrap();

--- a/crates/libs/did/src/federation.rs
+++ b/crates/libs/did/src/federation.rs
@@ -163,3 +163,34 @@ pub enum SendActivityResponse {
     /// request.
     Batch(Vec<SendActivityResult>),
 }
+
+/// Request arguments for the `fetch_status` method.
+#[derive(Debug, Clone, PartialEq, Eq, CandidType, Serialize, Deserialize)]
+pub struct FetchStatusArgs {
+    /// ActivityPub URI of the status to fetch.
+    pub uri: String,
+    /// Optional actor URI of the requester. Forwarded to the target user
+    /// canister so it can apply visibility rules.
+    pub requester_actor_uri: Option<String>,
+}
+
+/// Error type for the `fetch_status` method.
+#[derive(Debug, Clone, PartialEq, Eq, CandidType, Serialize, Deserialize)]
+pub enum FetchStatusError {
+    /// The URI host is not local. M1 only supports local fetch; HTTPS
+    /// outcalls land in M3.
+    Unsupported,
+    /// The URI could not be parsed (host or path shape).
+    InvalidUri,
+    /// The status was not found, or the requester is not allowed to see it.
+    NotFound,
+    /// Internal error occurred while fetching the status.
+    Internal(String),
+}
+
+/// Response type for the `fetch_status` method.
+#[derive(Debug, Clone, PartialEq, Eq, CandidType, Serialize, Deserialize)]
+pub enum FetchStatusResponse {
+    Ok(crate::common::Status),
+    Err(FetchStatusError),
+}

--- a/crates/libs/did/src/federation/tests.rs
+++ b/crates/libs/did/src/federation/tests.rs
@@ -212,3 +212,58 @@ fn test_should_roundtrip_send_activity_response_batch() {
     let decoded = Decode!(&bytes, SendActivityResponse).unwrap();
     assert_eq!(resp, decoded);
 }
+
+#[test]
+fn test_should_roundtrip_fetch_status_args_with_requester() {
+    let args = FetchStatusArgs {
+        uri: "https://mastic.social/users/alice/statuses/123".to_string(),
+        requester_actor_uri: Some("https://mastic.social/users/bob".to_string()),
+    };
+    let bytes = Encode!(&args).unwrap();
+    let decoded = Decode!(&bytes, FetchStatusArgs).unwrap();
+    assert_eq!(args, decoded);
+}
+
+#[test]
+fn test_should_roundtrip_fetch_status_args_no_requester() {
+    let args = FetchStatusArgs {
+        uri: "https://mastic.social/users/alice/statuses/456".to_string(),
+        requester_actor_uri: None,
+    };
+    let bytes = Encode!(&args).unwrap();
+    let decoded = Decode!(&bytes, FetchStatusArgs).unwrap();
+    assert_eq!(args, decoded);
+}
+
+#[test]
+fn test_should_roundtrip_fetch_status_response_ok() {
+    let resp = FetchStatusResponse::Ok(crate::common::Status {
+        id: 42,
+        content: "Hello, world!".to_string(),
+        author: "https://mastic.social/users/alice".to_string(),
+        created_at: 1_000_000_000,
+        visibility: crate::common::Visibility::Public,
+        like_count: 3,
+        boost_count: 1,
+        spoiler_text: Some("Content warning".to_string()),
+        sensitive: true,
+    });
+    let bytes = Encode!(&resp).unwrap();
+    let decoded = Decode!(&bytes, FetchStatusResponse).unwrap();
+    assert_eq!(resp, decoded);
+}
+
+#[test]
+fn test_should_roundtrip_fetch_status_response_err() {
+    for error in [
+        FetchStatusError::Unsupported,
+        FetchStatusError::InvalidUri,
+        FetchStatusError::NotFound,
+        FetchStatusError::Internal("db failure".to_string()),
+    ] {
+        let resp = FetchStatusResponse::Err(error);
+        let bytes = Encode!(&resp).unwrap();
+        let decoded = Decode!(&bytes, FetchStatusResponse).unwrap();
+        assert_eq!(resp, decoded);
+    }
+}

--- a/crates/libs/did/src/user.rs
+++ b/crates/libs/did/src/user.rs
@@ -499,6 +499,33 @@ pub enum ReadFeedResponse {
     Err(ReadFeedError),
 }
 
+/// Request arguments for the `get_local_status` method.
+#[derive(Debug, Clone, PartialEq, Eq, CandidType, Serialize, Deserialize)]
+pub struct GetLocalStatusArgs {
+    /// Snowflake id of the status to fetch.
+    pub id: u64,
+    /// Optional actor URI of the requester. Honored only when the caller is
+    /// the federation canister; ignored for owner / anonymous callers.
+    pub requester_actor_uri: Option<String>,
+}
+
+/// Error type for the `get_local_status` method.
+#[derive(Debug, Clone, PartialEq, Eq, CandidType, Serialize, Deserialize)]
+pub enum GetLocalStatusError {
+    /// The status does not exist on this canister, or visibility rules
+    /// prevent the requester from accessing it.
+    NotFound,
+    /// Internal error occurred while fetching the status.
+    Internal(String),
+}
+
+/// Response type for the `get_local_status` method.
+#[derive(Debug, Clone, PartialEq, Eq, CandidType, Serialize, Deserialize)]
+pub enum GetLocalStatusResponse {
+    Ok(Status),
+    Err(GetLocalStatusError),
+}
+
 /// Request arguments for the `receive_activity` method.
 /// Called by the Federation Canister to deliver an incoming ActivityPub activity.
 #[derive(Debug, Clone, PartialEq, Eq, CandidType, Serialize, Deserialize)]

--- a/crates/libs/did/src/user.rs
+++ b/crates/libs/did/src/user.rs
@@ -388,23 +388,19 @@ pub enum UnlikeStatusResponse {
 /// Request arguments for the `boost_status` method.
 #[derive(Debug, Clone, PartialEq, Eq, CandidType, Serialize, Deserialize)]
 pub struct BoostStatusArgs {
-    /// The unique ID of the status to boost.
-    pub status_id: String,
-    /// Principal of the User Canister that authored the status.
-    pub author_canister: candid::Principal,
+    /// ActivityPub URI of the status to like.
+    pub status_url: String,
 }
 
 /// Error types for the `boost_status` method.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, CandidType, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, CandidType, Serialize, Deserialize)]
 pub enum BoostStatusError {
-    /// The caller is not the canister owner.
-    Unauthorized,
-    /// The caller has already boosted this status.
-    AlreadyBoosted,
+    /// Internal error occurred while boosting the status.
+    Internal(String),
 }
 
 /// Response type for the `boost_status` method.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, CandidType, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, CandidType, Serialize, Deserialize)]
 pub enum BoostStatusResponse {
     Ok,
     Err(BoostStatusError),
@@ -413,23 +409,19 @@ pub enum BoostStatusResponse {
 /// Request arguments for the `undo_boost` method.
 #[derive(Debug, Clone, PartialEq, Eq, CandidType, Serialize, Deserialize)]
 pub struct UndoBoostArgs {
-    /// The unique ID of the status to un-boost.
-    pub status_id: String,
-    /// Principal of the User Canister that authored the status.
-    pub author_canister: candid::Principal,
+    /// ActivityPub URI of the status to un-boost.
+    pub status_url: String,
 }
 
 /// Error types for the `undo_boost` method.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, CandidType, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, CandidType, Serialize, Deserialize)]
 pub enum UndoBoostError {
-    /// The caller is not the canister owner.
-    Unauthorized,
-    /// No boost exists for the given status.
-    NotFound,
+    /// Internal error occurred while un-boosting the status.
+    Internal(String),
 }
 
 /// Response type for the `undo_boost` method.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, CandidType, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, CandidType, Serialize, Deserialize)]
 pub enum UndoBoostResponse {
     Ok,
     Err(UndoBoostError),

--- a/crates/libs/did/src/user/tests.rs
+++ b/crates/libs/did/src/user/tests.rs
@@ -450,8 +450,7 @@ fn test_should_roundtrip_undo_like_response_err() {
 #[test]
 fn test_should_roundtrip_boost_status_args() {
     let args = BoostStatusArgs {
-        status_id: "test-id".to_string(),
-        author_canister: candid::Principal::anonymous(),
+        status_url: "https://example.com/users/alice/statuses/123".to_string(),
     };
     let bytes = Encode!(&args).unwrap();
     let decoded = Decode!(&bytes, BoostStatusArgs).unwrap();
@@ -468,10 +467,7 @@ fn test_should_roundtrip_boost_status_response_ok() {
 
 #[test]
 fn test_should_roundtrip_boost_status_response_err() {
-    for error in [
-        BoostStatusError::Unauthorized,
-        BoostStatusError::AlreadyBoosted,
-    ] {
+    for error in [BoostStatusError::Internal("err".to_string())] {
         let resp = BoostStatusResponse::Err(error);
         let bytes = Encode!(&resp).unwrap();
         let decoded = Decode!(&bytes, BoostStatusResponse).unwrap();
@@ -482,8 +478,7 @@ fn test_should_roundtrip_boost_status_response_err() {
 #[test]
 fn test_should_roundtrip_undo_boost_args() {
     let args = UndoBoostArgs {
-        status_id: "test-id".to_string(),
-        author_canister: candid::Principal::anonymous(),
+        status_url: "https://example.com/users/alice/statuses/123".to_string(),
     };
     let bytes = Encode!(&args).unwrap();
     let decoded = Decode!(&bytes, UndoBoostArgs).unwrap();
@@ -500,7 +495,7 @@ fn test_should_roundtrip_undo_boost_response_ok() {
 
 #[test]
 fn test_should_roundtrip_undo_boost_response_err() {
-    for error in [UndoBoostError::Unauthorized, UndoBoostError::NotFound] {
+    for error in [UndoBoostError::Internal("err".to_string())] {
         let resp = UndoBoostResponse::Err(error);
         let bytes = Encode!(&resp).unwrap();
         let decoded = Decode!(&bytes, UndoBoostResponse).unwrap();

--- a/crates/libs/did/src/user/tests.rs
+++ b/crates/libs/did/src/user/tests.rs
@@ -596,6 +596,8 @@ fn test_should_roundtrip_read_feed_response_ok() {
             sensitive: false,
         },
         boosted_by: None,
+        liked: false,
+        boosted: false,
     }]);
     let bytes = Encode!(&resp).unwrap();
     let decoded = Decode!(&bytes, ReadFeedResponse).unwrap();

--- a/crates/libs/did/src/user/tests.rs
+++ b/crates/libs/did/src/user/tests.rs
@@ -620,6 +620,59 @@ fn test_should_roundtrip_read_feed_response_err() {
 }
 
 #[test]
+fn test_should_roundtrip_get_local_status_args_with_requester() {
+    let args = GetLocalStatusArgs {
+        id: 123456789,
+        requester_actor_uri: Some("https://mastic.social/users/alice".to_string()),
+    };
+    let bytes = Encode!(&args).unwrap();
+    let decoded = Decode!(&bytes, GetLocalStatusArgs).unwrap();
+    assert_eq!(args, decoded);
+}
+
+#[test]
+fn test_should_roundtrip_get_local_status_args_no_requester() {
+    let args = GetLocalStatusArgs {
+        id: 42,
+        requester_actor_uri: None,
+    };
+    let bytes = Encode!(&args).unwrap();
+    let decoded = Decode!(&bytes, GetLocalStatusArgs).unwrap();
+    assert_eq!(args, decoded);
+}
+
+#[test]
+fn test_should_roundtrip_get_local_status_response_ok() {
+    let resp = GetLocalStatusResponse::Ok(crate::common::Status {
+        id: 2,
+        content: "Hello".to_string(),
+        author: "https://mastic.social/users/alice".to_string(),
+        created_at: 42,
+        visibility: crate::common::Visibility::Public,
+        like_count: 0,
+        boost_count: 0,
+        spoiler_text: None,
+        sensitive: false,
+    });
+    let bytes = Encode!(&resp).unwrap();
+    let decoded = Decode!(&bytes, GetLocalStatusResponse).unwrap();
+    assert_eq!(resp, decoded);
+}
+
+#[test]
+fn test_should_roundtrip_get_local_status_response_err() {
+    for error in [
+        GetLocalStatusError::NotFound,
+        GetLocalStatusError::Internal("db error".to_string()),
+    ] {
+        let resp = GetLocalStatusResponse::Err(error);
+        let bytes = Encode!(&resp).unwrap();
+        let decoded = Decode!(&bytes, GetLocalStatusResponse).unwrap();
+        assert_eq!(resp, decoded);
+    }
+}
+
+#[test]
 fn test_should_roundtrip_receive_activity_args() {
     let args = ReceiveActivityArgs {
         activity_json: r#"{"type":"Follow"}"#.to_string(),

--- a/crates/libs/did/src/user/tests.rs
+++ b/crates/libs/did/src/user/tests.rs
@@ -345,6 +345,8 @@ fn test_should_roundtrip_publish_status_response_ok() {
         visibility: crate::common::Visibility::Public,
         like_count: 0,
         boost_count: 0,
+        spoiler_text: None,
+        sensitive: false,
     });
     let bytes = Encode!(&resp).unwrap();
     let decoded = Decode!(&bytes, PublishStatusResponse).unwrap();
@@ -551,6 +553,8 @@ fn test_should_roundtrip_get_statuses_response_ok() {
         visibility: crate::common::Visibility::Public,
         like_count: 0,
         boost_count: 0,
+        spoiler_text: None,
+        sensitive: false,
     }]);
     let bytes = Encode!(&resp).unwrap();
     let decoded = Decode!(&bytes, GetStatusesResponse).unwrap();
@@ -592,6 +596,8 @@ fn test_should_roundtrip_read_feed_response_ok() {
             visibility: crate::common::Visibility::Public,
             like_count: 0,
             boost_count: 0,
+            spoiler_text: None,
+            sensitive: false,
         },
         boosted_by: None,
     }]);

--- a/crates/libs/did/src/user/tests.rs
+++ b/crates/libs/did/src/user/tests.rs
@@ -469,12 +469,10 @@ fn test_should_roundtrip_boost_status_response_ok() {
 
 #[test]
 fn test_should_roundtrip_boost_status_response_err() {
-    for error in [BoostStatusError::Internal("err".to_string())] {
-        let resp = BoostStatusResponse::Err(error);
-        let bytes = Encode!(&resp).unwrap();
-        let decoded = Decode!(&bytes, BoostStatusResponse).unwrap();
-        assert_eq!(resp, decoded);
-    }
+    let resp = BoostStatusResponse::Err(BoostStatusError::Internal("err".to_string()));
+    let bytes = Encode!(&resp).unwrap();
+    let decoded = Decode!(&bytes, BoostStatusResponse).unwrap();
+    assert_eq!(resp, decoded);
 }
 
 #[test]
@@ -497,12 +495,10 @@ fn test_should_roundtrip_undo_boost_response_ok() {
 
 #[test]
 fn test_should_roundtrip_undo_boost_response_err() {
-    for error in [UndoBoostError::Internal("err".to_string())] {
-        let resp = UndoBoostResponse::Err(error);
-        let bytes = Encode!(&resp).unwrap();
-        let decoded = Decode!(&bytes, UndoBoostResponse).unwrap();
-        assert_eq!(resp, decoded);
-    }
+    let resp = UndoBoostResponse::Err(UndoBoostError::Internal("err".to_string()));
+    let bytes = Encode!(&resp).unwrap();
+    let decoded = Decode!(&bytes, UndoBoostResponse).unwrap();
+    assert_eq!(resp, decoded);
 }
 
 #[test]

--- a/docs/src/activitypub.md
+++ b/docs/src/activitypub.md
@@ -516,6 +516,15 @@ The `Announce` activity is used to share an existing object with the actor's fol
 
 The side effect of receiving an Announce on the **inbox** (S2S) is that the server SHOULD increment the shares count of the announced object and MAY display the object as having been shared by the announcing actor.
 
+> **Mastic implementation (M1):** Outbound `Announce` is emitted by the
+> User Canister's `boost_status` flow (with `Undo(Announce)` from
+> `undo_boost`). Inbound `Announce` is processed by `handle_announce`
+> in `crates/canisters/user/src/domain/activity/handle_incoming.rs`,
+> which inserts an inbox row, a feed entry, and increments the local
+> target's `statuses.boost_count` (saturating). Inbound `Undo(Announce)`
+> is dispatched to `handle_undo_announce`, which deletes the inbox /
+> feed rows and saturating-decrements the boost count.
+
 ```json
 {
   "@context": "https://www.w3.org/ns/activitystreams",
@@ -658,8 +667,8 @@ Mastodon supports the following activities for `Statuses`:
 - `Update`: Update an existing status in the database
 - `Delete`: Delete a Status from the database
 - `Like`: Favourited a Status
-- `Announce`: Boost a status (like rt on Twitter)
-- `Undo`: Undo a Like or a Boost
+- `Announce`: Boost a status (like rt on Twitter). **Mastic M1**: outbound via `boost_status`, inbound via `handle_announce`.
+- `Undo`: Undo a Like or a Boost. **Mastic M1**: outbound via `undo_like` / `undo_boost`, inbound via `handle_undo_like` / `handle_undo_announce`.
 - `Flag`: Transformed into a report to the moderation team. See the [Reports extension](#reports-extension) for more information
 - `QuoteRequest`: Request approval for a quote post. See the [Quote Posts extension](#quote-posts)
 

--- a/docs/src/architecture.md
+++ b/docs/src/architecture.md
@@ -17,6 +17,7 @@
     - [Federation Install Arguments](#federation-install-arguments)
   - [Authorization Model](#authorization-model)
   - [Inter-Canister Communication](#inter-canister-communication)
+  - [Boost Flow](#boost-flow)
   - [Shared Libraries](#shared-libraries)
 
 This document describes the architecture of Mastic, detailing
@@ -265,6 +266,48 @@ invocations. The key communication patterns are:
 4. **Canister lifecycle** -- Directory Canister calls the IC management
    canister (`create_canister`, `install_code`, `stop_canister`,
    `delete_canister`) to manage User Canister instances.
+
+## Boost Flow
+
+Boosting (`Announce`) requires denormalizing the original status content
+into a wrapper row owned by the booster, so the feed can render the
+boost without re-fetching on every read. The booster's User Canister
+never trusts content supplied by its caller; instead it fetches the
+verified `Status` through the Federation Canister.
+
+```mermaid
+sequenceDiagram
+    actor A as Alice (booster)
+    participant UC as Booster User Canister
+    participant FED as Federation Canister
+    participant DIR as Directory Canister
+    participant TUC as Target User Canister (author)
+    participant Fol as Follower User Canisters
+
+    A->>UC: boost_status(status_url)
+    UC->>FED: fetch_status(uri, requester=alice_actor_uri)
+    FED->>DIR: lookup handle from URI
+    DIR-->>FED: target canister id
+    FED->>TUC: get_local_status(id, requester=alice_actor_uri)
+    TUC-->>FED: Status (visibility-filtered)
+    FED-->>UC: Status
+    UC->>UC: tx { wrapper Status, Boost row, FeedEntry } (shared snowflake)
+    UC->>FED: send_activity(Batch[Announce])
+    FED->>TUC: receive_activity(Announce)  -- bumps boost_count
+    FED->>Fol: receive_activity(Announce)  -- inbox row + feed entry
+    UC-->>A: Ok
+```
+
+A single Snowflake is reused as `boosts.id`, `boosts.status_id`, the
+wrapper `statuses.id`, and the booster's `feed.id`. The same Snowflake
+also forms the canonical id of the emitted `Announce` activity:
+`<own_actor_uri>/statuses/<snowflake>`.
+
+Both `boost_status` and `undo_boost` are idempotent: a repeat call
+returns `Ok` without inserting a duplicate row or re-dispatching the
+activity. Remote URIs (host ≠ instance `public_url`) currently return
+`Unsupported` from `Federation.fetch_status`; Milestone 3 will extend
+the remote branch with HTTPS outcalls.
 
 ## Shared Libraries
 

--- a/docs/src/architecture/database-schema.md
+++ b/docs/src/architecture/database-schema.md
@@ -238,6 +238,13 @@ paired with a wrapper row in the `statuses` table.
 | `original_status_uri` | `TEXT`   | validated                     | URI of the boosted status             |
 | `created_at`          | `UINT64` | INDEX                         | Timestamp when the boost was emitted  |
 
+The same Snowflake is reused as `boosts.id`, `boosts.status_id`, the
+wrapper `statuses.id`, and the wrapper's `feed.id` — making the
+wrapper status URL `<actor>/statuses/<snowflake>` also the canonical
+`id` of the emitted `Announce` activity. One sequence increment per
+boost; one URL that dereferences both the wrapper status and the boost
+activity.
+
 ### `media` Table
 
 See the [Media Attachments](../specs/media.md) spec for full validation

--- a/docs/src/federation.did
+++ b/docs/src/federation.did
@@ -10,6 +10,28 @@ type FederationInstallArgs = variant {
     directory_canister : principal;
   };
 };
+// Request arguments for the `fetch_status` method.
+type FetchStatusArgs = record {
+  // ActivityPub URI of the status to fetch.
+  uri : text;
+  // Optional actor URI of the requester. Forwarded to the target user
+  // canister so it can apply visibility rules.
+  requester_actor_uri : opt text;
+};
+// Error type for the `fetch_status` method.
+type FetchStatusError = variant {
+  // Internal error occurred while fetching the status.
+  Internal : text;
+  // The status was not found, or the requester is not allowed to see it.
+  NotFound;
+  // The URI could not be parsed (host or path shape).
+  InvalidUri;
+  // The URI host is not local. M1 only supports local fetch; HTTPS
+  // outcalls land in M3.
+  Unsupported;
+};
+// Response type for the `fetch_status` method.
+type FetchStatusResponse = variant { Ok : Status; Err : FetchStatusError };
 // Arguments for the `register_user` method of the Federation canister.
 type RegisterUserArgs = record {
   user_handle : text;
@@ -65,7 +87,41 @@ type SendActivityResponse = variant {
 // Carries the delivery result for a single [`SendActivityArgsObject`]. Batch
 // calls return one result per input object, index-aligned with the request.
 type SendActivityResult = variant { Ok; Err : SendActivityError };
+// A single post authored by a user. Each status has a unique ID, content body,
+// author principal, creation timestamp, and visibility setting.
+type Status = record {
+  // Unique identifier for this status, assigned by the User Canister. (Snowflake id)
+  id : nat64;
+  // The text content of the status.
+  content : text;
+  // Cached count of `Like` activities received for this status.
+  like_count : nat64;
+  // Timestamp (milliseconds since epoch) of when the status was created.
+  created_at : nat64;
+  // The actor URI of the status author (e.g. `https://mastic.social/users/alice`).
+  author : text;
+  // The visibility setting of the status, controlling its audience.
+  visibility : Visibility;
+  // Optional content warning / spoiler text shown before content.
+  spoiler_text : opt text;
+  // Whether the status should be hidden behind a content warning by clients.
+  sensitive : bool;
+  // Cached count of `Announce` (boost) activities received for this status.
+  boost_count : nat64;
+};
+// Controls the audience of a status post. Maps to ActivityPub addressing
+type Visibility = variant {
+  // visible only to the author's followers
+  FollowersOnly;
+  // visible to everyone and included in public timelines
+  Public;
+  // visible to everyone via direct link, but excluded from public timelines
+  Unlisted;
+  // visible only to explicitly mentioned users
+  Direct;
+};
 service : (FederationInstallArgs) -> {
+  fetch_status : (FetchStatusArgs) -> (FetchStatusResponse);
   register_user : (RegisterUserArgs) -> (RegisterUserResponse);
   send_activity : (SendActivityArgs) -> (SendActivityResponse);
 }

--- a/docs/src/interface/types.md
+++ b/docs/src/interface/types.md
@@ -36,12 +36,14 @@
     - [UnlikeStatus](#undolike)
     - [BoostStatus](#booststatus)
     - [UndoBoost](#undoboost)
+    - [GetLocalStatus](#getlocalstatus)
     - [GetLiked](#getliked)
     - [ReadFeed](#readfeed)
     - [ReceiveActivity](#receiveactivity)
   - [Federation Canister Types](#federation-canister-types)
     - [FederationInstallArgs](#federationinstallargs)
     - [SendActivity](#sendactivity)
+    - [FetchStatus](#fetchstatus)
 
 This document defines all shared Candid types used across the Directory, Federation, and User canisters.
 
@@ -93,15 +95,17 @@ type UserProfile = record {
 A single post authored by a user. Each status has a unique ID, content body,
 author principal, creation timestamp, and visibility setting.
 
-| Field         | Description                                                        |
-| ------------- | ------------------------------------------------------------------ |
-| `id`          | Snowflake identifier of the status assigned by the User Canister.  |
-| `content`     | The text content of the post.                                      |
-| `author`      | ActivityPub actor URI of the status author.                        |
-| `created_at`  | Timestamp (milliseconds since epoch) when the status was created.  |
-| `visibility`  | Audience control for this status (see [Visibility](#visibility)).  |
-| `like_count`  | Cached count of `Like` activities received for this status.        |
-| `boost_count` | Cached count of `Announce` (boost) activities received.            |
+| Field          | Description                                                          |
+| -------------- | -------------------------------------------------------------------- |
+| `id`           | Snowflake identifier of the status assigned by the User Canister.    |
+| `content`      | The text content of the post.                                        |
+| `author`       | ActivityPub actor URI of the status author.                          |
+| `created_at`   | Timestamp (milliseconds since epoch) when the status was created.    |
+| `visibility`   | Audience control for this status (see [Visibility](#visibility)).    |
+| `like_count`   | Cached count of `Like` activities received for this status.          |
+| `boost_count`  | Cached count of `Announce` (boost) activities received.              |
+| `spoiler_text` | Optional content warning / spoiler text shown before the content.    |
+| `sensitive`    | If `true`, clients should hide the content behind a CW by default.   |
 
 ```candid
 type Status = record {
@@ -112,8 +116,16 @@ type Status = record {
   visibility : Visibility;
   like_count : nat64;
   boost_count : nat64;
+  spoiler_text : opt text;
+  sensitive : bool;
 };
 ```
+
+When a status is boosted, the booster's User Canister inserts a wrapper
+row in its own `statuses` table that denormalizes the original
+`content`, `spoiler_text`, and `sensitive` fields. Feed rendering reads
+the wrapper directly so the boosted CW carries through into the
+booster's outbox copy.
 
 ### FeedItem
 
@@ -895,6 +907,13 @@ Request, response, and error types for the `boost_status` method. Boosts
 (reblogs) a status authored by another user, sharing it with the caller's
 followers.
 
+The flow resolves the original status through the Federation Canister's
+[`fetch_status`](#fetchstatus) endpoint (which dereferences local
+authors via [`get_local_status`](#getlocalstatus)), then inserts a
+wrapper `Status` row, a `boosts` row, and a `feed` outbox entry that
+all share a single Snowflake — also reused as the emitted `Announce`
+activity id.
+
 `boost_status` is **idempotent**: calling it for a status the caller has
 already boosted returns `Ok` without recording a duplicate row in the
 boosts collection and without re-emitting an `Announce` activity. Only the
@@ -951,6 +970,50 @@ type UndoBoostResponse = variant {
 };
 
 type UndoBoostError = variant {
+  Internal : text;
+};
+```
+
+### GetLocalStatus
+
+Request, response, and error types for the `get_local_status` query.
+Returns a single `Status` owned by this User Canister. Used by the
+Federation Canister's [`fetch_status`](#fetchstatus) endpoint to
+dereference a local actor's status.
+
+`get_local_status` is a public query with no inspect block. The caller's
+principal determines the visibility scope:
+
+- **Owner principal**: can read any status regardless of visibility.
+- **Federation Canister principal** with `requester_actor_uri = Some(uri)`:
+  returns `Public` and `Unlisted` always; returns `FollowersOnly` only
+  if `uri` is in the followers list; returns `NotFound` for `Direct`.
+- **Federation Canister principal** with `requester_actor_uri = None`:
+  returns `Public` and `Unlisted` only.
+- **Anonymous / other principals**: returns `Public` and `Unlisted`
+  only.
+
+| Field                 | Description                                                    |
+| --------------------- | -------------------------------------------------------------- |
+| `id`                  | Snowflake ID of the status to read.                            |
+| `requester_actor_uri` | Actor URI of the requester (used for visibility filtering).    |
+
+- **NotFound**: no status with the given ID is visible to the caller.
+- **Internal**: an unexpected internal error occurred.
+
+```candid
+type GetLocalStatusArgs = record {
+  id : nat64;
+  requester_actor_uri : opt text;
+};
+
+type GetLocalStatusResponse = variant {
+  Ok : Status;
+  Err : GetLocalStatusError;
+};
+
+type GetLocalStatusError = variant {
+  NotFound;
   Internal : text;
 };
 ```
@@ -1117,5 +1180,49 @@ type SendActivityError = variant {
   UnknownLocalUser : text;
   DeliveryFailed : text;
   Rejected : text;
+};
+```
+
+### FetchStatus
+
+Request, response, and error types for the `fetch_status` method. Called
+by a User Canister to dereference a status by URI through the
+Federation Canister. The Federation Canister parses the URI, resolves
+the local handle via the Directory Canister, and forwards the request
+to the target User Canister's [`get_local_status`](#getlocalstatus)
+query.
+
+In Milestone 1, only local URIs (host equal to the instance
+`public_url`) are supported. Remote URIs return `Unsupported`;
+Milestone 3 will add HTTPS outcalls for cross-instance fetches.
+
+| Field                 | Description                                                    |
+| --------------------- | -------------------------------------------------------------- |
+| `uri`                 | ActivityPub status URI to dereference.                         |
+| `requester_actor_uri` | Actor URI of the requester (forwarded for visibility scoping). |
+
+- **InvalidUri**: the URI failed to parse or did not match the expected
+  `<public_url>/users/<handle>/statuses/<id>` shape.
+- **Unsupported**: the URI host is not local (Milestone 1 limitation).
+- **NotFound**: the URI is local but no matching handle / status exists,
+  or the status is not visible to the requester.
+- **Internal**: an unexpected internal error occurred.
+
+```candid
+type FetchStatusArgs = record {
+  uri : text;
+  requester_actor_uri : opt text;
+};
+
+type FetchStatusResponse = variant {
+  Ok : Status;
+  Err : FetchStatusError;
+};
+
+type FetchStatusError = variant {
+  InvalidUri;
+  Unsupported;
+  NotFound;
+  Internal : text;
 };
 ```

--- a/docs/src/interface/types.md
+++ b/docs/src/interface/types.md
@@ -95,17 +95,17 @@ type UserProfile = record {
 A single post authored by a user. Each status has a unique ID, content body,
 author principal, creation timestamp, and visibility setting.
 
-| Field          | Description                                                          |
-| -------------- | -------------------------------------------------------------------- |
-| `id`           | Snowflake identifier of the status assigned by the User Canister.    |
-| `content`      | The text content of the post.                                        |
-| `author`       | ActivityPub actor URI of the status author.                          |
-| `created_at`   | Timestamp (milliseconds since epoch) when the status was created.    |
-| `visibility`   | Audience control for this status (see [Visibility](#visibility)).    |
-| `like_count`   | Cached count of `Like` activities received for this status.          |
-| `boost_count`  | Cached count of `Announce` (boost) activities received.              |
-| `spoiler_text` | Optional content warning / spoiler text shown before the content.    |
-| `sensitive`    | If `true`, clients should hide the content behind a CW by default.   |
+| Field          | Description                                                        |
+| -------------- | ------------------------------------------------------------------ |
+| `id`           | Snowflake identifier of the status assigned by the User Canister.  |
+| `content`      | The text content of the post.                                      |
+| `author`       | ActivityPub actor URI of the status author.                        |
+| `created_at`   | Timestamp (milliseconds since epoch) when the status was created.  |
+| `visibility`   | Audience control for this status (see [Visibility](#visibility)).  |
+| `like_count`   | Cached count of `Like` activities received for this status.        |
+| `boost_count`  | Cached count of `Announce` (boost) activities received.            |
+| `spoiler_text` | Optional content warning / spoiler text shown before the content.  |
+| `sensitive`    | If `true`, clients should hide the content behind a CW by default. |
 
 ```candid
 type Status = record {
@@ -130,17 +130,23 @@ booster's outbox copy.
 ### FeedItem
 
 A single entry in a user's feed. Wraps a `Status` and optionally indicates
-that it was boosted (reblogged) by another user.
+that it was boosted (reblogged) by another user. Also surfaces per-viewer
+interaction flags so clients can render "you liked this" / "you boosted
+this" markers without an additional round-trip.
 
-| Field        | Description                                                                  |
-| ------------ | ---------------------------------------------------------------------------- |
-| `status`     | The status being displayed.                                                  |
-| `boosted_by` | If present, the principal of the user who boosted this status into the feed. |
+| Field        | Description                                                                                                          |
+| ------------ | -------------------------------------------------------------------------------------------------------------------- |
+| `status`     | The status being displayed.                                                                                          |
+| `boosted_by` | If present, the actor URI of the user who boosted this status into the feed.                                         |
+| `liked`      | `true` if the viewing user has liked the underlying status.                                                          |
+| `boosted`    | `true` if the viewing user has boosted the underlying status. Always `true` for the viewer's own boost wrapper rows. |
 
 ```candid
 type FeedItem = record {
   status : Status;
-  boosted_by : opt principal;
+  boosted_by : opt text;
+  liked : bool;
+  boosted : bool;
 };
 ```
 
@@ -252,11 +258,11 @@ Response and error types for the `who_am_i` method. Returns the caller's handle,
 User Canister ID, and canister status, allowing a logged-in user to discover
 their own identity and check canister readiness.
 
-| Field              | Description                                                                              |
-| :----------------- | :--------------------------------------------------------------------------------------- |
-| `handle`           | The caller's registered handle.                                                          |
-| `user_canister`    | Principal of the caller's User Canister. (Optional)                                      |
-| `canister_status`  | Status of the caller's User Canister (see [UserCanisterStatus](#usercanisterstatus)).    |
+| Field             | Description                                                                           |
+| :---------------- | :------------------------------------------------------------------------------------ |
+| `handle`          | The caller's registered handle.                                                       |
+| `user_canister`   | Principal of the caller's User Canister. (Optional)                                   |
+| `canister_status` | Status of the caller's User Canister (see [UserCanisterStatus](#usercanisterstatus)). |
 
 - **NotRegistered**: the caller has no account in the directory.
 
@@ -300,10 +306,10 @@ type UserCanisterError = variant {
 Request, response, and error types for the `get_user` method. Looks up a user
 by handle and returns their handle and User Canister ID.
 
-| Field         | Description                                  |
-| ------------- | -------------------------------------------- |
-| `handle`      | The handle to look up.                       |
-| `canister_id` | Principal of the looked-up user's canister.  |
+| Field         | Description                                 |
+| ------------- | ------------------------------------------- |
+| `handle`      | The handle to look up.                      |
+| `canister_id` | Principal of the looked-up user's canister. |
 
 - **NotFound**: no user exists with the given handle.
 
@@ -332,9 +338,9 @@ type GetUserError = variant {
 Request, response, and error types for the `add_moderator` method. Grants
 moderator privileges to a principal. Only existing moderators may call this.
 
-| Field       | Description                              |
-| ----------- | ---------------------------------------- |
-| `principal` | The principal to promote to moderator.   |
+| Field       | Description                            |
+| ----------- | -------------------------------------- |
+| `principal` | The principal to promote to moderator. |
 
 - **Unauthorized**: the caller is not a moderator.
 - **AlreadyModerator**: the target principal is already a moderator.
@@ -388,9 +394,9 @@ type RemoveModeratorError = variant {
 Request, response, and error types for the `suspend` method. Suspends a user
 account, preventing further activity. Only moderators may call this.
 
-| Field       | Description                             |
-| ----------- | --------------------------------------- |
-| `principal` | The principal of the user to suspend.   |
+| Field       | Description                           |
+| ----------- | ------------------------------------- |
+| `principal` | The principal of the user to suspend. |
 
 - **Unauthorized**: the caller is not a moderator.
 - **NotFound**: no user exists with the given principal.
@@ -427,18 +433,18 @@ are returned. `CreationPending`, `CreationFailed`, `DeletionPending`, and
 
 An empty `query` returns all eligible users, paginated.
 
-| Field    | Description                                              |
-| :------- | :------------------------------------------------------- |
-| `query`  | Free-text search string matched against handles.         |
-| `offset` | Number of results to skip (for pagination).              |
-| `limit`  | Maximum results to return; must be in `1..=50`.          |
+| Field    | Description                                      |
+| :------- | :----------------------------------------------- |
+| `query`  | Free-text search string matched against handles. |
+| `offset` | Number of results to skip (for pagination).      |
+| `limit`  | Maximum results to return; must be in `1..=50`.  |
 
 Each result entry contains:
 
-| Field         | Description                                |
-| :------------ | :----------------------------------------- |
-| `handle`      | The matched user's handle.                 |
-| `canister_id` | Principal of the matched user's canister.  |
+| Field         | Description                               |
+| :------------ | :---------------------------------------- |
+| `handle`      | The matched user's handle.                |
+| `canister_id` | Principal of the matched user's canister. |
 
 Errors:
 
@@ -568,9 +574,9 @@ type UpdateProfileError = variant {
 Request, response, and error types for the `follow_user` method. Sends a
 follow request to another user by handle.
 
-| Field    | Description                    |
-| -------- | ------------------------------ |
-| `handle` | Handle of the user to follow.  |
+| Field    | Description                   |
+| -------- | ----------------------------- |
+| `handle` | Handle of the user to follow. |
 
 - **Unauthorized**: the caller is not the canister owner.
 - **AlreadyFollowing**: the caller already follows the target user.
@@ -600,9 +606,9 @@ type FollowUserError = variant {
 Request, response, and error types for the `accept_follow` method. Accepts a
 pending follow request from another user, adding them to the followers list.
 
-| Field      | Description                                                     |
-| ---------- | --------------------------------------------------------------- |
-| `follower` | Principal of the User Canister whose follow request to accept.  |
+| Field      | Description                                                    |
+| ---------- | -------------------------------------------------------------- |
+| `follower` | Principal of the User Canister whose follow request to accept. |
 
 - **Unauthorized**: the caller is not the canister owner.
 - **RequestNotFound**: no pending follow request exists from the given principal.
@@ -628,9 +634,9 @@ type AcceptFollowError = variant {
 Request, response, and error types for the `reject_follow` method. Rejects a
 pending follow request from another user.
 
-| Field      | Description                                                     |
-| ---------- | --------------------------------------------------------------- |
-| `follower` | Principal of the User Canister whose follow request to reject.  |
+| Field      | Description                                                    |
+| ---------- | -------------------------------------------------------------- |
+| `follower` | Principal of the User Canister whose follow request to reject. |
 
 - **Unauthorized**: the caller is not the canister owner.
 - **RequestNotFound**: no pending follow request exists from the given principal.
@@ -657,9 +663,9 @@ Request, response, and error types for the `unfollow_user` method. Removes the
 caller from the target user's followers list and removes the target from the
 caller's following list.
 
-| Field         | Description                                  |
-| ------------- | -------------------------------------------- |
-| `canister_id` | Principal of the User Canister to unfollow.  |
+| Field         | Description                                 |
+| ------------- | ------------------------------------------- |
+| `canister_id` | Principal of the User Canister to unfollow. |
 
 - **Unauthorized**: the caller is not the canister owner.
 - **NotFollowing**: the caller does not currently follow the target user.
@@ -685,9 +691,9 @@ type UnfollowUserError = variant {
 Request, response, and error types for the `block_user` method. Blocks another
 user, preventing them from following or interacting with the caller.
 
-| Field         | Description                               |
-| ------------- | ----------------------------------------- |
-| `canister_id` | Principal of the User Canister to block.  |
+| Field         | Description                              |
+| ------------- | ---------------------------------------- |
+| `canister_id` | Principal of the User Canister to block. |
 
 - **Unauthorized**: the caller is not the canister owner.
 
@@ -712,10 +718,10 @@ Request, response, and error types for the `get_followers` method. Returns a
 paginated list of actor URIs that follow this user. The `limit` must not exceed
 **50** (the maximum page size).
 
-| Field    | Description                                              |
-| -------- | -------------------------------------------------------- |
-| `offset` | Number of results to skip (for pagination).              |
-| `limit`  | Maximum number of results to return (max 50).            |
+| Field    | Description                                   |
+| -------- | --------------------------------------------- |
+| `offset` | Number of results to skip (for pagination).   |
+| `limit`  | Maximum number of results to return (max 50). |
 
 - **LimitExceeded**: the requested `limit` exceeds the maximum page size (50).
 - **Internal**: an internal error occurred while querying followers.
@@ -743,10 +749,10 @@ Request, response, and error types for the `get_following` method. Returns a
 paginated list of actor URIs that this user follows. The `limit` must not exceed
 **50** (the maximum page size).
 
-| Field    | Description                                              |
-| -------- | -------------------------------------------------------- |
-| `offset` | Number of results to skip (for pagination).              |
-| `limit`  | Maximum number of results to return (max 50).            |
+| Field    | Description                                   |
+| -------- | --------------------------------------------- |
+| `offset` | Number of results to skip (for pagination).   |
+| `limit`  | Maximum number of results to return (max 50). |
 
 - **LimitExceeded**: the requested `limit` exceeds the maximum page size (50).
 - **Internal**: an internal error occurred while querying the following list.
@@ -776,11 +782,11 @@ Canister. For `Public`, `Unlisted`, and `FollowersOnly` visibilities, the
 recipients are the author's followers. For `Direct` visibility, the recipients
 are the explicitly listed `mentions` — followers are not addressed.
 
-| Field        | Description                                                                             |
-| ------------ | --------------------------------------------------------------------------------------- |
-| `content`    | The text content of the new post.                                                       |
-| `visibility` | Audience control for this status (see [Visibility](#visibility)).                       |
-| `mentions`   | Actor URIs explicitly mentioned. Required (non-empty) when `visibility` is `Direct`.    |
+| Field        | Description                                                                          |
+| ------------ | ------------------------------------------------------------------------------------ |
+| `content`    | The text content of the new post.                                                    |
+| `visibility` | Audience control for this status (see [Visibility](#visibility)).                    |
+| `mentions`   | Actor URIs explicitly mentioned. Required (non-empty) when `visibility` is `Direct`. |
 
 On success, returns the created `Status` with its assigned ID and timestamp.
 
@@ -817,9 +823,9 @@ type PublishStatusError = variant {
 Request, response, and error types for the `delete_status` method. Removes a
 status post from the caller's outbox.
 
-| Field       | Description                             |
-| ----------- | --------------------------------------- |
-| `status_id` | The unique ID of the status to delete.  |
+| Field       | Description                            |
+| ----------- | -------------------------------------- |
+| `status_id` | The unique ID of the status to delete. |
 
 - **Unauthorized**: the caller is not the canister owner.
 - **NotFound**: no status exists with the given ID.
@@ -851,9 +857,9 @@ liked collection and without re-emitting a `Like` activity. Only the
 caller (canister owner) is authorized; non-owner calls are rejected at
 the inspect layer.
 
-| Field        | Description                              |
-| ------------ | ---------------------------------------- |
-| `status_url` | ActivityPub URI of the status to like.   |
+| Field        | Description                            |
+| ------------ | -------------------------------------- |
+| `status_url` | ActivityPub URI of the status to like. |
 
 - **Internal**: an unexpected internal error occurred (database access
   failure, federation dispatch failure, etc.).
@@ -993,10 +999,10 @@ principal determines the visibility scope:
 - **Anonymous / other principals**: returns `Public` and `Unlisted`
   only.
 
-| Field                 | Description                                                    |
-| --------------------- | -------------------------------------------------------------- |
-| `id`                  | Snowflake ID of the status to read.                            |
-| `requester_actor_uri` | Actor URI of the requester (used for visibility filtering).    |
+| Field                 | Description                                                 |
+| --------------------- | ----------------------------------------------------------- |
+| `id`                  | Snowflake ID of the status to read.                         |
+| `requester_actor_uri` | Actor URI of the requester (used for visibility filtering). |
 
 - **NotFound**: no status with the given ID is visible to the caller.
 - **Internal**: an unexpected internal error occurred.
@@ -1081,9 +1087,9 @@ Request, response, and error types for the `receive_activity` method. Called by
 the Federation Canister to deliver an incoming ActivityPub activity (encoded as
 JSON) to this User Canister's inbox.
 
-| Field           | Description                                |
-| --------------- | ------------------------------------------ |
-| `activity_json` | JSON-encoded ActivityPub activity object.  |
+| Field           | Description                               |
+| --------------- | ----------------------------------------- |
+| `activity_json` | JSON-encoded ActivityPub activity object. |
 
 - **Unauthorized**: the caller is not the Federation Canister.
 - **InvalidActivity**: the JSON could not be parsed as a valid ActivityPub
@@ -1138,10 +1144,10 @@ a single activity (`One`) or a batch (`Batch`) per call. Local targets are
 routed to the recipient User Canister via the Directory Canister; remote
 targets are skipped (remote HTTP delivery is Milestone 2).
 
-| Field           | Description                                                 |
-| --------------- | ----------------------------------------------------------- |
-| `activity_json` | JSON-encoded ActivityPub activity object to send.           |
-| `target_inbox`  | URL of the actor's inbox to deliver the activity to.        |
+| Field           | Description                                          |
+| --------------- | ---------------------------------------------------- |
+| `activity_json` | JSON-encoded ActivityPub activity object to send.    |
+| `target_inbox`  | URL of the actor's inbox to deliver the activity to. |
 
 `SendActivityError`:
 

--- a/docs/src/interface/types.md
+++ b/docs/src/interface/types.md
@@ -895,18 +895,22 @@ Request, response, and error types for the `boost_status` method. Boosts
 (reblogs) a status authored by another user, sharing it with the caller's
 followers.
 
-| Field              | Description                                              |
-| ------------------ | -------------------------------------------------------- |
-| `status_id`        | The unique ID of the status to boost.                    |
-| `author_canister`  | Principal of the User Canister that authored the status. |
+`boost_status` is **idempotent**: calling it for a status the caller has
+already boosted returns `Ok` without recording a duplicate row in the
+boosts collection and without re-emitting an `Announce` activity. Only the
+caller (canister owner) is authorized; non-owner calls are rejected at the
+inspect layer.
 
-- **Unauthorized**: the caller is not the canister owner.
-- **AlreadyBoosted**: the caller has already boosted this status.
+| Field        | Description                             |
+| ------------ | --------------------------------------- |
+| `status_url` | ActivityPub URI of the status to boost. |
+
+- **Internal**: an unexpected internal error occurred (database access
+  failure, federation dispatch failure, etc.).
 
 ```candid
 type BoostStatusArgs = record {
-  status_id : text;
-  author_canister : principal;
+  status_url : text;
 };
 
 type BoostStatusResponse = variant {
@@ -915,8 +919,7 @@ type BoostStatusResponse = variant {
 };
 
 type BoostStatusError = variant {
-  Unauthorized;
-  AlreadyBoosted;
+  Internal : text;
 };
 ```
 
@@ -925,18 +928,21 @@ type BoostStatusError = variant {
 Request, response, and error types for the `undo_boost` method. Removes a
 previously recorded boost from a status.
 
-| Field              | Description                                              |
-| ------------------ | -------------------------------------------------------- |
-| `status_id`        | The unique ID of the status to un-boost.                 |
-| `author_canister`  | Principal of the User Canister that authored the status. |
+`undo_boost` is **idempotent**: calling it for a status the caller has
+not boosted (or has already un-boosted) returns `Ok` without emitting a
+second `Undo(Announce)` activity. Only the caller (canister owner) is
+authorized; non-owner calls are rejected at the inspect layer.
 
-- **Unauthorized**: the caller is not the canister owner.
-- **NotFound**: no boost exists for the given status.
+| Field        | Description                                |
+| ------------ | ------------------------------------------ |
+| `status_url` | ActivityPub URI of the status to un-boost. |
+
+- **Internal**: an unexpected internal error occurred (database access
+  failure, federation dispatch failure, etc.).
 
 ```candid
 type UndoBoostArgs = record {
-  status_id : text;
-  author_canister : principal;
+  status_url : text;
 };
 
 type UndoBoostResponse = variant {
@@ -945,8 +951,7 @@ type UndoBoostResponse = variant {
 };
 
 type UndoBoostError = variant {
-  Unauthorized;
-  NotFound;
+  Internal : text;
 };
 ```
 

--- a/docs/src/milestones/milestone-1.md
+++ b/docs/src/milestones/milestone-1.md
@@ -207,32 +207,91 @@ author and the user's followers.
 
 **What should be done:**
 
-- Implement `boost_status(BoostStatusArgs)`:
-  - Authorize the caller (owner only)
-  - Record the boost in the user's outbox
-  - Build an `Announce` activity
-  - Send the activity to the Federation Canister (targets: status author +
-    all of the booster's followers)
-- Implement `undo_boost(UndoBoostArgs)`:
-  - Remove the boost from the outbox
-  - Send an `Undo(Announce)` activity
+- Implement `boost_status(BoostStatusArgs { status_url })`:
+  - Authorize the caller (owner only) at the inspect layer
+  - **Idempotent**: if a boost row for `status_url` already exists, return
+    `Ok` without inserting a duplicate row and without re-dispatching the
+    activity
+  - Otherwise:
+    - Resolve the original status (content, author URI, visibility,
+      spoiler, sensitive flag) by looking up the local `statuses` table
+      when the target is local, or the local inbox row when the target
+      is remote
+    - Insert a wrapper row into `statuses` owned by the booster with a
+      **denormalized copy** of the original content fields. This is the
+      booster's outbox entry for the boost
+    - Insert a row into `boosts` linking the wrapper (`status_id`) to
+      the `original_status_uri`
+    - Insert a `feed` entry with `source = Outbox` for the wrapper so
+      the boost appears in the booster's own feed
+    - Build an `Announce` activity and send it to the Federation Canister
+      (targets: status author + all of the booster's followers)
+- Implement `undo_boost(UndoBoostArgs { status_url })`:
+  - Authorize the caller (owner only) at the inspect layer
+  - **Idempotent**: if no boost row for `status_url` exists, return `Ok`
+    without dispatching an `Undo(Announce)` activity
+  - Otherwise, remove the `boosts` row, the wrapper `statuses` row, and
+    the corresponding `feed` outbox entry. Then send an `Undo(Announce)`
+    activity to the same targets
 - **User Canister** `receive_activity` handler: handle incoming `Announce`:
-  - Store the boosted status in the inbox (as a boost, not a new status)
+  - Insert an `inbox` row with `is_boost = true`,
+    `original_status_uri = <target>`, `actor_uri = booster`,
+    `activity_type = Announce`
+  - Insert a `feed` entry with `source = Inbox` for that row so the
+    boost appears in the recipient's feed
+  - If the local target status exists, increment
+    `statuses.boost_count` (saturating)
 - Handle incoming `Undo(Announce)`:
-  - Remove the boosted status from the inbox
+  - Delete the matching inbox row and its `feed` entry
+  - If the local target status exists, decrement
+    `statuses.boost_count` (saturating at 0)
+- **Feed rendering** (`read_feed`):
+  - Outbox path: when a `statuses` row is referenced by a `boosts`
+    row, hydrate the feed item using the denormalized copy and set
+    `boosted_by = Some(owner_actor_uri)`, `author = original author URI`.
+    Closes the existing `boosted_by: None` FIXME in
+    `crates/canisters/user/src/domain/feed/read_feed.rs`
+  - Inbox path: when an `inbox` row has `is_boost = true`, hydrate the
+    feed item by resolving `original_status_uri` (local `statuses` if
+    present, otherwise from any cached inbox row), and set
+    `boosted_by = Some(actor_uri)`, `author = original author URI`.
+    Closes the corresponding inbox-side FIXME
 - Define `BoostStatusArgs`, `BoostStatusResponse`, `UndoBoostArgs`,
-  `UndoBoostResponse` in the `did` crate
+  `UndoBoostResponse` in the `did` crate. Both error enums expose only
+  `Internal(String)`; authorization failures are rejected at the inspect
+  layer (no `Unauthorized` variant)
+- Extend `Status` / `FeedItem` with `boosted_by: Option<Text>`
 - Add `Announce` to `ActivityType`
+
+**Edit propagation note:** the wrapper row holds a denormalized copy of
+the original status content. When the original author edits the status
+(WI-1.23), the resulting `Update(Note)` activity received by the
+booster's canister must overwrite the wrapper's `content`,
+`spoiler_text`, and `sensitive` fields in addition to the inbox row's
+`object_data`. WI-1.23 covers this propagation.
 
 **Acceptance Criteria:**
 
-- Boosting a status records it in the outbox
+- Boosting a status inserts a wrapper row into the booster's outbox
+  with a denormalized copy of the original content
+- A `boosts` row links the wrapper to `original_status_uri`
+- The booster sees their own boost in their feed with
+  `boosted_by = self` and `author = original author URI`
 - An `Announce` activity is sent to the author and the booster's followers
-- Followers see the boost in their feed
-- Undoing a boost removes it and sends an `Undo(Announce)` activity
-- Cannot boost the same status twice
-- Integration test: Alice boosts Bob's status, Charlie (Alice's follower) sees
-  it in their feed
+- Followers see the boost in their feed with
+  `boosted_by = booster` and `author = original author URI`
+- `boost_status` is idempotent: calling it twice for the same `status_url`
+  returns `Ok` both times, stores a single boost row + wrapper, and
+  dispatches the `Announce` activity only once
+- Undoing a boost removes the `boosts` row, the wrapper status, the
+  outbox feed entry, and dispatches an `Undo(Announce)` activity
+- Receivers delete the inbox boost row and feed entry on `Undo(Announce)`
+- `undo_boost` is idempotent: calling it for a status that is not
+  boosted returns `Ok` without dispatching a second `Undo(Announce)`
+- Self-boost is allowed
+- Integration test: Alice boosts Bob's status, Charlie (Alice's follower)
+  sees it in his feed with `boosted_by = alice` and `author = bob`;
+  Alice also sees the boost in her own feed; undo removes it from both
 
 ### WI-1.8: Implement User Canister - delete status (UC15)
 

--- a/docs/src/project.md
+++ b/docs/src/project.md
@@ -224,6 +224,8 @@ http\_request : (*HttpRequest*) -> (*HttpResponse*) query;
 
 http\_request\_update : (*HttpRequest*) -> (*HttpResponse*);
 
+fetch\_status : (*FetchStatusArgs*) -> (*FetchStatusResponse*);
+
 send\_activity : (*SendActivityArgs*) -> (*SendActivityResponse*)
 
 }
@@ -251,6 +253,8 @@ get\_followers : (*GetFollowersArgs*) -> (*GetFollowersResponse*) query;
 get\_following : (*GetFollowingArgs*) -> (*GetFollowingResponse*) query;
 
 get\_liked : (*GetLikedArgs*) -> (*GetLikedResponse*) query;
+
+get\_local\_status : (*GetLocalStatusArgs*) -> (*GetLocalStatusResponse*) query;
 
 get\_profile : () -> (*GetProfileResponse*) query;
 

--- a/docs/src/project/flows.md
+++ b/docs/src/project/flows.md
@@ -310,26 +310,46 @@ sequenceDiagram
 
 ```mermaid
 sequenceDiagram
-    actor A as Alice
-    participant UC as Alice's User Canister
-    participant DIR as Directory Canister
+    actor A as Alice (booster)
+    participant UC as Booster User Canister
     participant FED as Federation Canister
-    participant TUC as Target User Canister (local)
-    participant M as Mastodon Web2
+    participant DIR as Directory Canister
+    participant TUC as Target User Canister (author)
+    participant Fol as Follower User Canisters
 
-    A->>DIR: Get Alice's User Canister (candid)
-    DIR->>A: User Canister Principal
-    A->>UC: Boost Status (candid)
-    UC->>UC: Store Boost in Alice's Outbox
-    UC->>FED: Forward Announce Activity (ic)
-    alt Status author is local
-        FED->>DIR: Resolve author's User Canister
-        FED->>TUC: Deliver Announce activity
-    else Status author is remote
-        FED->>M: Forward Announce Activity (ActivityPub)
-    end
-    Note over FED: Also delivers to Alice's followers (local + remote)
+    A->>UC: boost_status(status_url)
+    UC->>FED: fetch_status(uri, requester=alice_actor_uri)
+    FED->>DIR: lookup handle from URI
+    DIR-->>FED: target canister id
+    FED->>TUC: get_local_status(id, requester=alice_actor_uri)
+    TUC-->>FED: Status (visibility-filtered)
+    FED-->>UC: Status
+    UC->>UC: tx { wrapper Status, Boost row, FeedEntry } (shared snowflake)
+    UC->>FED: send_activity(Batch[Announce])
+    FED->>TUC: receive_activity(Announce)  -- bumps boost_count
+    FED->>Fol: receive_activity(Announce)  -- inbox row + feed entry
+    UC-->>A: Ok
 ```
+
+The booster's User Canister never trusts boost content from its caller:
+the wrapper row's `content`, `spoiler_text`, and `sensitive` are
+populated from the `Status` returned by `Federation.fetch_status`,
+which in turn dereferences the local author through
+`User.get_local_status` (Milestone 1; Milestone 3 will extend the
+remote branch via HTTPS outcalls).
+
+A single Snowflake is reused as `boosts.id`, the wrapper `statuses.id`,
+the `feed.id` for the booster's outbox entry, and the `Announce`
+activity `id` (`<own_actor_uri>/statuses/<snowflake>`).
+
+`boost_status` is **idempotent**: a duplicate boost of the same
+`status_url` returns `Ok` without inserting a second wrapper or
+re-emitting the `Announce`. `undo_boost` reverses the flow — it deletes
+the `boosts` row, the wrapper `statuses` row, and the `feed` outbox
+entry, then dispatches an `Undo(Announce)` to followers and the
+original author. `undo_boost` is also idempotent.
+
+Remote author / follower delivery via HTTPS is Milestone 3.
 
 ## Delete Status
 

--- a/docs/src/specs/status.md
+++ b/docs/src/specs/status.md
@@ -50,6 +50,15 @@ Boolean flag. Clients are expected to hide media and content behind a
 "show more" gate when `sensitive = true`, even if `spoiler_text` is
 null. No validation beyond type.
 
+Both `spoiler_text` and `sensitive` are part of the [`Status`](../interface/types.md#status)
+candid record returned by feed-rendering queries. When a status is
+boosted, the booster's User Canister inserts a wrapper row in its own
+`statuses` table that **denormalizes** these fields from the original
+status (resolved through `Federation.fetch_status`), so the boosted
+content warning carries through into the booster's outbox copy and
+into followers' inboxes without any extra cross-canister read at feed
+render time.
+
 ## `edited_at`
 
 Nullable `Uint64` timestamp. Written by the edit flow; never set by

--- a/docs/src/specs/urls.md
+++ b/docs/src/specs/urls.md
@@ -7,13 +7,21 @@ across the codebase.
 
 ## URL Table
 
-| Pattern                                 | Purpose              |
-| --------------------------------------- | -------------------- |
-| `{public_url}/users/{handle}`           | Actor URI (profile)  |
-| `{public_url}/users/{handle}/inbox`     | ActivityPub inbox    |
-| `{public_url}/users/{handle}/outbox`    | ActivityPub outbox   |
-| `{public_url}/users/{handle}/followers` | Followers collection |
-| `{public_url}/users/{handle}/following` | Following collection |
+| Pattern                                       | Purpose              |
+| --------------------------------------------- | -------------------- |
+| `{public_url}/users/{handle}`                 | Actor URI (profile)  |
+| `{public_url}/users/{handle}/inbox`           | ActivityPub inbox    |
+| `{public_url}/users/{handle}/outbox`          | ActivityPub outbox   |
+| `{public_url}/users/{handle}/followers`       | Followers collection |
+| `{public_url}/users/{handle}/following`       | Following collection |
+| `{public_url}/users/{handle}/statuses/{id}`   | Status URL           |
+
+When a user boosts a status, the wrapper status URL
+`<actor>/statuses/<snowflake>` is also the canonical `id` of the
+emitted `Announce` activity. The booster's `Boost` row, wrapper
+`Status`, `FeedEntry`, and the `Announce` activity all share a single
+Snowflake — one URL dereferences both the wrapper status and the boost
+activity.
 
 ## Example
 

--- a/docs/src/user.did
+++ b/docs/src/user.did
@@ -52,6 +52,13 @@ type FeedItem = record {
   // It works like this: if Alice creates a status, and Bob boosts it,
   // then a new Feed Item is created with `boosted_by` set to Bob's actor URI.
   boosted_by : opt text;
+  // `true` if the viewing user has liked the underlying [`Status`].
+  liked : bool;
+  // `true` if the viewing user has boosted (reblogged) the underlying
+  // [`Status`]. For the user's own boost wrapper this is always `true`;
+  // for inbox boost items it indicates the viewer has independently
+  // boosted the same original status.
+  boosted : bool;
 };
 // A helper enum for update operations on optional fields.
 // For example, when updating a user profile,

--- a/docs/src/user.did
+++ b/docs/src/user.did
@@ -14,6 +14,18 @@ type AcceptFollowError = variant {
 };
 // Response type for the `accept_follow` method.
 type AcceptFollowResponse = variant { Ok; Err : AcceptFollowError };
+// Request arguments for the `boost_status` method.
+type BoostStatusArgs = record {
+  // ActivityPub URI of the status to like.
+  status_url : text;
+};
+// Error types for the `boost_status` method.
+type BoostStatusError = variant {
+  // Internal error occurred while boosting the status.
+  Internal : text;
+};
+// Response type for the `boost_status` method.
+type BoostStatusResponse = variant { Ok; Err : BoostStatusError };
 // Error types for the `emit_delete_profile_activity` method.
 // 
 // Called by the Directory Canister during delete_profile flow to aggregate and
@@ -119,6 +131,27 @@ type GetLikedArgs = record {
 type GetLikedError = variant { Internal : text };
 // Response type for the `get_liked` method.
 type GetLikedResponse = variant { Ok : vec text; Err : GetLikedError };
+// Request arguments for the `get_local_status` method.
+type GetLocalStatusArgs = record {
+  // Snowflake id of the status to fetch.
+  id : nat64;
+  // Optional actor URI of the requester. Honored only when the caller is
+  // the federation canister; ignored for owner / anonymous callers.
+  requester_actor_uri : opt text;
+};
+// Error type for the `get_local_status` method.
+type GetLocalStatusError = variant {
+  // Internal error occurred while fetching the status.
+  Internal : text;
+  // The status does not exist on this canister, or visibility rules
+  // prevent the requester from accessing it.
+  NotFound;
+};
+// Response type for the `get_local_status` method.
+type GetLocalStatusResponse = variant {
+  Ok : Status;
+  Err : GetLocalStatusError;
+};
 // Error types for the `get_profile` method.
 type GetProfileError = variant {
   // Internal error occurred while fetching the profile.
@@ -214,9 +247,20 @@ type Status = record {
   author : text;
   // The visibility setting of the status, controlling its audience.
   visibility : Visibility;
+  // Optional content warning / spoiler text shown before content.
+  spoiler_text : opt text;
+  // Whether the status should be hidden behind a content warning by clients.
+  sensitive : bool;
   // Cached count of `Announce` (boost) activities received for this status.
   boost_count : nat64;
 };
+// Request arguments for the `undo_boost` method.
+type UndoBoostArgs = record {
+  // ActivityPub URI of the status to un-boost.
+  status_url : text;
+};
+// Response type for the `undo_boost` method.
+type UndoBoostResponse = variant { Ok; Err : GetLikedError };
 // Request arguments for the `update_profile` method.
 // All fields are optional; only provided fields are updated.
 type UpdateProfileArgs = record {
@@ -272,6 +316,7 @@ type Visibility = variant {
 };
 service : (UserInstallArgs) -> {
   accept_follow : (AcceptFollowArgs) -> (AcceptFollowResponse);
+  boost_status : (BoostStatusArgs) -> (BoostStatusResponse);
   emit_delete_profile_activity : () -> (EmitDeleteProfileActivityResponse);
   follow_user : (FollowUserArgs) -> (FollowUserResponse);
   get_follow_requests : (GetFollowRequestsArgs) -> (
@@ -280,6 +325,7 @@ service : (UserInstallArgs) -> {
   get_followers : (GetFollowersArgs) -> (GetFollowersResponse) query;
   get_following : (GetFollowersArgs) -> (GetFollowersResponse) query;
   get_liked : (GetLikedArgs) -> (GetLikedResponse) query;
+  get_local_status : (GetLocalStatusArgs) -> (GetLocalStatusResponse) query;
   get_profile : () -> (GetProfileResponse) query;
   get_statuses : (GetLikedArgs) -> (GetStatusesResponse) composite_query;
   like_status : (LikeStatusArgs) -> (LikeStatusResponse);
@@ -287,7 +333,8 @@ service : (UserInstallArgs) -> {
   read_feed : (GetLikedArgs) -> (ReadFeedResponse) query;
   receive_activity : (ReceiveActivityArgs) -> (ReceiveActivityResponse);
   reject_follow : (AcceptFollowArgs) -> (AcceptFollowResponse);
-  unfollow_user : (AcceptFollowArgs) -> (LikeStatusResponse);
-  unlike_status : (LikeStatusArgs) -> (LikeStatusResponse);
-  update_profile : (UpdateProfileArgs) -> (LikeStatusResponse);
+  undo_boost : (UndoBoostArgs) -> (UndoBoostResponse);
+  unfollow_user : (AcceptFollowArgs) -> (UndoBoostResponse);
+  unlike_status : (UndoBoostArgs) -> (UndoBoostResponse);
+  update_profile : (UpdateProfileArgs) -> (UndoBoostResponse);
 }

--- a/integration-tests/src/user_client.rs
+++ b/integration-tests/src/user_client.rs
@@ -1,13 +1,13 @@
 use candid::{Encode, Principal};
 use did::common::Visibility;
 use did::user::{
-    AcceptFollowArgs, AcceptFollowResponse, FollowUserArgs, FollowUserResponse,
-    GetFollowRequestsArgs, GetFollowRequestsResponse, GetFollowersArgs, GetFollowersResponse,
-    GetFollowingArgs, GetFollowingResponse, GetLikedArgs, GetLikedResponse, GetProfileResponse,
-    GetStatusesArgs, GetStatusesResponse, LikeStatusArgs, LikeStatusResponse, PublishStatusArgs,
-    PublishStatusResponse, ReadFeedArgs, ReadFeedResponse, RejectFollowArgs, RejectFollowResponse,
-    UnfollowUserArgs, UnfollowUserResponse, UnlikeStatusArgs, UnlikeStatusResponse,
-    UpdateProfileArgs, UpdateProfileResponse,
+    AcceptFollowArgs, AcceptFollowResponse, BoostStatusArgs, BoostStatusResponse, FollowUserArgs,
+    FollowUserResponse, GetFollowRequestsArgs, GetFollowRequestsResponse, GetFollowersArgs,
+    GetFollowersResponse, GetFollowingArgs, GetFollowingResponse, GetLikedArgs, GetLikedResponse,
+    GetProfileResponse, GetStatusesArgs, GetStatusesResponse, LikeStatusArgs, LikeStatusResponse,
+    PublishStatusArgs, PublishStatusResponse, ReadFeedArgs, ReadFeedResponse, RejectFollowArgs,
+    RejectFollowResponse, UndoBoostArgs, UndoBoostResponse, UnfollowUserArgs, UnfollowUserResponse,
+    UnlikeStatusArgs, UnlikeStatusResponse, UpdateProfileArgs, UpdateProfileResponse,
 };
 use pocket_ic_harness::PocketIcTestEnv;
 
@@ -244,6 +244,34 @@ impl UserClient<'_> {
             )
             .await
             .expect("Failed to call unlike_status")
+    }
+
+    pub async fn boost_status(&self, caller: Principal, status_url: String) -> BoostStatusResponse {
+        let args = BoostStatusArgs { status_url };
+
+        self.env
+            .update(
+                self.canister_id,
+                caller,
+                "boost_status",
+                Encode!(&args).expect("Failed to encode boost_status arguments"),
+            )
+            .await
+            .expect("Failed to call boost_status")
+    }
+
+    pub async fn undo_boost(&self, caller: Principal, status_url: String) -> UndoBoostResponse {
+        let args = UndoBoostArgs { status_url };
+
+        self.env
+            .update(
+                self.canister_id,
+                caller,
+                "undo_boost",
+                Encode!(&args).expect("Failed to encode undo_boost arguments"),
+            )
+            .await
+            .expect("Failed to call undo_boost")
     }
 
     pub async fn get_liked(&self, caller: Principal, offset: u64, limit: u64) -> GetLikedResponse {

--- a/integration-tests/tests/boost_status.rs
+++ b/integration-tests/tests/boost_status.rs
@@ -71,6 +71,14 @@ async fn test_alice_boosts_bob_charlie_sees_it(env: PocketIcTestEnv<MasticCanist
     );
     assert_eq!(alice_boost_item.status.id, bob_status_id);
     assert_eq!(alice_boost_item.status.content, "Bob says hi");
+    assert!(
+        alice_boost_item.boosted,
+        "alice's boost wrapper carries boosted=true"
+    );
+    assert!(
+        !alice_boost_item.liked,
+        "alice has not liked bob's status yet"
+    );
 
     // 6. Charlie's feed contains the boost too.
     let ReadFeedResponse::Ok(charlie_feed) = charlie_client.read_feed(charlie(), 0, 10).await
@@ -89,6 +97,11 @@ async fn test_alice_boosts_bob_charlie_sees_it(env: PocketIcTestEnv<MasticCanist
         charlie_boost_item.status.author,
         format!("{PUBLIC_URL}/users/bob")
     );
+    assert!(
+        !charlie_boost_item.boosted,
+        "charlie has not boosted bob's status"
+    );
+    assert!(!charlie_boost_item.liked, "charlie has not liked it either");
 
     // 7. Bob's status reports boost_count = 1.
     let GetStatusesResponse::Ok(bob_statuses) = bob_client.get_statuses(bob(), 0, 10).await else {

--- a/integration-tests/tests/boost_status.rs
+++ b/integration-tests/tests/boost_status.rs
@@ -1,0 +1,184 @@
+//! Integration tests for WI-1.7 / UC11 — boost status.
+
+use did::common::Visibility;
+use did::user::{
+    BoostStatusResponse, GetStatusesResponse, PublishStatusResponse, ReadFeedResponse,
+    UndoBoostResponse,
+};
+use integration_tests::helpers::{follow_and_accept, sign_up_user};
+use integration_tests::{MasticCanisterSetup, PUBLIC_URL, UserClient, charlie};
+use pocket_ic_harness::{PocketIcTestEnv, alice, bob};
+
+fn status_uri(handle: &str, id: u64) -> String {
+    format!("{PUBLIC_URL}/users/{handle}/statuses/{id}")
+}
+
+async fn publish_bob_public_status(
+    env: &PocketIcTestEnv<MasticCanisterSetup>,
+    bob_canister: candid::Principal,
+) -> u64 {
+    let bob_client = UserClient::new(env, bob_canister);
+    let resp = bob_client
+        .publish_status(bob(), "Bob says hi".to_string(), Visibility::Public, vec![])
+        .await;
+    let PublishStatusResponse::Ok(status) = resp else {
+        panic!("publish_status failed: {resp:?}");
+    };
+    status.id
+}
+
+#[pocket_ic_harness::test]
+async fn test_alice_boosts_bob_charlie_sees_it(env: PocketIcTestEnv<MasticCanisterSetup>) {
+    // 1. Set up Alice (booster) and Bob (author).
+    let bob_canister = sign_up_user(&env, bob(), "bob".to_string()).await;
+    let alice_canister = sign_up_user(&env, alice(), "alice".to_string()).await;
+
+    // 2. Charlie follows Alice (so Charlie should see Alice's boost in his feed).
+    let charlie_canister =
+        follow_and_accept(&env, charlie(), "charlie", alice(), alice_canister, "alice").await;
+
+    let alice_client = UserClient::new(&env, alice_canister);
+    let bob_client = UserClient::new(&env, bob_canister);
+    let charlie_client = UserClient::new(&env, charlie_canister);
+
+    // 3. Bob publishes a public status.
+    let bob_status_id = publish_bob_public_status(&env, bob_canister).await;
+    let bob_status_uri = status_uri("bob", bob_status_id);
+
+    // 4. Alice boosts Bob's status.
+    assert_eq!(
+        alice_client
+            .boost_status(alice(), bob_status_uri.clone())
+            .await,
+        BoostStatusResponse::Ok
+    );
+
+    // 5. Alice's feed contains the boost: boosted_by = alice, author = bob, id = bob's status id.
+    let ReadFeedResponse::Ok(alice_feed) = alice_client.read_feed(alice(), 0, 10).await else {
+        panic!("alice read_feed failed");
+    };
+    let alice_boost_item = alice_feed
+        .iter()
+        .find(|i| i.boosted_by.is_some())
+        .expect("alice feed contains the boost");
+    assert_eq!(
+        alice_boost_item.boosted_by.as_deref(),
+        Some(format!("{PUBLIC_URL}/users/alice").as_str())
+    );
+    assert_eq!(
+        alice_boost_item.status.author,
+        format!("{PUBLIC_URL}/users/bob")
+    );
+    assert_eq!(alice_boost_item.status.id, bob_status_id);
+    assert_eq!(alice_boost_item.status.content, "Bob says hi");
+
+    // 6. Charlie's feed contains the boost too.
+    let ReadFeedResponse::Ok(charlie_feed) = charlie_client.read_feed(charlie(), 0, 10).await
+    else {
+        panic!("charlie read_feed failed");
+    };
+    let charlie_boost_item = charlie_feed
+        .iter()
+        .find(|i| i.boosted_by.is_some())
+        .expect("charlie feed contains the boost");
+    assert_eq!(
+        charlie_boost_item.boosted_by.as_deref(),
+        Some(format!("{PUBLIC_URL}/users/alice").as_str())
+    );
+    assert_eq!(
+        charlie_boost_item.status.author,
+        format!("{PUBLIC_URL}/users/bob")
+    );
+
+    // 7. Bob's status reports boost_count = 1.
+    let GetStatusesResponse::Ok(bob_statuses) = bob_client.get_statuses(bob(), 0, 10).await else {
+        panic!("get_statuses failed");
+    };
+    assert_eq!(bob_statuses.len(), 1);
+    assert_eq!(bob_statuses[0].id, bob_status_id);
+    assert_eq!(bob_statuses[0].boost_count, 1);
+
+    // 8. Idempotent boost — calling again leaves the count at 1.
+    assert_eq!(
+        alice_client
+            .boost_status(alice(), bob_status_uri.clone())
+            .await,
+        BoostStatusResponse::Ok
+    );
+    let GetStatusesResponse::Ok(bob_statuses_after) = bob_client.get_statuses(bob(), 0, 10).await
+    else {
+        panic!("get_statuses failed");
+    };
+    assert_eq!(bob_statuses_after[0].boost_count, 1);
+
+    // 9. Undo boost — the boost item disappears from both feeds and Bob's count returns to 0.
+    assert_eq!(
+        alice_client
+            .undo_boost(alice(), bob_status_uri.clone())
+            .await,
+        UndoBoostResponse::Ok
+    );
+
+    let ReadFeedResponse::Ok(alice_feed_after) = alice_client.read_feed(alice(), 0, 10).await
+    else {
+        panic!("alice read_feed failed");
+    };
+    assert!(
+        alice_feed_after.iter().all(|i| i.boosted_by.is_none()),
+        "alice's feed has no boost item after undo"
+    );
+
+    let ReadFeedResponse::Ok(charlie_feed_after) = charlie_client.read_feed(charlie(), 0, 10).await
+    else {
+        panic!("charlie read_feed failed");
+    };
+    assert!(
+        charlie_feed_after.iter().all(|i| i.boosted_by.is_none()),
+        "charlie's feed has no boost item after undo"
+    );
+
+    let GetStatusesResponse::Ok(bob_statuses_final) = bob_client.get_statuses(bob(), 0, 10).await
+    else {
+        panic!("get_statuses failed");
+    };
+    assert_eq!(bob_statuses_final[0].boost_count, 0);
+}
+
+#[pocket_ic_harness::test]
+async fn test_self_boost(env: PocketIcTestEnv<MasticCanisterSetup>) {
+    // Alice boosts her own status — should appear in her own feed.
+    let alice_canister = sign_up_user(&env, alice(), "alice".to_string()).await;
+    let alice_client = UserClient::new(&env, alice_canister);
+
+    let resp = alice_client
+        .publish_status(alice(), "Mine".to_string(), Visibility::Public, vec![])
+        .await;
+    let PublishStatusResponse::Ok(alice_status) = resp else {
+        panic!("publish_status failed");
+    };
+    let alice_status_uri = status_uri("alice", alice_status.id);
+
+    assert_eq!(
+        alice_client
+            .boost_status(alice(), alice_status_uri.clone())
+            .await,
+        BoostStatusResponse::Ok
+    );
+
+    let ReadFeedResponse::Ok(feed) = alice_client.read_feed(alice(), 0, 10).await else {
+        panic!("read_feed failed");
+    };
+    let boost_item = feed
+        .iter()
+        .find(|i| i.boosted_by.is_some())
+        .expect("self-boost shows in own feed");
+    assert_eq!(
+        boost_item.boosted_by.as_deref(),
+        Some(format!("{PUBLIC_URL}/users/alice").as_str())
+    );
+    assert_eq!(
+        boost_item.status.author,
+        format!("{PUBLIC_URL}/users/alice")
+    );
+    assert_eq!(boost_item.status.id, alice_status.id);
+}

--- a/integration-tests/tests/like.rs
+++ b/integration-tests/tests/like.rs
@@ -1,7 +1,7 @@
 use did::common::Visibility;
 use did::user::{
     GetLikedResponse, GetStatusesResponse, LikeStatusResponse, PublishStatusResponse,
-    UnlikeStatusResponse,
+    ReadFeedResponse, UnlikeStatusResponse,
 };
 use integration_tests::helpers::{follow_and_accept, sign_up_user};
 use integration_tests::{MasticCanisterSetup, PUBLIC_URL, UserClient};
@@ -167,4 +167,97 @@ async fn test_should_succeed_unlike_when_not_liked(env: PocketIcTestEnv<MasticCa
         panic!("get_statuses failed");
     };
     assert_eq!(bob_statuses[0].like_count, 0);
+}
+
+#[pocket_ic_harness::test]
+async fn test_should_surface_liked_flag_in_feed(env: PocketIcTestEnv<MasticCanisterSetup>) {
+    let bob_canister = sign_up_user(&env, bob(), "bob".to_string()).await;
+    let alice_canister =
+        follow_and_accept(&env, alice(), "alice", bob(), bob_canister, "bob").await;
+
+    let alice_client = UserClient::new(&env, alice_canister);
+
+    let bob_status_id = publish_bob_status(&env, bob_canister).await;
+    let bob_status_uri = status_uri("bob", bob_status_id);
+
+    // Before liking: alice's feed shows bob's inbox-delivered status with liked=false.
+    let ReadFeedResponse::Ok(feed_before) = alice_client.read_feed(alice(), 0, 10).await else {
+        panic!("read_feed failed");
+    };
+    let item_before = feed_before
+        .iter()
+        .find(|i| i.status.id == bob_status_id)
+        .expect("bob's status delivered to alice's inbox");
+    assert!(!item_before.liked, "not liked yet");
+    assert!(!item_before.boosted);
+
+    // Alice likes bob's status.
+    assert_eq!(
+        alice_client
+            .like_status(alice(), bob_status_uri.clone())
+            .await,
+        LikeStatusResponse::Ok
+    );
+
+    // After liking: liked flag flips to true on the same feed item.
+    let ReadFeedResponse::Ok(feed_after) = alice_client.read_feed(alice(), 0, 10).await else {
+        panic!("read_feed failed");
+    };
+    let item_after = feed_after
+        .iter()
+        .find(|i| i.status.id == bob_status_id)
+        .expect("status still in feed after like");
+    assert!(item_after.liked, "liked flag set after like");
+    assert!(!item_after.boosted);
+
+    // Unliking flips it back.
+    assert_eq!(
+        alice_client
+            .unlike_status(alice(), bob_status_uri.clone())
+            .await,
+        UnlikeStatusResponse::Ok
+    );
+
+    let ReadFeedResponse::Ok(feed_unlike) = alice_client.read_feed(alice(), 0, 10).await else {
+        panic!("read_feed failed");
+    };
+    let item_unlike = feed_unlike
+        .iter()
+        .find(|i| i.status.id == bob_status_id)
+        .expect("status still in feed after unlike");
+    assert!(!item_unlike.liked, "liked flag cleared after unlike");
+}
+
+#[pocket_ic_harness::test]
+async fn test_should_surface_liked_flag_on_own_outbox_status(
+    env: PocketIcTestEnv<MasticCanisterSetup>,
+) {
+    let alice_canister = sign_up_user(&env, alice(), "alice".to_string()).await;
+    let alice_client = UserClient::new(&env, alice_canister);
+
+    let resp = alice_client
+        .publish_status(alice(), "Mine".to_string(), Visibility::Public, vec![])
+        .await;
+    let PublishStatusResponse::Ok(alice_status) = resp else {
+        panic!("publish_status failed");
+    };
+    let alice_status_uri = status_uri("alice", alice_status.id);
+
+    // Alice self-likes.
+    assert_eq!(
+        alice_client
+            .like_status(alice(), alice_status_uri.clone())
+            .await,
+        LikeStatusResponse::Ok
+    );
+
+    let ReadFeedResponse::Ok(feed) = alice_client.read_feed(alice(), 0, 10).await else {
+        panic!("read_feed failed");
+    };
+    let item = feed
+        .iter()
+        .find(|i| i.status.id == alice_status.id)
+        .expect("own status in feed");
+    assert!(item.liked, "self-like surfaces in feed");
+    assert!(!item.boosted);
 }


### PR DESCRIPTION
## Summary

Implements **WI-1.7 Boost / Undo Boost** for the user canister and refactors the repository layer used by both `user` and `directory` canisters.

### WI-1.7 boost feature
- `Status` extended with `spoiler_text` + `sensitive`; `BoostRepository` adds `find_by_original_uri`; `StatusRepository` gains `increment_boost_count` / `decrement_boost_count`.
- `did::user::GetLocalStatus` + `did::federation::FetchStatus` types.
- `federation` canister: `fetch_status` flow (local-only) and update endpoint; `user` canister adds `federation::fetch_status` adapter.
- `user::get_local_status` query with caller-scoped visibility.
- `boost_status` flow (fetch + insert wrapper Status/Boost/FeedEntry + Announce dispatch) and `undo_boost` flow (delete + Undo(Announce) dispatch).
- Inbox handlers for `Announce` and `Undo(Announce)`; outbox/inbox renderers surface `boosted_by` + original author; feed items now expose viewer `liked` / `boosted` flags.
- End-to-end pocket-ic integration tests for boost / undo_boost.
- Architecture, sequence diagrams, and Candid interface docs updated.

### Repository refactor
- `db_utils::transaction::Transaction` primitive (`begin` / `commit` / `rollback` / `run`) so callers own transaction lifecycle.
- All 12 repositories (`user`: block, follower, following, follow_request, liked, profile, status, feed, boost; `directory`: users, moderators, tombstone) converted from associated-function style to instance-based with optional `TransactionId`.
- `db_utils::repository::Repository` trait with `Schema` associated type and required `oneshot` / `with_transaction` / `tx` / `schema` methods, providing a default `db()` accessor — drops the per-repo `db()` boilerplate.
- Boost flow finalised: cross-table writes moved out of `BoostRepository` into per-flow helpers (`boost_status::insert_boost_with_wrapper`, `undo_boost::delete_boost_with_wrapper`); each repo writes only its own table.

## Test plan
- [x] `just check_code` (fmt + clippy `-D warnings`)
- [x] `just test` — 341 user, 170 directory, 81 db-utils, 39 federation, 4 ic-utils, all passing
- [x] `just build_all` — directory/federation/user WASM artefacts rebuild clean
- [x] `just integration_test` — pocket-ic suites green, including new boost/undo_boost end-to-end coverage